### PR TITLE
Translate September and October 2024

### DIFF
--- a/docs/release-notes/v1_94.md
+++ b/docs/release-notes/v1_94.md
@@ -1,361 +1,361 @@
 ---
 Order: 103
-TOCTitle: September 2024
-PageTitle: Visual Studio Code September 2024
-MetaDescription: Learn what is new in the Visual Studio Code September 2024 Release (1.94)
+TOCTitle: 2024 年 9 月
+PageTitle: Visual Studio Code 2024 年 9 月
+MetaDescription: Visual Studio Code 2024 年 9 月リリース (1.94) の新機能を学びます
 MetaSocialImage: 1_94/release-highlights.png
 Date: 2024-10-3
 DownloadVersion: 1.94.2
 ---
-# September 2024 (version 1.94)
+# 2024 年 9 月 (バージョン 1.94)
 
-**Update 1.94.1**: The update addresses this security [issue](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22September+2024+Recovery+1%22+).
+**アップデート 1.94.1**: このアップデートはこのセキュリティ [問題](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22September+2024+Recovery+1%22+) に対処します。
 
-**Update 1.94.2**: The update addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22September+2024+Recovery+2%22+is%3Aclosed).
+**アップデート 1.94.2**: このアップデートはこれらの [問題](https://github.com/microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22September+2024+Recovery+2%22+is%3Aclosed) に対処します。
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the September 2024 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2024 年 9 月リリースへようこそ。このバージョンには多くの更新が含まれており、いくつかの主要なハイライトは次のとおりです:
 
-* [Find in Explorer](#find-in-explorer) - Quickly find files in the Explorer view with the improved Find control.
-* [Source Control Graph](#source-control) - More filtering options and interactivity in the Source Control Graph.
-* [Python test coverage](#python) - Run Python tests with coverage and get rich results in the editor.
-* [ESM](#esm-is-shipping-for-vs-code) - Faster VS Code startup thanks to the migration to ESM.
-* [Account preference](#change-an-extensions-account-preference) - Specify which account to use for an extension.
-* [Copilot in Native REPL](#inline-chat-and-completions-in-python-native-repl) - Get code completions and Inline Chat in the Native REPL.
-* [Improved chat context](#drag-and-drop-files-to-add-chat-context) - Drag & drop files or use IntelliSense for more relevant chat context.
-* [Test environment setup](#automated-test-setup-override) - Get help with setting up a test framework for your workspace.
+* [エクスプローラーで検索](#find-in-explorer) - 改良された検索コントロールでエクスプローラー ビュー内のファイルをすばやく見つけます。
+* [ソース コントロール グラフ](#source-control) - ソース コントロール グラフでのフィルタリング オプションとインタラクティビティの向上。
+* [Python テスト カバレッジ](#python) - カバレッジを使用して Python テストを実行し、エディターでリッチな結果を取得します。
+* [ESM](#esm-is-shipping-for-vs-code) - ESM への移行により、VS Code の起動が高速化されました。
+* [アカウントの優先設定](#change-an-extensions-account-preference) - 拡張機能に使用するアカウントを指定します。
+* [ネイティブ REPL での Copilot](#inline-chat-and-completions-in-python-native-repl) - ネイティブ REPL でコード補完とインライン チャットを取得します。
+* [改善されたチャット コンテキスト](#drag-and-drop-files-to-add-chat-context) - ファイルをドラッグ アンド ドロップするか、IntelliSense を使用して、より関連性の高いチャット コンテキストを取得します。
+* [テスト環境のセットアップ](#automated-test-setup-override) - ワークスペースのテスト フレームワークのセットアップを支援します。
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+>これらのリリース ノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [更新プログラム](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** できるだけ早く新機能を試してみたいですか? ナイトリー [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新の更新プログラムをすぐに試すことができます。
 
 ## GitHub Copilot
 
-### Switch language models in chat
+### チャットで言語モデルを切り替える
 
-Previously, we announced that you can [sign up for early access to OpenAI o1 models](https://github.com/o1-waitlist-signup). Once you have access, you will have a Copilot Chat model picker control in Copilot Chat in VS Code to choose which model version to use for your chat conversations.
+以前、[OpenAI o1 モデルへの早期アクセスにサインアップ](https://github.com/o1-waitlist-signup) できることを発表しました。アクセス権を取得すると、VS Code の Copilot Chat でチャット会話に使用するモデル バージョンを選択するための Copilot Chat モデル ピッカー コントロールが表示されます。
 
-![Copilot model picker control in the Chat view enables switching to another language model.](https://code.visualstudio.com/assets/updates/1_94/copilot-model-picker.png)
+![Copilot モデル ピッカー コントロールを使用すると、チャットで別の言語モデルに切り替えることができます。](https://code.visualstudio.com/assets/updates/1_94/copilot-model-picker.png)
 
-### GPT-4o in Inline Chat
+### GPT-4o をインライン チャットで使用
 
-We've upgraded Copilot Inline Chat to GPT-4o, to give you faster, more accurate, and higher-quality code and explanations when you use Chat in the editor.
+Copilot インライン チャットを GPT-4o にアップグレードしました。これにより、エディターでチャットを使用する際に、より高速で正確かつ高品質なコードと説明を提供します。
 
-### Public code matching in chat
+### チャットでの公開コードの一致
 
-You can allow GitHub Copilot to return code that could match publicly available code on GitHub.com. When this functionality is enabled for your [organization subscription](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/setting-policies-for-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#policies-for-suggestion-matching) or [personal subscription](https://docs.github.com/en/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-copilot-policies-as-an-individual-subscriber#enabling-or-disabling-suggestions-matching-public-code), Copilot code completions already provided you with details about the matches that were detected. We now show you these matches for public code in Copilot Chat as well.
+GitHub Copilot が GitHub.com 上の公開されているコードと一致する可能性のあるコードを返すことを許可できます。この機能が [組織向けサブスクリプション](https://docs.github.com/copilot/managing-copilot/managing-github-copilot-in-your-organization/setting-policies-for-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#policies-for-suggestion-matching) または [個人向けサブスクリプショ](https://docs.github.com/copilot/managing-copilot/managing-copilot-as-an-individual-subscriber/managing-copilot-policies-as-an-individual-subscriber#enabling-or-disabling-suggestions-matching-public-code) で有効になっている場合、Copilot コード補完は既に検出された一致の詳細を提供します。これで、Copilot Chat でもこれらの公開コードの一致を表示できるようになりました。
 
-If this is enabled for your organization or subscription, you might see a message at the end of the response with a **View matches** link. If you select the link, an editor opens that shows you the details of the matching code references with more details.
+この機能が組織のサブスクリプションまたは個人のサブスクリプションで有効になっている場合、応答の最後に **一致を表示** リンクが表示されることがあります。リンクを選択すると、エディターが開き、一致するコード参照の詳細が表示されます。
 
-![Chat code referencing example.](https://code.visualstudio.com/assets/updates/1_94/code-references.png)
+![チャット コード参照の例。](https://code.visualstudio.com/assets/updates/1_94/code-references.png)
 
-Get more information about [code referencing in GitHub Copilot](https://github.blog/news-insights/product-news/code-referencing-now-generally-available-in-github-copilot-and-with-microsoft-azure-ai/) on the GitHub Blog.
+GitHub Copilot の[コード参照に関する詳細情報](https://github.blog/news-insights/product-news/code-referencing-now-generally-available-in-github-copilot-and-with-microsoft-azure-ai/) は GitHub ブログでご覧いただけます。
 
-### File suggestions in chat
+### チャットでのファイル提案
 
-In chat input fields, you can now type `#<filename>` to get file name suggestions and quickly attach them to your prompt as context. This works in chat locations that support file attachments, such as the Chat view, Quick Chat, Inline Chat, and Notebook Chat.
+チャット入力フィールドで `#<filename>` と入力すると、ファイル名の提案が表示され、プロンプトにコンテキストとしてすばやく添付できます。これは、ファイルの添付をサポートするチャットの場所 (チャット ビュー、クイック チャット、インライン チャット、ノートブック チャットなど) で機能します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/chat-file-complete.mp4" title="File suggestions when typing #filename" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/chat-file-complete.mp4" title="ファイル名を入力するときのファイル提案" autoplay loop controls muted></video>
 
-### Improved file links in chat responses
+### チャット応答でのファイル リンクの改善
 
-We've improved the rendering of any workspace file paths that are mentioned in Copilot responses. These paths are very common when  you ask [`@workspace`](https://code.visualstudio.com/docs/copilot/copilot-chat#_workspace) questions.
+Copilot 応答で言及されるワークスペース ファイル パスのレンダリングを改善しました。これらのパスは、[`@workspace`](https://code.visualstudio.com/docs/copilot/copilot-chat#_workspace) 質問をするときに非常に一般的です。
 
-The first thing you'll notice, is that paths to workspace files now include a file icon. This enables you to easily distinguish them in the chat response. The file icon is based on your current [file icon theme](https://code.visualstudio.com/docs/getstarted/themes#_file-icon-themes).
+最初に気付くのは、ワークスペース ファイルへのパスにファイル アイコンが含まれるようになったことです。これにより、チャット応答で簡単に識別できます。ファイル アイコンは、現在の[ファイル アイコン テーマ](https://code.visualstudio.com/docs/getstarted/themes#_file-icon-themes) に基づいています。
 
-![Paths to workspace files in the response now render using file icons.](https://code.visualstudio.com/assets/updates/1_94/copilot-path-overview.png)
+![応答内のワークスペース ファイルへのパスは、ファイル アイコンを使用してレンダリングされます。](https://code.visualstudio.com/assets/updates/1_94/copilot-path-overview.png)
 
-These paths are interactive links, so just select them to open the corresponding file. You can even use drag and drop to open the file in a new editor group, or insert it into a text editor by holding `kbstyle(Shift)` before dropping.
+これらのパスはインタラクティブ リンクであるため、それらを選択するだけで対応するファイルが開きます。ファイルを新しいエディター グループで開くには、ドラッグ アンド ドロップを使用するか、`kbstyle(Shift)` を押しながらドロップしてテキスト エディターに挿入します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/copilot-path-dnd.mp4" title="Dragging and dropping a workspace file from copilot into the editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/copilot-path-dnd.mp4" title="copilot からワークスペース ファイルをエディターにドラッグ アンド ドロップする" autoplay loop controls muted></video>
 
-By default, these links only show the file name but you can hover over them to see the full file path.
+デフォルトでは、これらのリンクにはファイル名のみが表示されますが、リンクにカーソルを合わせると完全なファイル パスが表示されます。
 
-![Hovering over a workspace path to see the full workspace path.](https://code.visualstudio.com/assets/updates/1_94/copilot-path-hover.png)
+![ワークスペース パスにカーソルを合わせて、完全なワークスペース パスを表示します。](https://code.visualstudio.com/assets/updates/1_94/copilot-path-hover.png)
 
-You can also right-click on one of these paths to open a context menu with additional commands, such as copying a relative path to the resource, or revealing the file in your operating system's file explorer.
+また、これらのパスの 1 つを右クリックして、リソースへの相対パスをコピーしたり、オペレーティング システムのファイル エクスプローラーでファイルを表示したりするなどの追加コマンドを含むコンテキスト メニューを開くこともできます。
 
-![The context menu for a workspace path in chat provides options to open the file or copy its path.](https://code.visualstudio.com/assets/updates/1_94/copilot-path-right-click.png)
+![チャット内のワークスペース パスのコンテキスト メニューには、ファイルを開いたり、パスをコピーしたりするオプションが用意されています。](https://code.visualstudio.com/assets/updates/1_94/copilot-path-right-click.png)
 
-We plan to further improve workspace path rendering in the coming iterations, as well as make similar improvements to symbol names in responses.
+今後のイテレーションでワークスペース パスのレンダリングをさらに改善し、応答内のシンボル名にも同様の改善を行う予定です。
 
-### Drag and drop files to add chat context
+### ファイルをドラッグ アンド ドロップしてチャット コンテキストを追加する {#drag-and-drop-files-to-add-chat-context}
 
-You can now easily attach additional files as context for a chat prompt by dragging files or editor tabs from the workbench directly into chat. For Inline Cat, hold `kbstyle(Shift)` and drop a file to add it as context instead of opening it in the editor.
+ワークベンチからファイルやエディター タブをチャットに直接ドラッグすることで、チャット プロンプトのコンテキストとして追加のファイルを簡単に添付できるようになりました。インライン キャットの場合、`kbstyle(Shift)` を押しながらファイルをドロップして、エディターで開くのではなくコンテキストとして追加します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/copilot-attach-dnd.mp4" title="Dragging files and editors into chat" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/copilot-attach-dnd.mp4" title="ファイルとエディターをチャットにドラッグする" autoplay loop controls muted></video>
 
-### File attachments included in history
+### 履歴に含まれるファイルの添付
 
-There are multiple ways to attach a file or editor selection as relevant context to your chat request. Previously, this context was added only for the current request and was not included in the history of follow-on requests. Now, these attachments are kept in history, so that you can keep referring to them without having to reattach them.
+チャット リクエストの関連コンテキストとしてファイルまたはエディター選択を添付する方法は複数あります。以前は、このコンテキストは現在のリクエストにのみ追加され、フォローオン リクエストの履歴には含まれていませんでした。現在、これらの添付ファイルは履歴に保持されているため、再添付することなく参照し続けることができます。
 
-![Chat conversation shows that Copilot keeps track of attached files across multiple prompts.](https://code.visualstudio.com/assets/updates/1_94/file-attachment.png)
+![Copilot は、添付ファイルを複数のプロンプトにわたって追跡することを示すチャット会話。](https://code.visualstudio.com/assets/updates/1_94/file-attachment.png)
 
-### Inline Chat and completions in Python native REPL
+### Python ネイティブ REPL でのインライン チャットと補完 {#inline-chat-and-completions-in-python-native-repl}
 
-The native REPL editor, used by the Python extension, now supports Copilot Inline Chat and code completions directly in the input box.
+Python 拡張機能で使用されるネイティブ REPL エディターは、入力ボックスで Copilot インライン チャットとコード補完をサポートするようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/copilot-in-REPL.mp4" title="Using Copilot Inline Chat in the native REPL editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/copilot-in-REPL.mp4" title="ネイティブ REPL エディターで Copilot インライン チャットを使用する" autoplay loop controls muted></video>
 
-### Accept and run generated code in notebook
+### ノートブックで生成されたコードを受け入れて実行する
 
-When you use Copilot Inline Chat to generate code in a notebook, you can now accept and directly run the generated code from Inline Chat.
+Copilot インライン チャットを使用してノートブックでコードを生成する場合、インライン チャットから生成されたコードを受け入れて直接実行できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/notebook-accept-run.mp4" title="Accept and run generated code directly from Inline Chat" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/notebook-accept-run.mp4" title="インライン チャットから生成されたコードを受け入れて実行する" autoplay loop controls muted></video>
 
-### Attach variables in notebook chat
+### ノートブック チャットで変数を添付する
 
-When you use Copilot in a notebook, you can now attach variables from the Jupyter kernel in your requests. Adding variables gives you more precise control over the context for your chat request, so that you get more relevant responses from Copilot.
+ノートブックで Copilot を使用する場合、Jupyter カーネルから変数をリクエストに添付できるようになりました。変数を追加すると、チャット リクエストのコンテキストをより正確に制御できるため、Copilot からより関連性の高い応答を得ることができます。
 
-Either type `#`, followed by the variable name, or use the 📎 control (`kb(workbench.action.chat.attachContext)`) in Inline Chat to add a context variable.
+`#` と入力し、続けて変数名を入力するか、インライン チャットで 📎 コントロール (`kb(workbench.action.chat.attachContext)`) を使用してコンテキスト変数を追加します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/notebook-kernel-variable.mp4" title="Attach a context variable by using `#` in a notebook chat request" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/notebook-kernel-variable.mp4" title="ノートブック チャット リクエストで `#` を使用してコンテキスト変数を添付する" autoplay loop controls muted></video>
 
-### Refreshed chat user experience
+### 更新されたチャット ユーザー エクスペリエンス
 
-We've refreshed the Chat view with a clean new welcome experience, and we've updated the layout of the chat input area. You can now use the `@` button to easily find the list of available chat participants and slash commands, both the built-in ones and chat participants from extensions that you've installed. You can also still find participants and slash commands by typing `/` or `@` in the chat input box.
+クリーンな新しいウェルカム エクスペリエンスでチャット ビューを更新し、チャット入力エリアのレイアウトを更新しました。`@` ボタンを使用して、インストールした拡張機能からの組み込みのチャット参加者とスラッシュ コマンドの両方のリストを簡単に見つけることができるようになりました。チャット入力ボックスに `/` または `@` を入力して、参加者やスラッシュ コマンドを見つけることもできます。
 
-![Updated Chat view welcome experience.](https://code.visualstudio.com/assets/updates/1_94/chat-welcome.png)
+![更新されたチャット ビューのウェルカム エクスペリエンス。](https://code.visualstudio.com/assets/updates/1_94/chat-welcome.png)
 
-### Semantic search results (Preview)
+### セマンティック検索結果 (プレビュー)
 
-**Setting**: `setting(github.copilot.chat.search.semanticTextResults)`
+**設定**: `setting(github.copilot.chat.search.semanticTextResults)`
 
-The Search view enables you to perform an exact search across your files. We have now added functionality to the Search view that uses Copilot to give search results that are semantically relevant.
+検索ビューを使用すると、ファイル全体で正確な検索を実行できます。Copilot を使用して、意味的に関連する検索結果を提供する機能を検索ビューに追加しました。
 
-<video controls src="https://code.visualstudio.com/assets/updates/1_94/semantic-search-in-search-view.mp4" title="Semantic Search in Search View" autoplay loop controls muted></video>
+<video controls src="https://code.visualstudio.com/assets/updates/1_94/semantic-search-in-search-view.mp4" title="検索ビューでのセマンティック検索" autoplay loop controls muted></video>
 
-This functionality is still in preview and by default, the setting is not enabled. Try it out and let us know what you think!
+この機能はまだプレビュー段階であり、デフォルトでは設定が有効になっていません。ぜひ試してみて、フィードバックをお寄せください。
 
-### Fix test failure (Preview)
+### テストの失敗を修正する (プレビュー)
 
-**Setting**: `setting(github.copilot.chat.fixTestFailure.enabled)`
+**設定**: `setting(github.copilot.chat.fixTestFailure.enabled)`
 
-We've added specialized logic to help you to diagnose failing unit tests. This logic is triggered in some scenarios by the `/fix` slash command, and you can also invoke it directly with the `/fixTestFailure` slash command. The command is enabled in chat by default but can be disabled via the setting `setting(github.copilot.chat.fixTestFailure.enabled)`.
+失敗した単体テストの診断を支援するための特別なロジックを追加しました。このロジックは、いくつかのシナリオで `/fix` スラッシュ コマンドによってトリガーされます。また、`/fixTestFailure` スラッシュ コマンドを直接呼び出すこともできます。このコマンドはデフォルトでチャットで有効になっていますが、設定 `setting(github.copilot.chat.fixTestFailure.enabled)` を使用して無効にすることもできます。
 
 <h2 id="automated-test-setup-override"><div id="_automated-test-setup-override"/></h2>
 
-### Automated test setup (Experimental)
+### 自動テスト セットアップ (実験的)
 
-**Setting**: `setting(github.copilot.chat.experimental.setupTests.enabled)`
+**設定**: `setting(github.copilot.chat.experimental.setupTests.enabled)`
 
-We added an experimental `/setupTests` slash command that can help you configure the testing set up for your workspace. This command can recommend a testing framework, provide steps to set up and configure it, and suggest a VS Code extension to provide [testing integration in VS Code](https://code.visualstudio.com/docs/editor/testing). This can save you time and effort to get started with testing for your code.
+ワークスペースのテスト セットアップを構成するのに役立つ実験的な `/setupTests` スラッシュ コマンドを追加しました。このコマンドは、テスト フレームワークを推奨し、それをセットアップおよび構成する手順を提供し、VS Code で[テスト統合を提供する](https://code.visualstudio.com/docs/editor/testing) VS Code 拡張機能を提案できます。これにより、コードのテストを開始するための時間と労力を節約できます。
 
-When you use the `/tests` command to generate tests for your code, it can recommend `/setupTests` and testing extensions if looks like such an integration has not been set up yet in your workspace.
+コードのテストを生成するために `/tests` コマンドを使用する場合、ワークスペースでそのような統合がまだ設定されていないように見える場合、`/setupTests` とテスト拡張機能を推奨できます。
 
-### Start debugging from Chat (Experimental)
+### チャットからデバッグを開始する (実験的)
 
-**Setting**: `setting(github.copilot.chat.experimental.startDebugging.enabled)`
+**設定**: `setting(github.copilot.chat.experimental.startDebugging.enabled)`
 
-In this milestone, we made improvements to the experimental `/startDebugging` slash command. This command enables you to easily find or create a launch configuration and start [debugging](https://code.visualstudio.com/docs/editor/debugging) your application seamlessly. When you use `@vscode` in Copilot Chat, `/startDebugging` is now available by default.
+このマイルストーンでは、実験的な `/startDebugging` スラッシュ コマンドの改善を行いました。このコマンドを使用すると、起動構成を簡単に見つけたり作成したりして、アプリケーションの[デバッグ](https://code.visualstudio.com/docs/editor/debugging)をシームレスに開始できます。Copilot Chat で `@vscode` を使用すると、`/startDebugging` がデフォルトで使用できるようになりました。
 
-![A user types /startDebugging flask app port 3000 in the panel chat and is provided with the launch configuration.](https://code.visualstudio.com/assets/updates/1_94/start-debugging.png)
+![ユーザーがパネル チャットで /startDebugging flask app port 3000 と入力し、起動構成が提供されます。](https://code.visualstudio.com/assets/updates/1_94/start-debugging.png)
 
-### Chat in Command Center (Experimental)
+### コマンド センターでのチャット (実験的)
 
-**Setting**: `setting(chat.commandCenter.enabled)`
+**設定**: `setting(chat.commandCenter.enabled)`
 
-We are experimenting with a Command Center entry for accessing chat. It provides quick access to all relevant chat commands, like starting the different chat experiences or attaching context to your prompt. Note that the Command Center itself needs to be enabled for the chat Command Center entry to show.
+コマンド センター エントリを使用してチャットにアクセスする実験を行っています。これにより、さまざまなチャット エクスペリエンスを開始したり、プロンプトにコンテキストを添付したりするなど、関連するすべてのチャット コマンドにすばやくアクセスできます。コマンド センター自体が有効になっている必要があることに注意してください。チャット コマンド センター エントリを表示します。
 
-![Chat Command Center button and the drop-down menu with relevant chat actions.](https://code.visualstudio.com/assets/updates/1_94/chat-command-center.png)
+![チャット コマンド センター ボタンと、関連するチャット アクションを含むドロップダウン メニュー。](https://code.visualstudio.com/assets/updates/1_94/chat-command-center.png)
 
-### Improved temporal context (Experimental)
+### 改善された時間的コンテキスト (実験的)
 
-**Setting**: `setting(github.copilot.chat.experimental.temporalContext.enabled)`
+**設定**: `setting(github.copilot.chat.experimental.temporalContext.enabled)`
 
-With temporal context, you can instruct Inline Chat to consider recently opened or edited files as part of the chat context. We have improved this feature and invite everyone to give it a go.
+時間的コンテキストを使用すると、インライン チャットに最近開いたファイルや編集したファイルをチャット コンテキストの一部として考慮するように指示できます。この機能を改善しましたので、ぜひお試しください。
 
-### Custom instructions (Experimental)
+### カスタム命令 (実験的)
 
-**Setting**: `setting(github.copilot.chat.experimental.codeGeneration.useInstructionFiles)`
+**設定**: `setting(github.copilot.chat.experimental.codeGeneration.useInstructionFiles)`
 
-**Setting**: `setting(github.copilot.chat.experimental.testGeneration.instructions)`
+**設定**: `setting(github.copilot.chat.experimental.testGeneration.instructions)`
 
-Last milestone, we introduced custom [code-generation instructions](https://code.visualstudio.com/updates/v1_93#_code-generation-instructions). We've further expanded this functionality to define **shared instructions** for code generation in a `.github/copilot-instructions.md` file in your workspace. These common instructions supplement your own personal code generation instructions. Enable the code-generation instruction file with the `setting(github.copilot.chat.experimental.codeGeneration.useInstructionFiles)` setting.
+前回のマイルストーンでは、カスタム[コード生成命令](https://code.visualstudio.com/updates/v1_93#_code-generation-instructions)を導入しました。この機能をさらに拡張して、ワークスペースの `.github/copilot-instructions.md` ファイルに**共有命令**を定義できるようにしました。これらの共通命令は、個人のコード生成命令を補完します。`setting(github.copilot.chat.experimental.codeGeneration.useInstructionFiles)` 設定を使用して、コード生成命令ファイルを有効にします。
 
-In addition, you can now define instructions for **test generation** in settings or import them from a file. For example, if you always want to use a particular unit testing framework for your tests. Configure the test-generation instructions in the `setting(github.copilot.chat.experimental.testGeneration.instructions)` setting.
+さらに、**テスト生成**の命令を設定で定義したり、ファイルからインポートしたりできるようになりました。たとえば、常に特定の単体テスト フレームワークをテストに使用する場合などです。`setting(github.copilot.chat.experimental.testGeneration.instructions)` 設定でテスト生成命令を構成します。
 
-## Accessibility
+## アクセシビリティ
 
-### Getting started
+### はじめに
 
-Our **Help** menu now includes a **Get Started with Accessibility Features** walkthrough, which makes it easier for you to explore and utilize the accessibility options. The walkthrough introduces you to functionality, such as the accessibility help dialog, accessibility signals, keyboard shortcuts, and more.
+**ヘルプ** メニューには **アクセシビリティ機能の概要** ウォークスルーが含まれており、アクセシビリティ オプションを簡単に探索して利用できるようになりました。このウォークスルーでは、アクセシビリティ ヘルプ ダイアログ、アクセシビリティ シグナル、キーボード ショートカットなどの機能を紹介します。
 
-![Get Started with Accessibility Features product walkthrough.](https://code.visualstudio.com/assets/updates/1_94/accessibility-walkthrough.png)
+![アクセシビリティ機能の概要製品ウォークスルー。](https://code.visualstudio.com/assets/updates/1_94/accessibility-walkthrough.png)
 
-### Comment accessibility improvements
+### コメントのアクセシビリティの改善
 
-We have introduced an accessible view for comment thread controls. This view includes the relevant editor context, enabling you to stay focused without needing to switch between the editor and the accessible view. Likewise, the editor context is now provided in the accessible view for the comments panel.
+コメント スレッド コントロールのアクセシブル ビューを導入しました。このビューには関連するエディター コンテキストが含まれており、エディターとアクセシブル ビューを切り替えることなく集中して作業を続けることができます。同様に、コメント パネルのアクセシブル ビューにもエディター コンテキストが提供されます。
 
-We've also introduced the **Comments: Focus Comment on Current Line** command that lets you quickly move to the Comments control from the Editor by using the keyboard. There are also new actions to go to the next and previous commented ranges in the Editor: **Comments: Go to Next Commented Range** and **Comments: Go to Previous Commented Range**.
+また、キーボードを使用してエディターからコメント コントロールにすばやく移動できる **コメント: 現在の行のコメントにフォーカス** コマンドを導入しました。エディター内の次のコメント範囲と前のコメント範囲に移動するための新しいアクションもあります: **コメント: 次のコメント範囲に移動** および **コメント: 前のコメント範囲に移動**。
 
-## Workbench
+## ワークベンチ
 
-### Change an extension's account preference
+### 拡張機能のアカウント優先設定を変更する {#change-an-extensions-account-preference}
 
-In this iteration, we explored how to improve the experience of changing the preferred account for an extension. For example, if you have multiple GitHub accounts and you accidentally signed in to GitHub Copilot with the wrong account and now need to use the other one.
+このイテレーションでは、拡張機能の優先アカウントを変更するエクスペリエンスを改善する方法を検討しました。たとえば、複数の GitHub アカウントを持っていて、誤って間違ったアカウントで GitHub Copilot にサインインしてしまい、別のアカウントを使用する必要がある場合などです。
 
-It's now possible to change that preference after the fact in multiple ways.
+事後にその優先設定を変更することが可能になりました。
 
-* **Account menu in the Activity Bar** > **&lt;Your Account&gt;** > **Manage Trusted Extensions** > select the gear icon for an extension
+* **アクティビティ バーのアカウント メニュー** > **&lt;Your Account&gt;** > **信頼された拡張機能の管理** > 拡張機能の歯車アイコンを選択
 
-  ![Manage trusted extensions Quick Pick, with gear button highlighted.](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceManageTrustedExtensions.png)
+  ![信頼された拡張機能のクイック ピックを管理し、歯車ボタンを強調表示します。](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceManageTrustedExtensions.png)
 
-* **Extensions** view > context menu (or gear icon) on an extension that uses auth > select **Account Preferences**
+* **拡張機能** ビュー > 認証を使用する拡張機能のコンテキスト メニュー (または歯車アイコン) > **アカウント優先設定** を選択
 
-  ![Account preferences option in the context menu of an extension.](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceContextMenu.png)
+  ![拡張機能のコンテキスト メニューのアカウント優先設定オプション。](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceContextMenu.png)
 
-* Extension detail view > gear icon > select **Account Preferences**
+* 拡張機能の詳細ビュー > 歯車アイコン > **アカウント優先設定** を選択
 
-  ![Account preferences option in the gear menu of an extension.](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceGear.png)
+  ![拡張機能の歯車メニューのアカウント優先設定オプション。](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceGear.png)
 
-Choosing any of these options takes you to a Quick Pick where you can change the account that an extension uses.
+これらのオプションのいずれかを選択すると、拡張機能が使用するアカウントを変更できるクイック ピックに移動します。
 
-![The account preference Quick Pick that enables you to select extensions for a given account.](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceQuickPick.png)
+![アカウント優先設定クイック ピックにより、特定のアカウントの拡張機能を選択できます。](https://code.visualstudio.com/assets/updates/1_94/accountPreferenceQuickPick.png)
 
-When you change an extension's account preference, this sends an event to the extension and it is up to the extension to handle it properly. If you don't see the expected behavior, report an issue going for that extension, so the account preference experience can be handled.
+拡張機能のアカウント優先設定を変更すると、拡張機能にイベントが送信され、拡張機能が適切に処理する必要があります。期待どおりの動作が見られない場合は、その拡張機能に対して問題を報告して、アカウント優先設定エクスペリエンスを処理できるようにしてください。
 
-Also, let us know if you have any feedback on this flow.
+このフローに関するフィードバックがあればお知らせください。
 
-### View folders and workspaces associated with a profile
+### プロファイルに関連付けられたフォルダーとワークスペースを表示する
 
-In this milestone, we introduced a **Folders & Workspaces** section in the Profiles editor. This section lists all folders and workspaces that are associated with a specific profile from a central place. From this section, you can add or modify folders, or open the folder or workspace in a new window.
+このマイルストーンでは、プロファイル エディターに **フォルダーとワークスペース** セクションを導入しました。このセクションには、特定のプロファイルに関連付けられたすべてのフォルダーとワークスペースが中央の場所に一覧表示されます。このセクションから、フォルダーを追加または変更したり、フォルダーやワークスペースを新しいウィンドウで開いたりできます。
 
-![Folders & Workspaces section in the Profile editor.](https://code.visualstudio.com/assets/updates/1_94/profiles-editor-folders-workspaces.png)
+![プロファイル エディターのフォルダーとワークスペース セクション。](https://code.visualstudio.com/assets/updates/1_94/profiles-editor-folders-workspaces.png)
 
-### Update extensions across all profiles
+### すべてのプロファイルで拡張機能を更新する
 
-In this milestone, we introduced the ability to update extensions across all profiles. This is useful if you have multiple profiles and you want to keep your extensions versions in sync. Previously, you had to switch to each profile and update the extensions for that profile.
+このマイルストーンでは、すべてのプロファイルで拡張機能を更新する機能を導入しました。複数のプロファイルがあり、拡張機能のバージョンを同期させたい場合に便利です。以前は、各プロファイルに切り替えて、そのプロファイルの拡張機能を更新する必要がありました。
 
-### Warnings in the Extensions view
+### 拡張機能ビューの警告
 
-The Extensions view now shows a warning badge and associated information when there are any invalid extensions or extensions that are disabled due to version incompatibility.
+拡張機能ビューには、無効な拡張機能やバージョンの非互換性のために無効になっている拡張機能がある場合に、警告バッジと関連情報が表示されるようになりました。
 
-![Extensions view shows a warning badge and description about the warning.](https://code.visualstudio.com/assets/updates/1_94/extensions-warning-ux.png)
+![拡張機能ビューには、警告バッジと警告に関する説明が表示されます。](https://code.visualstudio.com/assets/updates/1_94/extensions-warning-ux.png)
 
-### Find in Explorer
+### エクスプローラーで検索 {#find-in-explorer}
 
-We’ve improved the Find feature in the Explorer view to make it easier to search for files in large projects. You can open the Find control in the File Explorer by using the `kb(list.find)` keyboard shortcut. While searching, you can switch between fuzzy matching and continuous matching for more flexible results.
+エクスプローラー ビューの検索機能を改善し、大規模なプロジェクトでファイルを検索しやすくしました。`kb(list.find)` キーボード ショートカットを使用して、ファイル エクスプローラーで検索コントロールを開くことができます。検索中は、柔軟な結果を得るために、あいまい一致と連続一致を切り替えることができます。
 
-Note that some context menu actions are temporarily disabled during searches. Stay tuned for more improvements coming soon!
+一部のコンテキスト メニュー アクションは検索中に一時的に無効になります。今後の改善にご期待ください!
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/file-explorer-find.mp4" title="Searching for files in explorer find" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/file-explorer-find.mp4" title="エクスプローラー検索でファイルを検索する" autoplay loop controls muted></video>
 
-### Release notes
+### リリース ノート
 
-We have a simplified syntax for referring to settings in our release notes (`setting(setting.name)`), which also has the now-familiar settings-gear rendering when displayed in the release notes editor.
+リリース ノートで設定を参照するための簡略化された構文 (`setting(setting.name)`) があり、リリース ノート エディターに表示されるときにおなじみの設定ギアのレンダリングも行われます。
 
-![Setting URL in release notes enables navigating to the Settings editor directly.](https://code.visualstudio.com/assets/updates/1_92/setting-url-in-release-notes.gif)
+![リリース ノートの設定 URL により、設定エディターに直接移動できます。](https://code.visualstudio.com/assets/updates/1_92/setting-url-in-release-notes.gif)
 
-## Editor
+## エディター
 
-### Inlay hint improvements
+### インレイ ヒントの改善
 
-We have added the `setting(editor.inlayHints.maximumLength)` setting, which controls after how many characters inlay hints are truncated.
+`setting(editor.inlayHints.maximumLength)` 設定を追加しました。この設定は、インレイ ヒントが切り捨てられる文字数を制御します。
 
-We have also revised the updating strategy for inlay hints and now, while typing, they should update sooner but not cause any horizontal movements of your cursor.
+インレイ ヒントの更新戦略も見直し、入力中にインレイ ヒントが早く更新されるようにしましたが、カーソルの水平移動は発生しません。
 
-### Experimental Edit Context
+### 実験的な編集コンテキスト
 
-This milestone, we introduced a new experimental setting `setting(editor.experimentalEditContextEnabled)`. This setting enables the [EditContext API](https://www.w3.org/TR/edit-context/) to power the editing experience in VS Code. The adoption of the [EditContext API](https://www.w3.org/TR/edit-context/) has enabled us to fix certain IME composition bugs. Generally we believe it will improve the editing experience in the long term, and ultimately it will be enabled by default.
+このマイルストーンでは、新しい実験的な設定 `setting(editor.experimentalEditContextEnabled)` を導入しました。この設定により、VS Code の編集エクスペリエンスを強化するために [EditContext API](https://www.w3.org/TR/edit-context/) が有効になります。[EditContext API](https://www.w3.org/TR/edit-context/) の採用により、特定の IME 構成バグを修正できました。一般的に、長期的には編集エクスペリエンスが向上すると考えており、最終的にはデフォルトで有効にする予定です。
 
-Make sure to reload your VS Code window after enabling this setting to take advantage of it.
+この設定を有効にした後、VS Code ウィンドウを再読み込みして、この設定を利用してください。
 
-## Source Control
+## ソース コントロール {#source-control}
 
-### Source Control Graph view improvements
+### ソース コントロール グラフ ビューの改善
 
-Last milestone, we added the new **Source Control Graph** view. This milestone, we have been working on expanding the functionality available in the newly added view as well as polishing the layout of the view.
+前回のマイルストーンでは、新しい **ソース コントロール グラフ** ビューを追加しました。このマイルストーンでは、新しく追加されたビューで利用可能な機能を拡張し、ビューのレイアウトを磨く作業を行いました。
 
-#### Repository picker
+#### リポジトリ ピッカー
 
-When you open a folder/workspace that contains multiple repositories, the Source Control Graph view title shows a repository picker. By default, the Source Control Graph view shows the active repository, matching the information in the Status Bar. You can use the repository picker to *lock* the Source Control Graph view to a particular repository.
+複数のリポジトリを含むフォルダー/ワークスペースを開くと、ソース コントロール グラフ ビューのタイトルにリポジトリ ピッカーが表示されます。デフォルトでは、ソース コントロール グラフ ビューはステータス バーの情報に一致するアクティブなリポジトリを表示します。リポジトリ ピッカーを使用して、ソース コントロール グラフ ビューを特定のリポジトリに*ロック*できます。
 
-![Repository picker control in the title of the Source Control Graph view.](https://code.visualstudio.com/assets/updates/1_94/scm-repository-picker-button.png)
+![ソース コントロール グラフ ビューのタイトルにあるリポジトリ ピッカー コントロール。](https://code.visualstudio.com/assets/updates/1_94/scm-repository-picker-button.png)
 
-#### History item reference picker
+#### 履歴アイテム参照ピッカー
 
-This milestone, we have added a new history item reference picker to the Source Control Graph view title. You can use this reference picker to filter the history items shown in the graph to a different branch, or to view multiple branches.
+このマイルストーンでは、ソース コントロール グラフ ビューのタイトルに新しい履歴アイテム参照ピッカーを追加しました。この参照ピッカーを使用して、グラフに表示される履歴アイテムを別のブランチにフィルタリングしたり、複数のブランチを表示したりできます。
 
-![History item reference Quick Pick control to choose one or more items.](https://code.visualstudio.com/assets/updates/1_94/scm-reference-quick-pick.png)
+![履歴アイテム参照クイック ピック コントロールを使用して、1 つ以上のアイテムを選択します。](https://code.visualstudio.com/assets/updates/1_94/scm-reference-quick-pick.png)
 
-By default the history item reference picker is set to `Auto`, which renders the graph for the current history item reference, its remote, and an optional base.
+デフォルトでは、履歴アイテム参照ピッカーは `Auto` に設定されており、現在の履歴アイテム参照、そのリモート、およびオプションのベースのグラフがレンダリングされます。
 
-![History item reference picker control in the title of the Source Control Graph view.](https://code.visualstudio.com/assets/updates/1_94/scm-reference-picker-button.png)
+![ソース コントロール グラフ ビューのタイトルにある履歴アイテム参照ピッカー コントロール。](https://code.visualstudio.com/assets/updates/1_94/scm-reference-picker-button.png)
 
-#### History item actions
+#### 履歴アイテム アクション
 
-This milestone, we have expanded the list of actions that are available in the context menu for source control history items. We have added actions to create a new branch/tag from a history item, cherry-pick a history item, and checkout (detached) an item.
+このマイルストーンでは、ソース コントロール履歴アイテムのコンテキスト メニューで利用できるアクションのリストを拡張しました。履歴アイテムから新しいブランチ/タグを作成したり、履歴アイテムをチェリーピックしたり、アイテムをチェックアウト (デタッチ) したりするアクションを追加しました。
 
-![Context menu for items in the Source Control Graph view.](https://code.visualstudio.com/assets/updates/1_94/scm-context-menu.png)
+![ソース コントロール グラフ ビューのアイテムのコンテキスト メニュー。](https://code.visualstudio.com/assets/updates/1_94/scm-context-menu.png)
 
-#### Source Control Graph settings
+#### ソース コントロール グラフの設定
 
-This milestone, we have added a set of new settings, so that you can customize the graph:
+このマイルストーンでは、グラフをカスタマイズできるようにするための新しい設定セットを追加しました:
 
-* `setting(scm.graph.badges)` - controls which badges are shown in the Source Control Graph view
-* `setting(scm.graph.pageOnScroll)` - controls whether the Source Control Graph view loads the next page of items when you scroll to the end of the list
-* `setting(scm.graph.pageSize)` - the default number of items to show in the Source Control Graph view and when loading more items
+* `setting(scm.graph.badges)` - ソース コントロール グラフ ビューに表示されるバッジを制御します
+* `setting(scm.graph.pageOnScroll)` - ソース コントロール グラフ ビューがリストの最後までスクロールしたときに次のページのアイテムを読み込むかどうかを制御します
+* `setting(scm.graph.pageSize)` - ソース コントロール グラフ ビューに表示されるデフォルトのアイテム数と、さらに多くのアイテムを読み込むときのアイテム数
 
-## Notebooks
+## ノートブック
 
-### Multi cursor support across cells (preview)
+### セル間のマルチカーソル サポート (プレビュー)
 
-The Notebook editor now supports multi-cursor editing between cells with the setting `setting(notebook.multiCursor.enabled:true)`. Currently, this can only be triggered with the shortcut `kbstyle(Ctrl+D)` and supports core editor actions alongside a limited subset of editor commands.
+ノートブック エディターは、`setting(notebook.multiCursor.enabled:true)` 設定を使用して、セル間のマルチカーソル編集をサポートするようになりました。現在、これはショートカット `kbstyle(Ctrl+D)` でのみトリガーされ、コア エディター アクションと限られたサブセットのエディター コマンドをサポートします。
 
-<video src="https://code.visualstudio.com/assets/updates/1_94/notebook-multi-cursor.mp4" title="Notebook multi cursor demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_94/notebook-multi-cursor.mp4" title="ノートブックのマルチカーソル デモ" autoplay loop controls muted></video>
 
-### Diff editor shows document metadata changes
+### Diff エディターはドキュメント メタデータの変更を表示します
 
-The notebook diff editor now also shows changes made to the document metadata, such as kernel information and cell language.
+ノートブックの diff エディターは、カーネル情報やセル言語など、ドキュメント メタデータに加えられた変更も表示するようになりました。
 
-![Notebook dif editor showing side-by-side changes to the document metadata.](https://code.visualstudio.com/assets/updates/1_94/notebook-diff-document-metadata.png)
+![ドキュメント メタデータの並べて表示される変更を示すノートブック diff エディター。](https://code.visualstudio.com/assets/updates/1_94/notebook-diff-document-metadata.png)
 
-### Collapse unchanged regions in diff view
+### Diff ビューで変更されていない領域を折りたたむ
 
-The notebook diff view now respects the setting `setting(diffEditor.hideUnchangedRegions.enabled)`. When enabled, unchanged code blocks are collapsed by default, which makes reviewing changes in large notebooks easier.
+ノートブックの diff ビューは、設定 `setting(diffEditor.hideUnchangedRegions.enabled)` を尊重するようになりました。有効にすると、変更されていないコード ブロックはデフォルトで折りたたまれるため、大規模なノートブックの変更を確認しやすくなります。
 
-![Diff editor shows unchanged code blocks as collapsed.](https://code.visualstudio.com/assets/updates/1_94/notebook-unchanged-region.png)
+![Diff エディターは、変更されていないコード ブロックを折りたたんで表示します。](https://code.visualstudio.com/assets/updates/1_94/notebook-unchanged-region.png)
 
-### Notebook serialization in web worker (Experimental)
+### Web ワーカーでのノートブックのシリアル化 (実験的)
 
-This release introduces an experimental feature that enables notebook serialization in a web worker. This can help reduce main thread blocking time in the Extension Host process when you work with large notebooks. By default, this feature is disabled but can be enabled by setting `setting(ipynb.experimental.serialization:true)` to `true`.
+このリリースでは、ノートブックのシリアル化を Web ワーカーで実行する実験的な機能を導入しました。これにより、大規模なノートブックを操作する際に、拡張機能ホスト プロセスのメイン スレッドのブロック時間を短縮できます。デフォルトではこの機能は無効になっていますが、`setting(ipynb.experimental.serialization:true)` を `true` に設定することで有効にできます。
 
-## Debug
+## デバッグ
 
-### Support for data colorization
+### データのカラー化のサポート
 
-VS Code supports new text styling capabilities from the Debug Adapter Protocol. This enables data in the Variables view, Watch view, hovers, and Debug Console to be colorized via ANSI escape sequences.
+VS Code は、デバッグ アダプター プロトコルからの新しいテキスト スタイリング機能をサポートしています。これにより、変数ビュー、ウォッチ ビュー、ホバー、およびデバッグ コンソール内のデータを ANSI エスケープ シーケンスを使用してカラー化できます。
 
-### JavaScript Debugger
+### JavaScript デバッガー
 
-#### Improved display of HTML elements
+#### HTML 要素の表示の改善
 
-We've improved how HTML elements are displayed in the JavaScript debugger. Previously, they were rendered as naive objects, which were hard to navigate. Now, they more closely reflect DOM structure, and we take advantage of new colorization capabilities to provide some basic syntax highlighting.
+JavaScript デバッガーでの HTML 要素の表示方法を改善しました。以前は、ナイーブなオブジェクトとしてレンダリングされており、ナビゲートが困難でした。現在では、DOM 構造をより正確に反映し、新しいカラー化機能を活用して基本的な構文の強調表示を提供しています。
 
-![HTML elements are colorized in the JavaScript Debug Console.](https://code.visualstudio.com/assets/updates/1_94/js-debug-html.png)
+![HTML 要素は JavaScript デバッグ コンソールでカラー化されます。](https://code.visualstudio.com/assets/updates/1_94/js-debug-html.png)
 
-#### Autocomplete of Node commands in launch configuration
+#### 起動構成での Node コマンドの自動補完
 
-There is a new autocompletion helper available in `launch.json` files for command-line applications that are installed in your `node_modules`. This makes it easier to set up debugging for tools like `vitest` or `nest`.
+`launch.json` ファイルには、`node_modules` にインストールされているコマンドライン アプリケーションの新しい自動補完ヘルパーが追加されました。これにより、`vitest` や `nest` などのツールのデバッグ設定が簡単になります。
 
-#### Cleaner Loaded Sources view
+#### クリーンな読み込まれたソース ビュー
 
-We changed how source paths are structured for Node.js built-in modules, evaluated scripts, and WebAssembly modules to make the **Loaded Sources** view less noisy and easier to browse.
+Node.js の組み込みモジュール、評価されたスクリプト、および WebAssembly モジュールのソース パスの構造を変更して、**読み込まれたソース** ビューがノイズが少なく、参照しやすくしました。
 
-## Languages
+## 言語
 
 ### TypeScript 5.6
 
-Our JavaScript and TypeScript support now uses TypeScript 5.6. This major update includes a number of language and tooling improvements, along with important bug fixes and performance optimizations.
+JavaScript および TypeScript のサポートは、現在 TypeScript 5.6 を使用しています。この主要なアップデートには、多くの言語およびツールの改善が含まれており、重要なバグ修正とパフォーマンスの最適化も行われています。
 
-You can read all about the TypeScript 5.6 release [on the TypeScript blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/). We've also included a few tooling highlights in the following sections.
+TypeScript 5.6 リリースの詳細については、[TypeScript ブログ](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/) をご覧ください。以下のセクションでは、いくつかのツールのハイライトも紹介しています。
 
-#### Detection of some common 'always true' programming mistakes
+#### 一部の一般的な「常に真」のプログラミング ミスの検出
 
-Say you're using a regular expression in JavaScript or TypeScript and write some code like this:
+JavaScript または TypeScript で正規表現を使用して次のようなコードを記述しているとします:
 
 ```typescript
 const str = '...'
@@ -366,29 +366,29 @@ if (/\d+(\.\d+)?/) {
 }
 ```
 
-Uh oh! Looks like we've forgotten to call `.test()` on the regular expression, meaning that the `if` conditional always evaluates to true. That's not what we want.
+おっと! 正規表現で `.test()` を呼び出すのを忘れているようです。これにより、`if` 条件は常に true と評価されます。これは望ましい結果ではありません。
 
-Even though this problem is obvious when pointed out, mistakes like this are surprisingly easy to make and have even caused real bugs in VS Code! Thankfully, TypeScript now reports some of the most common 'always true' errors in your program. This includes testing an `if` conditional against a value that is never value, or a conditional expression where the one side is unreachable, such as `/abc/ ?? /xyz/`.
+この問題は指摘されると明らかですが、このようなミスは驚くほど簡単に発生し、VS Code でも実際のバグを引き起こしました! 幸いなことに、TypeScript はプログラム内の最も一般的な「常に真」のエラーのいくつかを報告するようになりました。これには、決して値にならない値に対して `if` 条件をテストする場合や、片側が到達不能な条件式 (たとえば `/abc/ ?? /xyz/`) などが含まれます。
 
-[Check out the TypeScript release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#disallowed-nullish-and-truthy-checks) for more examples and details about how this feature works.
+この機能の動作の詳細と例については、[TypeScript リリース ノート](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#disallowed-nullish-and-truthy-checks) をご覧ください。
 
-#### Region prioritized diagnostics
+#### リージョン優先の診断
 
-Working in a very long JavaScript or TypeScript file? You should start seeing diagnostics for type error show up a little faster thanks to region prioritized diagnostics. This means that we try to get the diagnostics for the current visible code and show these first, even if the diagnostics for the rest of the file are still being computed.
+非常に長い JavaScript または TypeScript ファイルで作業していますか? リージョン優先の診断のおかげで、型エラーの診断が少し早く表示され始めるはずです。これにより、現在表示されているコードの診断を優先的に取得し、ファイル全体の診断がまだ計算中であっても、これらを最初に表示しようとします。
 
-This optimization is most relevant for complex files with thousands and thousands of lines. You may not notice any changes for smaller files.
+この最適化は、数千行の複雑なファイルに最も関連性があります。小さなファイルでは変更が見られない場合があります。
 
-#### Improved commit character for JavaScript and TypeScript
+#### JavaScript および TypeScript のコミット文字の改善
 
-Commit characters can speed up coding by automatically accepting completions when typed. For example, in JavaScript and TypeScript, `.` is often considered a commit character. This means to type `myVariable.property.`, you can just type `myv`, `.`, `p`, `.` with the first `.` accepting the completion for `myVariable` and the second `.` accepting the completion for `property`.
+コミット文字を使用すると、補完を自動的に受け入れることでコーディングを高速化できます。たとえば、JavaScript および TypeScript では、`.` はコミット文字と見なされることがよくあります。これにより、`myVariable.property.` を入力するには、`myv`、`.`、`p`、`.` と入力するだけで済みます。最初の `.` は `myVariable` の補完を受け入れ、2 番目の `.` は `property` の補完を受け入れます。
 
-These commit characters are now computed by TypeScript, which means that they can better take the program's structure into account. We can also continue improving our support for them over time.
+これらのコミット文字は現在 TypeScript によって計算されているため、プログラムの構造をより適切に考慮できます。今後もサポートを改善し続けることができます。
 
-Commit characters are enabled by default but can be disabled by setting `setting(editor.acceptSuggestionOnCommitCharacter: false)` to `false`.
+コミット文字はデフォルトで有効になっていますが、`setting(editor.acceptSuggestionOnCommitCharacter: false)` を `false` に設定することで無効にできます。
 
-#### Exclude Patterns for Auto-Imports
+#### 自動インポートの除外パターン
 
-The new `autoImportSpecifierExcludeRegexes` lets you exclude [auto import](https://code.visualstudio.com/docs/typescript/typescript-editing#_auto-imports) from specific packages by using a regular expression. For example, to exclude auto imports from the subdirectory of a module like lodash, you can set:
+新しい `autoImportSpecifierExcludeRegexes` を使用すると、正規表現を使用して特定のパッケージからの[自動インポート](https://code.visualstudio.com/docs/typescript/typescript-editing#_auto-imports)を除外できます。たとえば、lodash のサブディレクトリからの自動インポートを除外するには、次のように設定します:
 
 ```json
 {
@@ -398,36 +398,36 @@ The new `autoImportSpecifierExcludeRegexes` lets you exclude [auto import](https
 }
 ```
 
-You can configure this by using `setting(javascript.preferences.autoImportSpecifierExcludeRegexes)` for JavaScript and `setting(typescript.preferences.autoImportSpecifierExcludeRegexes)` for TypeScript. For more details see the [TypeScript 5.6 release notes](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#exclude-patterns-for-auto-imports)
+JavaScript の場合は `setting(javascript.preferences.autoImportSpecifierExcludeRegexes)` を、TypeScript の場合は `setting(typescript.preferences.autoImportSpecifierExcludeRegexes)` を使用してこれを構成できます。詳細については、[TypeScript 5.6 リリース ノート](https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#exclude-patterns-for-auto-imports) を参照してください。
 
-## Remote Development
+## リモート開発
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[リモート開発拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)を使用すると、[Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)、SSH 経由のリモート マシンまたは[リモート トンネル](https://code.visualstudio.com/docs/remote/tunnels)、または[Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) を使用して、フル機能の開発環境を使用できます。
 
-Highlights include:
+ハイライトには次のものが含まれます:
 
-* Attach to a Kubernetes container over SSH/Tunnel
-* Manually specify GPU availability
+* SSH/トンネル経由で Kubernetes コンテナーに接続する
+* GPU の可用性を手動で指定する
 
-You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_94.md).
+これらの機能の詳細については、[リモート開発リリース ノート](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_94.md)をご覧ください。
 
-## Contributions to extensions
+## 拡張機能への貢献
 
 ### Python
 
-#### Run tests with coverage
+#### カバレッジを使用してテストを実行する
 
-You can now run Python tests with coverage in VS Code! To run tests with coverage, select the coverage run icon in the Test Explorer or “Run with coverage” from any menu you normally trigger test runs from. The Python extension will run coverage by using the [`pytest-cov`](https://pypi.org/project/pytest-cov/) plugin if you are using pytest, or with [`coverage.py`](http://coverage.py/) for unittest.
+VS Code で Python テストをカバレッジで実行できるようになりました! カバレッジでテストを実行するには、テスト エクスプローラーでカバレッジ実行アイコンを選択するか、通常テスト実行をトリガーするメニューから「カバレッジで実行」を選択します。Python 拡張機能は、pytest を使用している場合は [`pytest-cov`](https://pypi.org/project/pytest-cov/) プラグインを使用して、unittest の場合は [`coverage.py`](http://coverage.py/) を使用してカバレッジを実行します。
 
-Once the coverage run is complete, lines are highlighted in the editor for line level coverage. These can be closed and re-opened via the Run Results panel in the bottom, where it says "Close Test Coverage" or "View Test Coverage" under the most recent test run. Additionally, a Test Coverage tab appears below the Testing tab in the Test Explorer, also with a beaker icon, which you can also navigate to with **Testing: Focus on Test Coverage View** in Command Palette (`kb(workbench.action.showCommands)`). On this panel you can view line and branch coverage metrics for each file and folder in your workspace.
+カバレッジ実行が完了すると、行レベルのカバレッジのためにエディター内の行が強調表示されます。これらは、下部の実行結果パネルで「テスト カバレッジを閉じる」または「テスト カバレッジを表示する」と表示される場所で閉じたり再度開いたりできます。さらに、テスト エクスプローラーのテスト タブの下にビーカー アイコン付きのテスト カバレッジ タブが表示され、**テスト: テスト カバレッジ ビューにフォーカス** でコマンド パレット (`kb(workbench.action.showCommands)`) で移動することもできます。このパネルでは、ワークスペース内の各ファイルおよびフォルダーの行およびブランチ カバレッジ メトリックを表示できます。
 
-For more information on running Python tests with coverage, see our [Python documentation](https://code.visualstudio.com/docs/python/testing#_run-tests-with-coverage). For general information on test coverage, see VS Code's [Test Coverage documentation](https://code.visualstudio.com/docs/editor/testing#_test-coverage).
+カバレッジを使用して Python テストを実行する方法の詳細については、[Python ドキュメント](https://code.visualstudio.com/docs/python/testing#_run-tests-with-coverage)を参照してください。テスト カバレッジの一般的な情報については、VS Code の[テスト カバレッジ ドキュメント](https://code.visualstudio.com/docs/editor/testing#_test-coverage)を参照してください。
 
-#### Python default problem matcher
+#### Python のデフォルトの問題マッチャー
 
-The Python extension now includes a default problem matcher, simplifying issue tracking in your Python code and offering more contextual feedback. To integrate it, add `"problemMatcher": "$python"` to your tasks in `task.json`. A problem matcher scans the task's output for errors and warnings and displays them in the Problems panel, enhancing your development workflow.
+Python 拡張機能にはデフォルトの問題マッチャーが含まれており、Python コードの問題追跡が簡単になり、より多くのコンテキスト フィードバックが提供されます。これを統合するには、`task.json` のタスクに `"problemMatcher": "$python"` を追加します。問題マッチャーは、タスクの出力をスキャンしてエラーや警告を検出し、それらを問題パネルに表示して、開発ワークフローを強化します。
 
-Below is an example of a `task.json` file that uses the default problem matcher for Python:
+以下は、Python のデフォルトの問題マッチャーを使用する `task.json` ファイルの例です:
 
 ```json
 {
@@ -446,238 +446,238 @@ Below is an example of a `task.json` file that uses the default problem matcher 
 }
 ```
 
-#### Shell integration in Python terminal REPL
+#### Python ターミナル REPL でのシェル統合
 
-The Python extension now includes a setting to opt in and out of `PYTHONSTARTUP` script, which runs before you type `python` or any other way to launch the Python REPL in the terminal. If you opt in, you can use features from terminal shell integrations, such as command decorations, re-run command, run recent commands, if they are in Mac or Linux. You can enable this via setting `setting(python.terminal.shellIntegration.enabled:true)`.
+Python 拡張機能には、`python` を入力する前に実行される `PYTHONSTARTUP` スクリプトのオプトインおよびオプトアウトの設定が含まれています。または、ターミナルで Python REPL を起動する他の方法を使用します。オプトインすると、Mac または Linux にある場合、コマンド デコレーション、コマンドの再実行、最近のコマンドの実行など、ターミナル シェル統合の機能を使用できます。`setting(python.terminal.shellIntegration.enabled:true)` 設定を使用してこれを有効にできます。
 
-#### Pylance Language Server Mode
+#### Pylance 言語サーバー モード
 
-There's a new setting `setting(python.analysis.languageServerMode)` that enables you to choose between our current IntelliSense experience or a lightweight one that is optimized for performance.
+`setting(python.analysis.languageServerMode)` という新しい設定があり、現在の IntelliSense エクスペリエンスとパフォーマンスに最適化された軽量なエクスペリエンスのどちらかを選択できます。
 
-If you don't require the full breadth of IntelliSense capabilities and prefer Pylance to be as resource-friendly as possible, you can set `setting(python.analysis.languageServerMode)` to `light`. Otherwise, to continue with the experience you have with Pylance today, you can set it to `default`.
+IntelliSense 機能の全範囲を必要とせず、Pylance をできるだけリソースに優しいものにしたい場合は、`setting(python.analysis.languageServerMode)` を `light` に設定できます。それ以外の場合は、今日の Pylance でのエクスペリエンスを続けるには、`default` に設定します。
 
-This new functionality overrides the default values of the following settings:
+この新しい機能は、次の設定のデフォルト値を上書きします:
 
-| Setting                           | `light` mode   | `default` mode   |
+| 設定                           | `light` モード   | `default` モード   |
 | :----------------------------- | :--------- | :--------- |
 | "python.analysis.exclude"                 | ["**"]      | []         |
 | "python.analysis.useLibraryCodeForTypes"    | false       | true       |
 | "python.analysis.enablePytestSupport"       | false       | true       |
 | "python.analysis.indexing"                 | false       | true       |
 
-The settings above can still be changed individually to override the default values.
+上記の設定は、デフォルト値を上書きするために個別に変更することもできます。
 
-### GitHub Pull Requests
+### GitHub プル リクエスト
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. Review the [changelog for the 0.98.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#0980) release of the extension to learn about the highlights.
+[GitHub プル リクエスト](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)拡張機能の進捗がさらに進みました。この拡張機能を使用すると、プル リクエストと問題を作成および管理できます。拡張機能の 0.98.0 リリースの[変更ログ](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#0980)を確認して、ハイライトを確認してください。
 
-## Extension Authoring
+## 拡張機能の作成
 
-### Remove custom allocator in the desktop app
+### デスクトップ アプリのカスタム アロケーターを削除する
 
-In this version, we have removed the custom allocator that was added in version 1.78 to the desktop application extension host. This custom allocator acts as a bridge for supporting V8 sandbox incompatible Node.js native addons that are built against the Electron runtime. You can refer to this [tracking issue](https://github.com/microsoft/vscode/issues/202385#issuecomment-2367174453) for additional context.
+このバージョンでは、バージョン 1.78 でデスクトップ アプリケーション拡張機能ホストに追加されたカスタム アロケーターを削除しました。このカスタム アロケーターは、Electron ランタイムに対してビルドされた V8 サンドボックスと互換性のない Node.js ネイティブ アドオンをサポートするためのブリッジとして機能します。追加のコンテキストについては、この[追跡問題](https://github.com/microsoft/vscode/issues/202385#issuecomment-2367174453)を参照してください。
 
-We have ensured that the top 5000 extensions are unaffected by this change. If your extension or a dependency of your extension is affected by this change, you can try the following remediation suggestions:
+上位 5000 の拡張機能に影響がないことを確認しました。この変更の影響を受ける拡張機能またはその依存関係がある場合は、次の修正提案を試してください:
 
-* If your extension uses [n-api](https://nodejs.org/docs/latest/api/n-api.html) then the status `napi_no_external_buffers_allowed` will be returned when using external array buffers. In which case, you can switch to use the copy version of the API [napi_create_buffer_copy](https://nodejs.org/docs/latest/api/n-api.html#napi_create_buffer_copy).
-* If your extension uses [node-addon-api](https://github.com/nodejs/node-addon-api) then refer to this [document](https://github.com/nodejs/node-addon-api/blob/main/doc/external_buffer.md) for alternative API and compile time settings.
-* If you want to avoid the performance cost from the copy, you can use the [V8 allocator](https://v8.github.io/api/head/classv8_1_1ArrayBuffer_1_1Allocator.html) to ensure that the buffer backing store is compatible with the V8 sandbox.
+* 拡張機能が [n-api](https://nodejs.org/docs/latest/api/n-api.html) を使用している場合、外部配列バッファーを使用する場合に `napi_no_external_buffers_allowed` ステータスが返されます。この場合、API のコピー バージョン [napi_create_buffer_copy](https://nodejs.org/docs/latest/api/n-api.html#napi_create_buffer_copy) を使用するように切り替えることができます。
+* 拡張機能が [node-addon-api](https://github.com/nodejs/node-addon-api) を使用している場合は、代替 API とコンパイル時設定についてこの[ドキュメント](https://github.com/nodejs/node-addon-api/blob/main/doc/external_buffer.md)を参照してください。
+* コピーによるパフォーマンス コストを回避したい場合は、[V8 アロケーター](https://v8.github.io/api/head/classv8_1_1ArrayBuffer_1_1Allocator.html)を使用して、バッファー バッキング ストアが V8 サンドボックスと互換性があることを確認できます。
 
-We have also added telemetry to identify extensions and native addons that might be affected, so we can proactively reach out to extension authors and offer help where possible. If your extension is effected, and none of the above suggestions work for you, comment in our [discussion thread](https://github.com/microsoft/vscode-discussions/discussions/1771) and we will gladly help.
+影響を受ける可能性のある拡張機能やネイティブ アドオンを特定するためのテレメトリも追加したため、拡張機能の作成者に積極的に連絡を取り、可能な限り支援を提供できます。拡張機能が影響を受けており、上記の提案がどれも機能しない場合は、[ディスカッション スレッド](https://github.com/microsoft/vscode-discussions/discussions/1771)にコメントを残してください。喜んでお手伝いします。
 
-## Debug Adapter Protocol
+## デバッグ アダプター プロトコル
 
-We formalized how text can be colorized and styled in the display of variables and output in the [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol). Colorization works via ANSI control sequences and require that both the client and debug adapter `supportsANSIStyling` in their initialize request and capabilities, respectively.
+[デバッグ アダプター プロトコル](https://microsoft.github.io/debug-adapter-protocol)の変数と出力の表示でテキストをカラー化およびスタイル設定する方法を正式化しました。カラー化は ANSI 制御シーケンスを介して機能し、クライアントとデバッグ アダプターの両方が初期化リクエストと機能で `supportsANSIStyling` をサポートする必要があります。
 
-## Preview Features
+## プレビュー機能
 
-### Multiple GitHub accounts
+### 複数の GitHub アカウント
 
-It's now possible to be logged in to multiple GitHub accounts in VS Code at the same time.
+VS Code で複数の GitHub アカウントに同時にログインできるようになりました。
 
-This functionality is enabled by default in VS Code Insiders. In Stable builds of VS Code, you can turn this on with the `setting(github.experimental.multipleAccounts)` setting.
+この機能は、VS Code Insiders ではデフォルトで有効になっています。VS Code の安定版ビルドでは、`setting(github.experimental.multipleAccounts)` 設定をオンにすることで有効にできます。
 
-Here are a couple of scenarios in which you might need multiple accounts:
+複数のアカウントが必要なシナリオの例を次に示します:
 
-* Use *Account1* for Settings Sync and *Account2* for the GitHub Pull Request extension
-* Use *Account1* for the GitHub extension (to push) and *Account2* for GitHub Copilot
+* *Account1* を設定同期に使用し、*Account2* を GitHub プル リクエスト拡張機能に使用する
+* *Account1* を GitHub 拡張機能 (プッシュ用) に使用し、*Account2* を GitHub Copilot に使用する
 
-To use this functionality, simply trigger a log in action (either with a built-in feature like Settings Sync or with an extension), and you'll be given the option to log in to a different account. This feature also pairs nicely with the new [Account Preference Quick Pick](#change-an-extensions-account-preference) should you need to change the account at a later stage.
+この機能を使用するには、(設定同期などの組み込み機能や拡張機能を使用して) ログイン アクションをトリガーし、別のアカウントにログインするオプションが表示されます。この機能は、新しい[アカウント優先設定クイック ピック](#change-an-extensions-account-preference)とも相性が良く、後でアカウントを変更する必要がある場合に便利です。
 
-While most things should just continue to work with your existing extensions, some behaviors might not play perfectly nice with this multi-account world just yet. If you think there's room for improvement, do open an issue on those extensions. With the help of the relatively new `vscode.authentication.getAccounts('github')` API, extensions have a lot of power to handle multiple accounts.
+ほとんどの機能は既存の拡張機能で引き続き動作するはずですが、一部の動作はこのマルチアカウント環境に完全には適合しない場合があります。改善の余地があると思われる場合は、それらの拡張機能に対して問題を報告してください。比較的新しい `vscode.authentication.getAccounts('github')` API を使用すると、拡張機能は複数のアカウントを処理するための多くの機能を利用できます。
 
-Next iteration, we are planning on turning this feature on by default for all users.
+次のイテレーションでは、この機能をすべてのユーザーにデフォルトで有効にする予定です。
 
-### MSAL-based Microsoft Authentication
+### MSAL ベースの Microsoft 認証
 
-We have been moving towards having our Microsoft Authentication stack use [MSAL (Microsoft Authentication Library)](http://github.com/AzureAD/microsoft-authentication-library-for-js). It's been a huge undertaking, but we have made great progress in this iteration. This work spans all VS Code clients, so that includes VS Code and [VS Code for the Web](https://vscode.dev).
+Microsoft 認証スタックを [MSAL (Microsoft Authentication Library)](http://github.com/AzureAD/microsoft-authentication-library-for-js) を使用するように移行しています。これは大規模な取り組みでしたが、このイテレーションでは大きな進展がありました。この作業は、VS Code と [VS Code for the Web](https://vscode.dev) を含むすべての VS Code クライアントにまたがっています。
 
-* For vscode.dev, we have enabled the browser-based `MSAL.js` for all Microsoft authentication requests. In other words, vscode.dev is now entirely on MSAL.
+* vscode.dev では、すべての Microsoft 認証リクエストに対してブラウザー ベースの `MSAL.js` を有効にしました。言い換えれば、vscode.dev は現在完全に MSAL 上にあります。
 
-* For VS Code, the desktop client, we have this feature behind a setting, `setting(microsoft.useMsal)`. It's behind a setting for now, as we plan on moving towards [the broker flow](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md), which would enable VS Code to use the authentication state of the operating system. So, to prevent as little interruption as possible, we will do that work first before enabling this widely. That said, if you're eager to try this new authentication, you are welcome to try and provide us feedback.
+* VS Code (デスクトップ クライアント) では、この機能は設定 `setting(microsoft.useMsal)` の背後にあります。これは、[ブローカー フロー](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)に移行する予定があるため、現在は設定の背後にあります。これにより、VS Code はオペレーティング システムの認証状態を使用できるようになります。したがって、可能な限り中断を防ぐために、これを広く有効にする前にその作業を行います。ただし、この新しい認証を試してみたい場合は、試してフィードバックを提供することをお勧めします。
 
-You can see the detailed status of this transition to MSAL across all of VS Code in [Issue #178740](https://github.com/microsoft/vscode/issues/178740).
+VS Code 全体での MSAL への移行の詳細な状況については、[Issue #178740](https://github.com/microsoft/vscode/issues/178740) を参照してください。
 
 ### TypeScript 5.7
 
-This release includes initial support for the upcoming TypeScript 5.7 release. Check out the [TypeScript 5.7 plan](https://github.com/microsoft/TypeScript/issues/59905) for details.
+このリリースには、次期 TypeScript 5.7 リリースの初期サポートが含まれています。詳細については、[TypeScript 5.7 プラン](https://github.com/microsoft/TypeScript/issues/59905) を参照してください。
 
-To start using preview builds of TypeScript 5.7, install the [TypeScript Nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next).
+TypeScript 5.7 のプレビュー ビルドを使用するには、[TypeScript Nightly 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next) をインストールします。
 
-## Proposed APIs
+## 提案された API
 
-### Tools for language models
+### 言語モデルのツール
 
-We continue to iterate on our `LanguageModelTool` API. The API comes with two major parts:
+`LanguageModelTool` API のイテレーションを続けています。API には 2 つの主要な部分があります:
 
-1. The ability for extensions to register a *tool*. A tool is a piece of functionality that is meant to be used by language models. For example, reading the Git history of a file.
+1. *ツール*を登録するための拡張機能の機能。ツールは、言語モデルによって使用されることを目的とした機能の一部です。たとえば、ファイルの Git 履歴を読み取ることができます。
 
-2. The mechanics for language models to support tools, such as extensions passing tools when making a request, language models requesting a tool invocation, and extensions communicating back the result of a tool invocation.
+2. 言語モデルがツールをサポートするためのメカニズム。たとえば、リクエスト時にツールを渡す拡張機能、ツールの呼び出しを要求する言語モデル、およびツールの呼び出し結果を拡張機能に通知するメカニズムです。
 
-In this milestone, we added the ability for tools to request user confirmation before running. This is helpful for tools that may have some side-effect.
+このマイルストーンでは、ツールが実行前にユーザーの確認を要求できる機能を追加しました。これは、副作用がある可能性のあるツールに役立ちます。
 
-Take a look at [issue #213274](https://github.com/microsoft/vscode/issues/213274) for more details or to give us feedback.
+詳細については、[issue #213274](https://github.com/microsoft/vscode/issues/213274) を参照するか、フィードバックを提供してください。
 
-> **Note**: The API is still under active development, and things will change.
+> **注**: API はまだ開発中であり、変更される可能性があります。
 
-## Engineering
+## エンジニアリング
 
-### ESM is shipping for VS Code
+### ESM は VS Code 用に出荷されています {#esm-is-shipping-for-vs-code}
 
-We are finally shipping our ESM work in VS Code Stable releases. That means that all layers of VS Code core (electron, node.js, browser, workers) use the `import` and `export` syntax in JavaScript for module loading and exporting. All usages of our legacy AMD loader are disabled and will be removed as part of our debt week in October.
+ついに ESM 作業を VS Code 安定版リリースで出荷しています。つまり、VS Code コアのすべてのレイヤー (electron、node.js、ブラウザー、ワーカー) が、モジュールの読み込みとエクスポートのために JavaScript で `import` および `export` 構文を使用しています。レガシー AMD ローダーのすべての使用は無効になっており、10 月の債務週の一環として削除されます。
 
-The move to ESM massively improves startup performance. For one, a lot of AMD overhead is removed, but then the main workbench bundle size is also reduced by more than 10%:
+ESM への移行により、起動パフォーマンスが大幅に向上します。まず、AMD のオーバーヘッドが大幅に削減されますが、メインのワークベンチ バンドル サイズも 10% 以上削減されます:
 
-![Graph showing the trend of the main bundle load time, showing a large drop after introducing ESM.](https://code.visualstudio.com/assets/updates/1_94/esm.png)
+![メイン バンドルの読み込み時間の傾向を示すグラフ。ESM の導入後に大幅な低下が見られます。](https://code.visualstudio.com/assets/updates/1_94/esm.png)
 
-Now that we are fully converted to ESM, we plan to improve our engineering system for VS Code. With ESM, a lot of modern tooling will work for us and we are very excited to share more details about this in the near future.
+ESM への完全な移行が完了したため、VS Code のエンジニアリング システムを改善する予定です。ESM を使用すると、多くの最新ツールが私たちのために機能し、近い将来に関する詳細を共有できることを非常に楽しみにしています。
 
-> **Note**: extensions are not impacted by this change and not loaded via ESM, please see [https://github.com/microsoft/vscode/issues/130367](https://github.com/microsoft/vscode/issues/130367) for details.
+> **注**: 拡張機能はこの変更の影響を受けず、ESM 経由で読み込まれることはありません。詳細については、[https://github.com/microsoft/vscode/issues/130367](https://github.com/microsoft/vscode/issues/130367) を参照してください。
 
-### Use NPM as default package manager
+### デフォルトのパッケージ マネージャーとして NPM を使用する
 
-Beginning of September 2024, we have completed the [switch from yarn to npm](https://github.com/microsoft/vscode/issues/196795) for package management in the [microsoft/vscode](https://github.com/microsoft/vscode) repo. This decision was based on the specific requirements of VS Code and center around these criteria:
+2024 年 9 月の初めに、[microsoft/vscode](https://github.com/microsoft/vscode) リポジトリのパッケージ管理に yarn から npm への[切り替えを完了しました](https://github.com/microsoft/vscode/issues/196795)。この決定は、VS Code の特定の要件に基づいており、次の基準を中心にしています:
 
-* Performance: we initially moved to yarn because of performance reasons and npm can now also meet our requirements
-* Security: we make our supply chain more secure by limiting exposure and reducing the number of tools we depend upon
+* パフォーマンス: 最初はパフォーマンスの理由で yarn に移行しましたが、npm も要件を満たすことができます
+* セキュリティ: 露出を制限し、依存するツールの数を減らすことで、サプライ チェーンをより安全にします
 
-## Notable fixes
+## 注目の修正
 
-* [226401](https://github.com/microsoft/vscode/issues/226401) fileWatcher keeps consuming CPU at 200%+
-* [10054](https://github.com/microsoft/vscode-remote-release/issues/10054) [WSL]: Ports tab incorrectly reports Ports in WSL being forwarded to local when `localhostForwarding = false`
+* [226401](https://github.com/microsoft/vscode/issues/226401) fileWatcher が CPU を 200% 以上消費し続ける
+* [10054](https://github.com/microsoft/vscode-remote-release/issues/10054) [WSL]: `localhostForwarding = false` の場合、ポート タブが WSL 内のポートがローカルに転送されていると誤って報告する
 
-## Thank you
+## ありがとう
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆様に心からの感謝を申し上げます。
 
-### Issue tracking
+### 問題追跡
 
-Contributions to our issue tracking:
+問題追跡への貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 
-### Pull requests
+### プルリクエスト
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
 * [@BABA983 (BABA)](https://github.com/BABA983)
-  * fix terminal tab selection not work properly [PR #224394](https://github.com/microsoft/vscode/pull/224394)
-  * Register fold import action [PR #227216](https://github.com/microsoft/vscode/pull/227216)
-* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): ci: ensure retry logic consistency [PR #226038](https://github.com/microsoft/vscode/pull/226038)
-* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): chore: rm unreached ignore items when build extensions. [PR #227906](https://github.com/microsoft/vscode/pull/227906)
-* [@dangerman (Anees Ahee)](https://github.com/dangerman): Fix Image Preview transparency grid scaling [PR #226505](https://github.com/microsoft/vscode/pull/226505)
-* [@g-cappai (Gianluca Cappai)](https://github.com/g-cappai): Fix open html anchor link in markdown preview [PR #228633](https://github.com/microsoft/vscode/pull/228633)
-* [@gabritto (Gabriela Araujo Britto)](https://github.com/gabritto): [typescript-language-features] Expandable hover [PR #228255](https://github.com/microsoft/vscode/pull/228255)
+  * ターミナル タブの選択が正しく機能しない問題を修正 [PR #224394](https://github.com/microsoft/vscode/pull/224394)
+  * インポート アクションの折りたたみを登録する [PR #227216](https://github.com/microsoft/vscode/pull/227216)
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): ci: リトライ ロジックの一貫性を確保する [PR #226038](https://github.com/microsoft/vscode/pull/226038)
+* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): chore: 拡張機能をビルドする際に到達できない無視項目を削除します。 [PR #227906](https://github.com/microsoft/vscode/pull/227906)
+* [@dangerman (Anees Ahee)](https://github.com/dangerman): 画像プレビューの透明グリッドのスケーリングを修正 [PR #226505](https://github.com/microsoft/vscode/pull/226505)
+* [@g-cappai (Gianluca Cappai)](https://github.com/g-cappai): Markdown プレビューで HTML アンカー リンクを開く [PR #228633](https://github.com/microsoft/vscode/pull/228633)
+* [@gabritto (Gabriela Araujo Britto)](https://github.com/gabritto): [typescript-language-features] 展開可能なホバー [PR #228255](https://github.com/microsoft/vscode/pull/228255)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
-  * Add actions to preview editor tab's hover [PR #226023](https://github.com/microsoft/vscode/pull/226023)
-  * Fix typo in workspace extension activation failure message [PR #227348](https://github.com/microsoft/vscode/pull/227348)
-  * Correct tooltip capitalization of debug panel in status bar (fix #228088) [PR #228089](https://github.com/microsoft/vscode/pull/228089)
-* [@henricryden](https://github.com/henricryden): additional search path for libc.so.6 in check-requirements-linux.sh [PR #227713](https://github.com/microsoft/vscode/pull/227713)
-* [@janssen-tiobe (janssen)](https://github.com/janssen-tiobe): Fix: agressive URI encoding in table view of the problems panel [PR #224841](https://github.com/microsoft/vscode/pull/224841)
-* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): Fix initial terminal dimensions are reload are incorrect [PR #225554](https://github.com/microsoft/vscode/pull/225554)
-* [@jjaeggli (Jacob Jaeggli)](https://github.com/jjaeggli): Document focus suggest details with ctrl+alt+space [PR #190096](https://github.com/microsoft/vscode/pull/190096)
-* [@juliapz (Julia Pozdeeva)](https://github.com/juliapz): Prevent find widget from being cropped in AUX window [PR #229001](https://github.com/microsoft/vscode/pull/229001)
-* [@marrej (Marcus Revaj)](https://github.com/marrej): # Render file creation in the refactor preview [PR #226950](https://github.com/microsoft/vscode/pull/226950)
+  * プレビュー エディター タブのホバーにアクションを追加する [PR #226023](https://github.com/microsoft/vscode/pull/226023)
+  * ワークスペース拡張機能のアクティベーション失敗メッセージのタイプミスを修正 [PR #227348](https://github.com/microsoft/vscode/pull/227348)
+  * ステータス バーのデバッグ パネルのツールチップの大文字を修正 (fix #228088) [PR #228089](https://github.com/microsoft/vscode/pull/228089)
+* [@henricryden](https://github.com/henricryden): check-requirements-linux.sh で libc.so.6 の追加の検索パス [PR #227713](https://github.com/microsoft/vscode/pull/227713)
+* [@janssen-tiobe (janssen)](https://github.com/janssen-tiobe): 修正: 問題パネルのテーブル ビューでの URI エンコードの過剰 [PR #224841](https://github.com/microsoft/vscode/pull/224841)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): 初期ターミナルの寸法がリロード時に正しくない問題を修正 [PR #225554](https://github.com/microsoft/vscode/pull/225554)
+* [@jjaeggli (Jacob Jaeggli)](https://github.com/jjaeggli): ctrl+alt+space で提案の詳細にフォーカスすることを文書化する [PR #190096](https://github.com/microsoft/vscode/pull/190096)
+* [@juliapz (Julia Pozdeeva)](https://github.com/juliapz): AUX ウィンドウで検索ウィジェットが切り取られないようにする [PR #229001](https://github.com/microsoft/vscode/pull/229001)
+* [@marrej (Marcus Revaj)](https://github.com/marrej): # リファクター プレビューでファイルの作成をレンダリングする [PR #226950](https://github.com/microsoft/vscode/pull/226950)
 * [@nojaf (Florian Verdonck)](https://github.com/nojaf)
-  * Use Worker to serialize Notebook [PR #226632](https://github.com/microsoft/vscode/pull/226632)
-  * Include id in ErrorNoTelemetry message [PR #226715](https://github.com/microsoft/vscode/pull/226715)
-* [@PhantomPower82](https://github.com/PhantomPower82): Polish getting started page (fix #226991) [PR #226994](https://github.com/microsoft/vscode/pull/226994)
-* [@rafamerlin (Rafael Merlin)](https://github.com/rafamerlin): Make Inlay hint length configurable [PR #221276](https://github.com/microsoft/vscode/pull/221276)
+  * ノートブックをシリアル化するためのワーカーを使用する [PR #226632](https://github.com/microsoft/vscode/pull/226632)
+  * ErrorNoTelemetry メッセージに id を含める [PR #226715](https://github.com/microsoft/vscode/pull/226715)
+* [@PhantomPower82](https://github.com/PhantomPower82): はじめにページを磨く (fix #226991) [PR #226994](https://github.com/microsoft/vscode/pull/226994)
+* [@rafamerlin (Rafael Merlin)](https://github.com/rafamerlin): インレイ ヒントの長さを構成可能にする [PR #221276](https://github.com/microsoft/vscode/pull/221276)
 * [@rehmsen (Ole)](https://github.com/rehmsen)
-  * Initialize test variables in `setup` to avoid order dependency. [PR #226596](https://github.com/microsoft/vscode/pull/226596)
-  * Support multiple comment widgets per notebook cell. [PR #226770](https://github.com/microsoft/vscode/pull/226770)
-* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Add test-results.xml to .gitignore [PR #214238](https://github.com/microsoft/vscode/pull/214238)
-* [@repraze (Thomas Dubosc)](https://github.com/repraze): fix: swap end for flex-end in browser/hover.css [PR #224102](https://github.com/microsoft/vscode/pull/224102)
-* [@segevfiner (Segev Finer)](https://github.com/segevfiner): Adopt ext host restart for custom text editors [PR #225985](https://github.com/microsoft/vscode/pull/225985)
-* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): fix: memory leak in debug view [PR #225334](https://github.com/microsoft/vscode/pull/225334)
-* [@sunnylost (sunnylost)](https://github.com/sunnylost): extensions: wrap table cell content in paragraph element [PR #228365](https://github.com/microsoft/vscode/pull/228365)
-* [@tisilent (xiejialong)](https://github.com/tisilent): Add editor gpu rendering fallback [PR #228414](https://github.com/microsoft/vscode/pull/228414)
-* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Ignore tsserver requests for createDirectoryWatcher(~/Library) on macOS [PR #227653](https://github.com/microsoft/vscode/pull/227653)
+  * `setup` でテスト変数を初期化して順序依存性を回避します。 [PR #226596](https://github.com/microsoft/vscode/pull/226596)
+  * ノートブック セルごとに複数のコメント ウィジェットをサポートします。 [PR #226770](https://github.com/microsoft/vscode/pull/226770)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): .gitignore に test-results.xml を追加する [PR #214238](https://github.com/microsoft/vscode/pull/214238)
+* [@repraze (Thomas Dubosc)](https://github.com/repraze): 修正: browser/hover.css で end を flex-end に置き換える [PR #224102](https://github.com/microsoft/vscode/pull/224102)
+* [@segevfiner (Segev Finer)](https://github.com/segevfiner): カスタム テキスト エディターの拡張ホストの再起動を採用する [PR #225985](https://github.com/microsoft/vscode/pull/225985)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): 修正: デバッグ ビューのメモリ リーク [PR #225334](https://github.com/microsoft/vscode/pull/225334)
+* [@sunnylost (sunnylost)](https://github.com/sunnylost): 拡張機能: テーブル セルの内容を段落要素でラップする [PR #228365](https://github.com/microsoft/vscode/pull/228365)
+* [@tisilent (xiejialong)](https://github.com/tisilent): エディターの GPU レンダリング フォールバックを追加する [PR #228414](https://github.com/microsoft/vscode/pull/228414)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): macOS で createDirectoryWatcher(~/Library) の tsserver リクエストを無視する [PR #227653](https://github.com/microsoft/vscode/pull/227653)
 
-Contributions to `vscode-docs`:
+`vscode-docs` への貢献:
 
-* [@0dinD (Odin Dahlström)](https://github.com/0dinD): Update supported Java versions [PR #7561](https://github.com/microsoft/vscode-docs/pull/7561)
-* [@alexwkleung (Alex Leung)](https://github.com/alexwkleung): Update enter jupyter server url screenshot [PR #7584](https://github.com/microsoft/vscode-docs/pull/7584)
-* [@DiskCrasher (Mike)](https://github.com/DiskCrasher): Fixed missing "!" in code [PR #7595](https://github.com/microsoft/vscode-docs/pull/7595)
-* [@gaganshera (Gaganjot Singh)](https://github.com/gaganshera): Update prompt-crafting.md [PR #7555](https://github.com/microsoft/vscode-docs/pull/7555)
-* [@harish-s-developer (Harish Srinivasan)](https://github.com/harish-s-developer): Added new Managing dependencies section, fixed one typo [PR #7617](https://github.com/microsoft/vscode-docs/pull/7617)
-* [@harrydowning (Harry Downing)](https://github.com/harrydowning): Remove incorrect statement about pre release tags [PR #7593](https://github.com/microsoft/vscode-docs/pull/7593)
-* [@listsarah (Sarah Listzwan)](https://github.com/listsarah): To Close Issue #7536: Update "Embedded Programming Languages" [PR #7539](https://github.com/microsoft/vscode-docs/pull/7539)
-* [@mistymadonna (Misty Hays)](https://github.com/mistymadonna): Updated Azure Extensions homepage, Created new Getting Started page [PR #7520](https://github.com/microsoft/vscode-docs/pull/7520)
-* [@muzimuzhi (Yukai Chou)](https://github.com/muzimuzhi): Typo, add missing inline code markup [PR #7589](https://github.com/microsoft/vscode-docs/pull/7589)
-* [@partev](https://github.com/partev): fix a URL redirect [PR #7608](https://github.com/microsoft/vscode-docs/pull/7608)
-* [@Sarke (Peter Stalman)](https://github.com/Sarke): Another Flatpak/KDE5 wallet workaround [PR #7606](https://github.com/microsoft/vscode-docs/pull/7606)
-* [@seaniyer (Sean)](https://github.com/seaniyer): Update publishing-extension.md [PR #7540](https://github.com/microsoft/vscode-docs/pull/7540)
-* [@vinistock (Vinicius Stock)](https://github.com/vinistock): Update Ruby links to point to new documentation [PR #7607](https://github.com/microsoft/vscode-docs/pull/7607)
+* [@0dinD (Odin Dahlström)](https://github.com/0dinD): サポートされている Java バージョンを更新する [PR #7561](https://github.com/microsoft/vscode-docs/pull/7561)
+* [@alexwkleung (Alex Leung)](https://github.com/alexwkleung): Jupyter サーバー URL の入力スクリーンショットを更新する [PR #7584](https://github.com/microsoft/vscode-docs/pull/7584)
+* [@DiskCrasher (Mike)](https://github.com/DiskCrasher): コードの欠落している "!" を修正しました [PR #7595](https://github.com/microsoft/vscode-docs/pull/7595)
+* [@gaganshera (Gaganjot Singh)](https://github.com/gaganshera): prompt-crafting.md を更新する [PR #7555](https://github.com/microsoft/vscode-docs/pull/7555)
+* [@harish-s-developer (Harish Srinivasan)](https://github.com/harish-s-developer): 新しい依存関係の管理セクションを追加し、1 つのタイプミスを修正しました [PR #7617](https://github.com/microsoft/vscode-docs/pull/7617)
+* [@harrydowning (Harry Downing)](https://github.com/harrydowning): プレリリース タグに関する誤った記述を削除する [PR #7593](https://github.com/microsoft/vscode-docs/pull/7593)
+* [@listsarah (Sarah Listzwan)](https://github.com/listsarah): Issue #7536 を閉じるために: 「埋め込みプログラミング言語」を更新する [PR #7539](https://github.com/microsoft/vscode-docs/pull/7539)
+* [@mistymadonna (Misty Hays)](https://github.com/mistymadonna): Azure 拡張機能のホームページを更新し、新しいはじめにページを作成しました [PR #7520](https://github.com/microsoft/vscode-docs/pull/7520)
+* [@muzimuzhi (Yukai Chou)](https://github.com/muzimuzhi): タイプミス、欠落しているインライン コード マークアップを追加する [PR #7589](https://github.com/microsoft/vscode-docs/pull/7589)
+* [@partev](https://github.com/partev): URL リダイレクトを修正する [PR #7608](https://github.com/microsoft/vscode-docs/pull/7608)
+* [@Sarke (Peter Stalman)](https://github.com/Sarke): もう 1 つの Flatpak/KDE5 ウォレットの回避策 [PR #7606](https://github.com/microsoft/vscode-docs/pull/7606)
+* [@seaniyer (Sean)](https://github.com/seaniyer): publishing-extension.md を更新する [PR #7540](https://github.com/microsoft/vscode-docs/pull/7540)
+* [@vinistock (Vinicius Stock)](https://github.com/vinistock): Ruby リンクを新しいドキュメントにポイントするように更新する [PR #7607](https://github.com/microsoft/vscode-docs/pull/7607)
 * [@wjandrea (William Andrea)](https://github.com/wjandrea)
-  * tasks.md: add `source` property to `problemMatcher` [PR #7493](https://github.com/microsoft/vscode-docs/pull/7493)
-  * tasks.md: mention `problemMatcher.severity` [PR #7494](https://github.com/microsoft/vscode-docs/pull/7494)
+  * tasks.md: `problemMatcher` プロパティに `source` を追加する [PR #7493](https://github.com/microsoft/vscode-docs/pull/7493)
+  * tasks.md: `problemMatcher.severity` に言及する [PR #7494](https://github.com/microsoft/vscode-docs/pull/7494)
 
-Contributions to `vscode-extension-samples`:
+`vscode-extension-samples` への貢献:
 
-* [@liu3hao (Weihao)](https://github.com/liu3hao): Add missing activation event [PR #1057](https://github.com/microsoft/vscode-extension-samples/pull/1057)
+* [@liu3hao (Weihao)](https://github.com/liu3hao): 欠落しているアクティベーション イベントを追加する [PR #1057](https://github.com/microsoft/vscode-extension-samples/pull/1057)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@lucacasonato (Luca Casonato)](https://github.com/lucacasonato): fix: don't inject NODE_OPTIONS in Deno [PR #2080](https://github.com/microsoft/vscode-js-debug/pull/2080)
+* [@lucacasonato (Luca Casonato)](https://github.com/lucacasonato): 修正: Deno で NODE_OPTIONS を挿入しない [PR #2080](https://github.com/microsoft/vscode-js-debug/pull/2080)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献:
 
-* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Make display_name changes also cause a kernel change event [PR #15967](https://github.com/microsoft/vscode-jupyter/pull/15967)
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): display_name の変更もカーネル変更イベントを引き起こすようにする [PR #15967](https://github.com/microsoft/vscode-jupyter/pull/15967)
 
-Contributions to `vscode-languageserver-node`:
+`vscode-languageserver-node` への貢献:
 
-* [@StellaHuang95 (Stella)](https://github.com/StellaHuang95): Support  `llmGenerated` property on `CodeAction` [PR #1557](https://github.com/microsoft/vscode-languageserver-node/pull/1557)
+* [@StellaHuang95 (Stella)](https://github.com/StellaHuang95): `CodeAction` に `llmGenerated` プロパティをサポートする [PR #1557](https://github.com/microsoft/vscode-languageserver-node/pull/1557)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@ixzhao](https://github.com/ixzhao): fix quote reply [PR #6230](https://github.com/microsoft/vscode-pull-request-github/pull/6230)
+* [@ixzhao](https://github.com/ixzhao): 引用返信を修正する [PR #6230](https://github.com/microsoft/vscode-pull-request-github/pull/6230)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
-* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Update debugpy info to latest shipped version [PR #462](https://github.com/microsoft/vscode-python-debugger/pull/462)
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): 最新の出荷バージョンに debugpy 情報を更新する [PR #462](https://github.com/microsoft/vscode-python-debugger/pull/462)
 
-Contributions to `vscode-vsce`:
+`vscode-vsce` への貢献:
 
-* [@mlasson (Marc Lasson)](https://github.com/mlasson): Fix typo in option hint [PR #1046](https://github.com/microsoft/vscode-vsce/pull/1046)
+* [@mlasson (Marc Lasson)](https://github.com/mlasson): オプションのヒントのタイプミスを修正する [PR #1046](https://github.com/microsoft/vscode-vsce/pull/1046)
 
-Contributions to `vscode-wasm`:
+`vscode-wasm` への貢献:
 
-* [@mlugg (Matthew Lugg)](https://github.com/mlugg): Fix stream bugs [PR #196](https://github.com/microsoft/vscode-wasm/pull/196)
+* [@mlugg (Matthew Lugg)](https://github.com/mlugg): ストリームのバグを修正する [PR #196](https://github.com/microsoft/vscode-wasm/pull/196)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@aschaber1 (Alexander Schaber)](https://github.com/aschaber1): chore: fix typo from `kubernets` to `kubernetes` [PR #2013](https://github.com/microsoft/language-server-protocol/pull/2013)
-* [@dawedawe (dawe)](https://github.com/dawedawe): fix typo in the documentation of CompletionParams [PR #2019](https://github.com/microsoft/language-server-protocol/pull/2019)
-* [@didrikmunther (Didrik Munther)](https://github.com/didrikmunther): Fix misspelling in pullDiagnostics.md [PR #2022](https://github.com/microsoft/language-server-protocol/pull/2022)
+* [@aschaber1 (Alexander Schaber)](https://github.com/aschaber1): chore: `kubernets` から `kubernetes` へのタイプミスを修正する [PR #2013](https://github.com/microsoft/language-server-protocol/pull/2013)
+* [@dawedawe (dawe)](https://github.com/dawedawe): CompletionParams のドキュメントのタイプミスを修正する [PR #2019](https://github.com/microsoft/language-server-protocol/pull/2019)
+* [@didrikmunther (Didrik Munther)](https://github.com/didrikmunther): pullDiagnostics.md のスペルミスを修正する [PR #2022](https://github.com/microsoft/language-server-protocol/pull/2022)
 * [@InSyncWithFoo (InSync)](https://github.com/InSyncWithFoo)
-  * Fix a few typos in `percentage`'s doc comments [PR #2010](https://github.com/microsoft/language-server-protocol/pull/2010)
-  * Add Taplo to implementor list [PR #2021](https://github.com/microsoft/language-server-protocol/pull/2021)
-* [@SamB (Samuel Bronson)](https://github.com/SamB): Update servers.md: vscode-markdown-languageserver moved [PR #2012](https://github.com/microsoft/language-server-protocol/pull/2012)
-* [@sh-cho (Seonghyeon Cho)](https://github.com/sh-cho): Add fluent-bit language server implementation [PR #2016](https://github.com/microsoft/language-server-protocol/pull/2016)
-* [@StellaHuang95 (Stella)](https://github.com/StellaHuang95): Support  `llmGenerated` property on `CodeAction` [PR #2020](https://github.com/microsoft/language-server-protocol/pull/2020)
+  * `percentage` のドキュメント コメントのいくつかのタイプミスを修正する [PR #2010](https://github.com/microsoft/language-server-protocol/pull/2010)
+  * Taplo を実装者リストに追加する [PR #2021](https://github.com/microsoft/language-server-protocol/pull/2021)
+* [@SamB (Samuel Bronson)](https://github.com/SamB): servers.md を更新: vscode-markdown-languageserver が移動しました [PR #2012](https://github.com/microsoft/language-server-protocol/pull/2012)
+* [@sh-cho (Seonghyeon Cho)](https://github.com/sh-cho): fluent-bit 言語サーバーの実装を追加する [PR #2016](https://github.com/microsoft/language-server-protocol/pull/2016)
+* [@StellaHuang95 (Stella)](https://github.com/StellaHuang95): `CodeAction` に `llmGenerated` プロパティをサポートする [PR #2020](https://github.com/microsoft/language-server-protocol/pull/2020)
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_95.md
+++ b/docs/release-notes/v1_95.md
@@ -1,705 +1,705 @@
 ---
 Order: 104
-TOCTitle: October 2024
-PageTitle: Visual Studio Code October 2024
-MetaDescription: Learn what is new in the Visual Studio Code October 2024 Release (1.95)
+TOCTitle: 2024 年 10 月
+PageTitle: Visual Studio Code 2024 年 10 月
+MetaDescription: Visual Studio Code 2024 年 10 月リリース (1.95) の新機能を学びます
 MetaSocialImage: 1_95/release-highlights.png
 Date: 2024-10-29
 DownloadVersion: 1.95.1
 ---
-# October 2024 (version 1.95)
+# 2024 年 10 月 (バージョン 1.95)
 
-**Update 1.95.1**: The update addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22October+2024+Recovery+1%22+is%3Aclosed).
+**アップデート 1.95.1**: このアップデートはこれらの [問題](https://github.com/microsoft/vscode/issues?q=is%3Aissue+milestone%3A%22October+2024+Recovery+1%22+is%3Aclosed) に対処します。
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the October 2024 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2024 年 10 月リリースへようこそ。このバージョンには多くの更新が含まれており、いくつかの主要なハイライトは次のとおりです:
 
-* [Copilot Edits](#start-a-code-editing-session-with-copilot-edits) - Iterate quickly on large changes across multiple files
-* [Copilot Chat in Secondary Side Bar](#chat-in-the-secondary-side-bar) - Keep Copilot Chat open and ready to-go while you work
-* [Multiple GitHub accounts](#multiple-github-accounts) - Log in to multiple GitHub accounts in VS Code simultaneously
-* [Copilot code reviews](#copilot-code-reviews) - Get a quick review pass or a deeper review of uncommitted changes
-* [Docstrings with Pylance](#generate-docstrings-with-pylance) - Generate docstring templates for classes or methods
-* [Preview settings indicator](#settings-editor-indicator-for-experimental-and-preview-settings) - View experimental and preview settings in the Settings editor
-* [Copilot extensibility](#copilot-extensions-showcase) - Showcasing Copilot extensibility in VS Code
+* [Copilot Edits](#start-a-code-editing-session-with-copilot-edits) - 複数のファイルにわたる大規模な変更を迅速に反復処理します
+* [セカンダリ サイドバーの Copilot チャット](#chat-in-the-secondary-side-bar) - 作業中に Copilot チャットを開いてすぐに使用できるようにします
+* [複数の GitHub アカウント](#multiple-github-accounts) - VS Code で複数の GitHub アカウントに同時にログインします
+* [Copilot コード レビュー](#copilot-code-reviews) - コミットされていない変更のクイック レビュー パスまたは詳細なレビューを取得します
+* [Pylance を使用したドックストリング](#generate-docstrings-with-pylance) - クラスまたはメソッドのドックストリング テンプレートを生成します
+* [プレビュー設定インジケーター](#settings-editor-indicator-for-experimental-and-preview-settings) - 設定エディターで実験的およびプレビュー設定を表示します
+* [Copilot 拡張機能](#copilot-extensions-showcase) - VS Code での Copilot 拡張機能を紹介します
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+>これらのリリース ノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [更新プログラム](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** できるだけ早く新機能を試してみたいですか? ナイトリー [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新の更新プログラムをすぐに試すことができます。
 
 ## GitHub Copilot
 
-Copilot features might go through different early access stages, which are typically enabled and configured through settings.
+Copilot 機能は、通常、設定を通じて有効化および構成されるさまざまな早期アクセス段階を経ることがあります。
 
-* **Experimental** - view the [experimental features](command:workbench.action.openSettings?%5B%22%40tag%3Aexperimental%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:experimental`)
+* **実験的** - [実験的機能](command:workbench.action.openSettings?%5B%22%40tag%3Aexperimental%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:experimental`) を表示します
 
-	This setting controls a new feature that is actively being developed and may be unstable. It is subject to change or removal.
+  この設定は、積極的に開発されており、不安定な可能性がある新機能を制御します。変更または削除される可能性があります。
 
-* **Preview** - view the [preview features](command:workbench.action.openSettings?%5B%22%40tag%3Apreview%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:preview`)
+* **プレビュー** - [プレビュー機能](command:workbench.action.openSettings?%5B%22%40tag%3Apreview%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:preview`) を表示します
 
-	This setting controls a new feature that is still under refinement yet ready to use. Feedback is welcome.
+  この設定は、まだ改良中ですが、使用する準備ができている新機能を制御します。フィードバックを歓迎します。
 
-### Start a code editing session with Copilot Edits
+### Copilot Edits でコード編集セッションを開始する {#start-a-code-editing-session-with-copilot-edits}
 
-> Copilot Edits is currently in preview
+> Copilot Edits は現在プレビュー中です
 
-**Setting**: `setting(github.copilot.chat.edits.enabled)`
+**設定**: `setting(github.copilot.chat.edits.enabled)`
 
-With Copilot Edits, you can start an AI-powered code editing session where you can quickly iterate on code changes. Based on your prompts, Copilot Edits proposes code changes across multiple files in your workspace. These edits are applied directly in the editor, so you can quickly review them in-place, with the full context of the surrounding code.
+Copilot Edits を使用すると、AI を活用したコード編集セッションを開始して、コード変更を迅速に反復処理できます。プロンプトに基づいて、Copilot Edits はワークスペース内の複数のファイルにわたるコード変更を提案します。これらの編集はエディターに直接適用されるため、周囲のコードの完全なコンテキストでインプレースで迅速にレビューできます。
 
-Copilot Edits is great for iterating on large changes across multiple files. It brings the conversational flow of Copilot Chat and fast feedback from Inline Chat together in one experience. Have an ongoing, multi-turn chat conversation on the side, while benefiting from inline code suggestions.
+Copilot Edits は、複数のファイルにわたる大規模な変更を反復処理するのに最適です。Copilot チャットの会話の流れとインライン チャットからの迅速なフィードバックを 1 つのエクスペリエンスにまとめます。サイドで進行中の複数ターンのチャット会話を行いながら、インライン コードの提案を活用できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/copilot-edits-hero.mp4" title="Use Copilot Edits to modify an Express app." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/copilot-edits-hero.mp4" title="Copilot Edits を使用して Express アプリを変更します。" autoplay loop controls muted></video>
 
-Get started with Copilot Edits in just three steps:
+Copilot Edits を使用して開始するには、次の 3 つの手順を実行します:
 
-1. Start an edit session by selecting **Open Copilot Edits** from the Chat menu, or press `kb(workbench.action.chat.openEditSession)`.
+1. チャット メニューから **Copilot Edits を開く** を選択するか、`kb(workbench.action.chat.openEditSession)` を押して編集セッションを開始します。
 
-    ![Screenshot showing the Copilot menu in the Command Center, highlighting the Open Edit Session item](https://code.visualstudio.com/assets/updates/1_95/copilot-command-center-open-edit-session.png)
+    ![コマンド センターの Copilot メニューを示すスクリーンショットで、編集セッションを開く項目を強調表示しています](https://code.visualstudio.com/assets/updates/1_95/copilot-command-center-open-edit-session.png)
 
-1. Add relevant files to the _working set_ to indicate to Copilot which files you want to work on.
+1. 関連するファイルを _作業セット_ に追加して、Copilot に作業するファイルを示します。
 
-1. Enter a prompt to tell Copilot about the edit you want to make! For example, `Add a simple navigation bar to all pages` or `Use vitest instead of jest`.
+1. プロンプトを入力して、行いたい編集について Copilot に伝えます。たとえば、`すべてのページにシンプルなナビゲーション バーを追加する` または `jest の代わりに vitest を使用する` などです。
 
-Get more details about [Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-edits) in our documentation. Try it out now and provide your feedback through [our issues](https://github.com/microsoft/vscode-copilot-release/issues)!
+ドキュメントで [Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-edits) の詳細を確認してください。今すぐ試して、[問題](https://github.com/microsoft/vscode-copilot-release/issues) を通じてフィードバックを提供してください。
 
-### Chat in the Secondary Side Bar
+### セカンダリ サイドバーのチャット {#chat-in-the-secondary-side-bar}
 
-The new default location for the Chat view is the [Secondary Side Bar](https://aka.ms/vscode-secondary-sidebar). By using the Secondary Side Bar, you can have chat open at any time, while you still have other views available to you like the File Explorer or Source Control. This provides you with a more integrated AI experience in VS Code. You can quickly get to chat by using the `kb(workbench.action.chat.open)` keyboard shortcut.
+チャット ビューの新しいデフォルトの場所は [セカンダリ サイドバー](https://aka.ms/vscode-secondary-sidebar) です。セカンダリ サイドバーを使用すると、ファイル エクスプローラーやソース管理などの他のビューを引き続き使用できる状態で、いつでもチャットを開くことができます。これにより、VS Code でより統合された AI エクスペリエンスが提供されます。`kb(workbench.action.chat.open)` キーボード ショートカットを使用して、すばやくチャットにアクセスできます。
 
-![Chat view in its new location after having moved.](<https://code.visualstudio.com/assets/updates/1_95/chat-new-location.png>)
+![移動後の新しい場所にあるチャット ビュー。](<https://code.visualstudio.com/assets/updates/1_95/chat-new-location.png>)
 
-With the introduction of the new Chat menu next to the Command Center, bringing up the Secondary Side Bar with chat is just a click away:
+コマンド センターの横に新しいチャット メニューが導入されたことで、チャットを使用したセカンダリ サイドバーをすぐに表示できます:
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/chat-video.mp4" title="Chat in Secondary Side Bar." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/chat-video.mp4" title="セカンダリ サイドバーのチャット。" autoplay loop controls muted></video>
 
-The chat menu gives you access to the most common tasks for Copilot Chat. If you wish to hide this menu, a new setting `setting(chat.commandCenter.enabled)` is provided.
+チャット メニューを使用すると、Copilot チャットの最も一般的なタスクにアクセスできます。このメニューを非表示にしたい場合は、新しい設定 `setting(chat.commandCenter.enabled)` が提供されます。
 
-![Chat menu in the Command Center.](<https://code.visualstudio.com/assets/updates/1_95/chat-menu.png>)
+![コマンド センターのチャット メニュー。](<https://code.visualstudio.com/assets/updates/1_95/chat-menu.png>)
 
-**Note:** If you had previously installed GitHub Copilot, a view will show up at the location you had Chat before that enables you to restore the Chat view to the old location, if that works better for you.
+**注**: 以前に GitHub Copilot をインストールしていた場合、チャット ビューを以前の場所に復元できるビューが表示されます。これにより、以前の場所にチャット ビューを復元できます。
 
-![Chat view in its old location showing that Chat has moved to the Secondary Side Bar.](<https://code.visualstudio.com/assets/updates/1_95/chat-old-location.png>)
+![チャットがセカンダリ サイドバーに移動したことを示す以前の場所のチャット ビュー。](<https://code.visualstudio.com/assets/updates/1_95/chat-old-location.png>)
 
-### Copilot code reviews
+### Copilot コード レビュー {#copilot-code-reviews}
 
-> Copilot code reviews are currently in preview
+> Copilot コード レビューは現在プレビュー中です
 
-With GitHub Copilot code review in Visual Studio Code, you can now get fast, AI-powered feedback on your code as you write it, or request a review of all your changes before you push. GitHub Copilot code review in Visual Studio Code is currently in preview. Try it out and provide feedback through [our issues](https://github.com/microsoft/vscode-copilot-release/issues).
+Visual Studio Code の GitHub Copilot コード レビューを使用すると、コードの記述中に迅速な AI 駆動のフィードバックを受け取ったり、プッシュする前にすべての変更のレビューをリクエストしたりできます。Visual Studio Code の GitHub Copilot コード レビューは現在プレビュー中です。ぜひ試してみて、[問題](https://github.com/microsoft/vscode-copilot-release/issues) を通じてフィードバックを提供してください。
 
-There are two ways to use Copilot code review in VS Code:
+VS Code で Copilot コード レビューを使用する方法は 2 つあります:
 
-* **Review selection**: for a quick review pass, select code in the editor and either select **Copilot** > **Review and Comment** from the editor context menu, or use the **GitHub Copilot: Review and Comment** command from the Command Palette. _(This feature is in preview.)_
+* **選択のレビュー**: クイック レビュー パスの場合、エディターでコードを選択し、エディター コンテキスト メニューから **Copilot** > **レビューとコメント** を選択するか、コマンド パレットから **GitHub Copilot: レビューとコメント** コマンドを使用します。_(この機能はプレビュー中です。)_
 
-* **Review changes**: for a deeper review of all uncommitted changes, select the **Copilot Code Review** button in the **Source Control** view, which you can also do in your pull request on GitHub.com. _(Join the [waitlist](https://gh.io/copilot-code-review-waitlist), open to all Copilot subscribers)_
+* **変更のレビュー**: コミットされていないすべての変更の詳細なレビューの場合、**ソース管理** ビューで **Copilot コード レビュー** ボタンを選択します。これを GitHub.com のプル リクエストでも行うことができます。_(すべての Copilot サブスクライバーに公開されている[ウェイトリスト](https://gh.io/copilot-code-review-waitlist) に参加します)_
 
-    ![Request review of uncommited changes](https://code.visualstudio.com/assets/updates/1_95/review_diff.png)
+    ![コミットされていない変更のレビューをリクエストする](https://code.visualstudio.com/assets/updates/1_95/review_diff.png)
 
-Copilot's feedback shows up as comments in the editor, attached to lines of your code. Where possible, the comments include actionable code suggestions, which you can apply in one action.
+Copilot のフィードバックは、エディター内のコード行に添付されたコメントとして表示されます。可能な場合、コメントには実行可能なコードの提案が含まれており、1 回のアクションで適用できます。
 
-![Screenshot showing a comment reviewing a code selection](https://code.visualstudio.com/assets/updates/1_95/reviewing_selection.png)
+![コード選択をレビューするコメントを示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_95/reviewing_selection.png)
 
-To learn more about Copilot code review, head to the [GitHub code review documentation](https://gh.io/copilot-code-review-docs).
+Copilot コード レビューの詳細については、[GitHub コード レビュー ドキュメント](https://gh.io/copilot-code-review-docs) を参照してください。
 
-Copilot's quick review on code selection can provide feedback that match the specific practices of your team or project, provided you give the right context. When reviewing selections with custom review instructions, you can define those specific requirements via the `setting(github.copilot.chat.reviewSelection.instructions)` setting. Similar to [code-generation and test-generation instructions](https://code.visualstudio.com/docs/copilot/copilot-customization), you can either define the instructions directly in the setting, or you can store them in a separate file and reference it in the setting.
+Copilot のコード選択に関するクイック レビューは、適切なコンテキストを提供することで、チームやプロジェクトの特定のプラクティスに一致するフィードバックを提供できます。カスタム レビュー指示を使用して選択をレビューする場合、`setting(github.copilot.chat.reviewSelection.instructions)` 設定を使用して、これらの特定の要件を定義できます。[コード生成およびテスト生成指示](https://code.visualstudio.com/docs/copilot/copilot-customization)と同様に、指示を設定に直接定義するか、別のファイルに保存して設定で参照することができます。
 
-The following code snippet shows an example of review instructions:
+次のコード スニペットは、レビュー指示の例を示しています:
 
 ```json
   "github.copilot.chat.reviewSelection.instructions": [
     {
-      "text": "Logging should be done with the Log4j ."
+      "text": "ログは Log4j を使用して行う必要があります。"
     },
     {
-      "text": "Always use the Polly library for fault-handling."
+      "text": "フォールト ハンドリングには常に Polly ライブラリを使用してください。"
     },
     {
-      "file": "code-style.md" // import instructions from file `code-style.md`
+      "file": "code-style.md" // ファイル `code-style.md` から指示をインポートします
     }
   ],
 ```
 
-An example of the contents of the `code-style.md` file:
+`code-style.md` ファイルの内容の例:
 
 ```markdown
-Private fields should start with an underscore.
+プライベート フィールドはアンダースコアで始める必要があります。
 
-A file can only contain one class declaration.
+ファイルには 1 つのクラス宣言のみを含めることができます。
 ```
 
-### Automatic chat participant detection
+### チャット参加者の自動検出
 
-**Setting**: `setting(chat.experimental.detectParticipant.enabled)`
+**設定**: `setting(chat.experimental.detectParticipant.enabled)`
 
-GitHub Copilot has several built-in chat participants, such as `@workspace`, and you may have installed other extensions that contribute chat participants too.
+GitHub Copilot には `@workspace` などのいくつかの組み込みチャット参加者があり、他の拡張機能をインストールしてチャット参加者を追加することもできます。
 
-To make it easier to use chat participants with natural language, Copilot Chat will automatically route your question to a suitable participant or chat command, when possible.
+自然言語でチャット参加者を使用しやすくするために、Copilot チャットは可能な場合に質問を適切な参加者またはチャット コマンドに自動的にルーティングします。
 
-If the automatically selected participant is not appropriate for your question, you can still select the **rerun without** link at the top of the chat response to resend your question to Copilot.
+自動的に選択された参加者が質問に適していない場合は、チャット応答の上部にある **再実行しない** リンクを選択して、質問を Copilot に再送信できます。
 
-![Screenshot of Chat view that shows how the '@workspace' participant is automatically detected.](https://code.visualstudio.com/assets/updates/1_93/participant-detection.png)
+![`@workspace` 参加者が自動的に検出される方法を示すチャット ビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_93/participant-detection.png)
 
-This month, we also added an action to let you skip this detection behavior on a per-request basis. The default action when you enter a chat prompt is **Send and dispatch**, which includes participant detection. If you choose **Send**, the request is sent directly to Copilot Chat and it won't be automatically dispatched to a chat participant.
+今月、リクエストごとにこの検出動作をスキップするアクションも追加しました。チャット プロンプトを入力するときのデフォルトのアクションは **送信してディスパッチ** であり、参加者の検出が含まれます。**送信** を選択すると、リクエストは Copilot チャットに直接送信され、チャット参加者に自動的にディスパッチされません。
 
-![The list of available "send" commands in the chat view.](<https://code.visualstudio.com/assets/updates/1_95/chat-send-commands.png>)
+![チャット ビューで利用可能な「送信」コマンドのリスト。](<https://code.visualstudio.com/assets/updates/1_95/chat-send-commands.png>)
 
-You can also disable automatic participant detection entirely with the `setting(chat.experimental.detectParticipant.enabled)` setting.
+`setting(chat.experimental.detectParticipant.enabled)` 設定を使用して、自動参加者検出を完全に無効にすることもできます。
 
-### Control current editor context
+### 現在のエディター コンテキストを制御する
 
-Copilot Chat has always automatically included your current selection or the currently visible code as context with your chat request. Large Language Models (LLMs) are generally good at understanding whether a piece of context is relevant. But sometimes, when you ask a question that is not about your current editor, including this context might affect how the model interprets your question.
+Copilot チャットは常に、チャット リクエストのコンテキストとして現在の選択または現在表示されているコードを自動的に含めていました。大規模言語モデル (LLM) は、コンテキストが関連しているかどうかを理解するのが得意です。ただし、現在のエディターに関する質問をしていない場合、このコンテキストを含めると、モデルが質問を解釈する方法に影響を与える可能性があります。
 
-We now show a special attachment control in the chat input that gives a hint about the editor context and which enables you to toggle whether or not to include the editor context.
+現在、チャット入力に特別な添付コントロールを表示して、エディター コンテキストに関するヒントを提供し、エディター コンテキストを含めるかどうかを切り替えることができます。
 
-![The current editor context control in the chat input, which shows that the context is not included.](<https://code.visualstudio.com/assets/updates/1_95/implicit-context.png>)
+![チャット入力の現在のエディター コンテキスト コントロール。コンテキストが含まれていないことを示しています。](<https://code.visualstudio.com/assets/updates/1_95/implicit-context.png>)
 
-There are no changes to the behavior of the editor context. When the active editor has a selection, then just the selection is included. Otherwise, just the code that is scrolled into view is included. You can still attach other files or the full file by using the paperclip button or by typing `#` in the chat prompt.
+エディター コンテキストの動作に変更はありません。アクティブなエディターに選択がある場合は、選択のみが含まれます。それ以外の場合は、表示されているコードのみが含まれます。ペーパークリップ ボタンを使用するか、チャット プロンプトに `#` を入力して、他のファイルや完全なファイルを添付することもできます。
 
-### Interactive workspace symbol links
+### インタラクティブなワークスペース シンボル リンク
 
-A common use case of Copilot Chat is asking questions about the code in your workspace, such as using `/tests` to generate new unit tests for the selected code or asking `@workspace` to find some specific class or function in your project. This milestone, we added enhanced links for any workspace symbols that Copilot mentions in chat responses. These symbol links can help you better understand Copilot responses and learn more about the symbols used in them.
+Copilot チャットの一般的な使用例は、ワークスペース内のコードに関する質問をすることです。たとえば、選択したコードの新しい単体テストを生成するために `/tests` を使用したり、プロジェクト内の特定のクラスや関数を見つけるために `@workspace` を使用したりします。このマイルストーンでは、Copilot がチャット応答で言及するワークスペース シンボルのリンクを強化しました。これらのシンボル リンクは、Copilot の応答をよりよく理解し、それらで使用されるシンボルについて詳しく学ぶのに役立ちます。
 
-Symbol links are rendered as little pills in the response, just like the [file links](https://code.visualstudio.com/updates/v1_94#_improved-file-links-in-chat-responses) we added last milestone. To start learn more about a symbol, just select the symbol link to jump to that symbol's definition:
+シンボル リンクは、前回のマイルストーンで追加した[ファイル リンク](https://code.visualstudio.com/updates/v1_94#_improved-file-links-in-chat-responses)と同様に、応答内で小さなピルとしてレンダリングされます。シンボルについて詳しく知るには、シンボル リンクを選択してそのシンボルの定義にジャンプします:
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/copilot-symbol-links-overview.mp4" title="Symbols links being rendered in a Copilot response. Clicking on then navigates to the symbol definition." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/copilot-symbol-links-overview.mp4" title="Copilot の応答でシンボル リンクがレンダリングされます。クリックするとシンボルの定義に移動します。" autoplay loop controls muted></video>
 
-You can also hover over the symbol link to see which file the symbol is defined in:
+シンボル リンクにカーソルを合わせると、シンボルが定義されているファイルを確認できます:
 
-![Hovering over a symbol link to see the file it's defined in.](https://code.visualstudio.com/assets/updates/1_95/copilot-symbol-link-hover.png)
+![シンボル リンクにカーソルを合わせて、シンボルが定義されているファイルを表示します。](https://code.visualstudio.com/assets/updates/1_95/copilot-symbol-link-hover.png)
 
-To start exploring a symbol in more detail, just right-click on the symbol link to bring up a context menu with options, such as **Go to Implementations** and **Go to References**:
+シンボルを詳しく調べるには、シンボル リンクを右クリックして、**実装に移動** や **参照に移動** などのオプションを含むコンテキスト メニューを表示します:
 
-![Using the context menu on a symbol link to learn more about a symbol.](https://code.visualstudio.com/assets/updates/1_95/copilot-symbol-link-context-menu.png)
+![シンボルについて詳しく知るためにシンボル リンクのコンテキスト メニューを使用します。](https://code.visualstudio.com/assets/updates/1_95/copilot-symbol-link-context-menu.png)
 
-Basic symbol links should work for any language that supports Go to Definition. More advanced IntelliSense options, such Go to Implementations, also require support for that language. Make sure to install language extensions to get the best symbol support for any programming languages used in Copilot responses.
+基本的なシンボル リンクは、定義に移動をサポートする任意の言語で機能するはずです。実装に移動などの高度な IntelliSense オプションも、その言語のサポートが必要です。Copilot の応答で使用されるプログラミング言語に最適なシンボル サポートを得るために、言語拡張機能をインストールしてください。
 
-### Fix using Copilot action in the Problem hover
+### 問題ホバーで Copilot アクションを使用して修正する
 
-When you hover over a problem in the editor, it now includes an action to fix the problem using Copilot. This action is available for problems that have a fix available, and the fix is generated by Copilot.
+エディターで問題にカーソルを合わせると、現在、Copilot を使用して問題を修正するアクションが含まれています。このアクションは、修正可能な問題に対して利用可能であり、修正は Copilot によって生成されます。
 
-![The Problem hover showing a Fix using Copilot action.](https://code.visualstudio.com/assets/updates/1_95/copilot-fix-problem-hover.png)
+![Copilot アクションを使用して修正する問題ホバー。](https://code.visualstudio.com/assets/updates/1_95/copilot-fix-problem-hover.png)
 
-### Workspace indexing
+### ワークスペースのインデックス作成
 
-[`@workspace`](https://code.visualstudio.com/docs/copilot/copilot-chat#_workspace) lets you ask questions about code in your current project. This is implemented using either [GitHub's code search](https://github.blog/2023-02-06-the-technology-behind-githubs-new-code-search) or a smart local index that VS Code constructs. This milestone, we added a few more UI elements that let you understand how this workspace index is being used.
+[`@workspace`](https://code.visualstudio.com/docs/copilot/copilot-chat#_workspace) を使用すると、現在のプロジェクトのコードに関する質問をすることができます。これは、[GitHub のコード検索](https://github.blog/2023-02-06-the-technology-behind-githubs-new-code-search)または VS Code が構築するスマートなローカル インデックスを使用して実装されます。このマイルストーンでは、このワークスペース インデックスの使用方法を理解するためのいくつかの新しい UI 要素を追加しました。
 
-First up, the new **GitHub Copilot: Build Local Workspace index** command lets you explicitly start indexing the current workspace. This indexing is normally kicked off automatically the first time you ask a `@workspace` question. With the new command, you can instead start indexing at any time. The command also enables indexing of larger workspaces, currently up to 2000 files (not including ignored files, such as the `node_modules` or `out` directories).
+まず、新しい **GitHub Copilot: ローカル ワークスペース インデックスの構築** コマンドを使用して、現在のワークスペースのインデックス作成を明示的に開始できます。このインデックス作成は、通常、最初に `@workspace` 質問をするときに自動的に開始されます。新しいコマンドを使用すると、いつでもインデックス作成を開始できます。このコマンドは、現在最大 2000 ファイル (たとえば、`node_modules` や `out` ディレクトリなどの無視されたファイルを含まない) の大規模なワークスペースのインデックス作成も有効にします。
 
-While the index is being built, we now also show a progress item in the status bar:
+インデックスが構築されている間、ステータス バーに進行状況アイテムが表示されるようになりました:
 
-![A status bar item showing the progress of indexing the current workspace.](https://code.visualstudio.com/assets/updates/1_95/copilot-workspace-ui-progress.png)
+![現在のワークスペースのインデックス作成の進行状況を示すステータス バー アイテム。](https://code.visualstudio.com/assets/updates/1_95/copilot-workspace-ui-progress.png)
 
-Indexing workspaces with many hundreds of files can take a little time. If you try to ask an `@workspace` question while indexing is being constructed, instead of waiting, Copilot will try to respond quickly by using a simpler local index that can be built up more quickly. We now show a warning in the response when this happens:
+数百のファイルを含むワークスペースのインデックス作成には少し時間がかかる場合があります。インデックスが構築されている間に `@workspace` 質問をしようとすると、待機する代わりに、Copilot はより迅速に構築できるシンプルなローカル インデックスを使用して迅速に応答しようとします。この場合、応答に警告が表示されるようになりました:
 
-![A warning showing on a response telling the user the Copilot index is being constructed.](https://code.visualstudio.com/assets/updates/1_95/copilot-workspace-ui-warning.png)
+![Copilot インデックスが構築されていることをユーザーに通知する応答に表示される警告。](https://code.visualstudio.com/assets/updates/1_95/copilot-workspace-ui-warning.png)
 
-Notice that Copilot was still able to answer the question in this case, even though it used the simpler local index instead of the more advanced one. That's often the case, although more ambiguous or complex questions might only be answerable once the smarter index has been constructed. Also keep in mind that if your workspace is backed by a GitHub repository, we can instead use [GitHub's code search](https://github.blog/2023-02-06-the-technology-behind-githubs-new-code-search) to answer questions. That means that code search is used instead of the simpler local index.
+この場合、Copilot はより高度なインデックスではなく、シンプルなローカル インデックスを使用しても質問に答えることができました。これはよくあることですが、より曖昧または複雑な質問は、スマートなインデックスが構築された後にのみ回答できる場合があります。また、ワークスペースが GitHub リポジトリによってバックアップされている場合、代わりに [GitHub のコード検索](https://github.blog/2023-02-06-the-technology-behind-githubs-new-code-search) を使用して質問に回答できることに注意してください。つまり、コード検索はシンプルなローカル インデックスの代わりに使用されます。
 
-### Chat follow-up improvements
+### チャットのフォローアップの改善
 
-**Setting**: `setting(github.copilot.chat.followUps)`
+**設定**: `setting(github.copilot.chat.followUps)`
 
-To make more room for chat conversations in the Chat view, we've made follow-up prompts more concise and, by default, they only appear on the first turn. Configure the `setting(github.copilot.chat.followUps)` setting to change when follow-up prompts appear:
+チャット ビューでのチャット会話のスペースを増やすために、フォローアップ プロンプトをより簡潔にし、デフォルトでは最初のターンにのみ表示されるようにしました。`setting(github.copilot.chat.followUps)` 設定を構成して、フォローアップ プロンプトが表示されるタイミングを変更します:
 
-* `firstOnly` (default) - Follow-up prompts only appear on the first turn
-* `always` - Follow-up prompts always appear
-* `never` - Disable follow-up prompts
+* `firstOnly` (デフォルト) - フォローアップ プロンプトは最初のターンにのみ表示されます
+* `always` - フォローアップ プロンプトは常に表示されます
+* `never` - フォローアップ プロンプトを無効にします
 
-### Sort by relevance in Semantic Search (Experimental)
+### セマンティック検索で関連性で並べ替え (実験的)
 
-**Setting**: `setting(github.copilot.chat.search.semanticTextResults)`
+**設定**: `setting(github.copilot.chat.search.semanticTextResults)`
 
-Last milestone, we introduced the ability to perform a semantic search using Copilot to get search results that are semantically relevant to your query. We have now improved the search results by sorting them by their relevance. Keyword matches from more relevant snippets are deemed more relevant overall.
+前回のマイルストーンでは、Copilot を使用してセマンティックに関連する検索結果を取得するセマンティック検索を実行する機能を導入しました。検索結果を関連性で並べ替えることで、検索結果を改善しました。より関連性の高いスニペットからのキーワード一致が全体的により関連性が高いと見なされます。
 
-## Workbench
+## ワークベンチ
 
-### Multiple GitHub accounts
+### 複数の GitHub アカウント {#multiple-github-accounts}
 
-Graduating last month's feature to the default behavior, it's now possible to be logged in to multiple GitHub accounts in VS Code at the same time.
+先月の機能をデフォルトの動作に昇格させ、VS Code で複数の GitHub アカウントに同時にログインできるようになりました。
 
-![Multiple GitHub Accounts in the Account menu.](https://code.visualstudio.com/assets/updates/1_95/multi-github-accounts.png)
+![アカウント メニューの複数の GitHub アカウント。](https://code.visualstudio.com/assets/updates/1_95/multi-github-accounts.png)
 
-Here are a couple of scenarios in which you might need multiple accounts:
+複数のアカウントが必要なシナリオの例を次に示します:
 
-* Use *Account1* for Settings Sync and *Account2* for the GitHub Pull Request extension
-* Use *Account1* for the GitHub extension (to push) and *Account2* for GitHub Copilot
+* *Account1* を設定同期に使用し、*Account2* を GitHub プル リクエスト拡張機能に使用する
+* *Account1* を GitHub 拡張機能 (プッシュ用) に使用し、*Account2* を GitHub Copilot に使用する
 
-To use this functionality, simply trigger a log in action (either with a built-in feature like Settings Sync or with an extension), and you'll be given the option to log in to a different account. This feature also pairs nicely with the [Account Preference Quick Pick](#add-additional-accounts-when-changing-account-preferences), should you need to change the selected account at a later stage.
+この機能を使用するには、(設定同期などの組み込み機能や拡張機能を使用して) ログイン アクションをトリガーし、別のアカウントにログインするオプションが表示されます。この機能は、後でアカウントを変更する必要がある場合に便利な[アカウント優先設定クイック ピック](#add-additional-accounts-when-changing-account-preferences)とも相性が良いです。
 
-While most things should just continue to work with your existing extensions, some behaviors might not play perfectly nice with this multi-account world just yet. If you think there's room for improvement, do open an issue on those extensions. With the help of the relatively new `vscode.authentication.getAccounts('github')` API, extensions have a lot of power to handle multiple accounts.
+ほとんどの機能は既存の拡張機能で引き続き動作するはずですが、一部の動作はこのマルチアカウント環境に完全には適合しない場合があります。改善の余地があると思われる場合は、それらの拡張機能に対して問題を報告してください。比較的新しい `vscode.authentication.getAccounts('github')` API を使用すると、拡張機能は複数のアカウントを処理するための多くの機能を利用できます。
 
-### Add additional accounts when changing account preferences
+### アカウント優先設定を変更する際に追加のアカウントを追加する {#add-additional-accounts-when-changing-account-preferences}
 
-Last month, we introduced the [Account Preference Quick Pick](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference), which is useful for changing the preferred account to use for an extension should you need to change that for any reason.
+先月、[アカウント優先設定クイック ピック](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference)を導入しました。これは、何らかの理由で拡張機能に使用する優先アカウントを変更する必要がある場合に便利です。
 
-One of the pieces of feedback we received was around wanting an easy way to add an account that is not yet logged in. This milestone, we have introduced a new item in the Quick Pick that enables you to do just that. Use the **Use a new account...** item to start an authentication flow and set the account preference to that account in one go.
+受け取ったフィードバックの 1 つは、まだログインしていないアカウントを簡単に追加したいというものでした。このマイルストーンでは、新しいアカウントを追加して、認証フローを開始し、そのアカウントにアカウント優先設定を設定できる新しい項目をクイック ピックに追加しました。**新しいアカウントを使用...** 項目を使用して、認証フローを開始し、アカウント優先設定をそのアカウントに設定します。
 
-![Use a new account option in the account preference Quick Pick.](https://code.visualstudio.com/assets/updates/1_95/use-new-account.png)
+![アカウント優先設定クイック ピックの新しいアカウント オプションを使用します。](https://code.visualstudio.com/assets/updates/1_95/use-new-account.png)
 
-### Settings editor indicator for Experimental and Preview settings
+### 設定エディターの実験的およびプレビュー設定のインジケーター {#settings-editor-indicator-for-experimental-and-preview-settings}
 
-Previously, it wasn't always clear which settings were experimental or preview from looking at the Settings editor. To highlight experimental and upcoming features, the Settings editor now displays indicators next to experimental and preview settings. You can type `@tag:experimental` or `@tag:preview` in the Settings editor search box to filter to settings accordingly.
+以前は、設定エディターを見ても、どの設定が実験的またはプレビューであるかが常に明確ではありませんでした。実験的および今後の機能を強調するために、設定エディターは現在、実験的およびプレビュー設定の横にインジケーターを表示します。設定エディターの検索ボックスに `@tag:experimental` または `@tag:preview` と入力して、設定をフィルタリングできます。
 
-Extension authors can add "experimental" or "preview" tags to their settings to show the corresponding indicator in the Settings editor.
+拡張機能の作成者は、設定エディターに対応するインジケーターを表示するために、設定に「experimental」または「preview」タグを追加できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/settings-editor-preview-search.mp4" title="Searching for preview settings in Settings editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/settings-editor-preview-search.mp4" title="設定エディターでプレビュー設定を検索する" autoplay loop controls muted></video>
 
-_Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
+_テーマ: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (プレビュー [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
 
-### More icons for profiles
+### プロファイルのアイコンを追加
 
-In this milestone, we have added more icons for profiles. You can now choose from a wider range of icons to customize your profile.
+このマイルストーンでは、プロファイルのアイコンを追加しました。プロファイルをカスタマイズするために、より多くのアイコンから選択できます。
 
-![Image showing all available profile icons, highlighting the newly added icons.](https://code.visualstudio.com/assets/updates/1_95/profile-icons.png)
+![すべての利用可能なプロファイル アイコンを示す画像で、新しく追加されたアイコンを強調表示しています。](https://code.visualstudio.com/assets/updates/1_95/profile-icons.png)
 
-### View icons in Panel
+### パネルのビュー アイコン
 
-In the workbench Panel area, views are typically displayed as labels in the title bar (for example, _TERMINAL_ or _OUTPUT_). However, on smaller screens, these labels can exceed the available space, causing some views to overflow into a dropdown menu.
+ワークベンチのパネル領域では、ビューは通常、タイトル バーにラベルとして表示されます (たとえば、_TERMINAL_ や _OUTPUT_)。ただし、画面が小さい場合、これらのラベルが使用可能なスペースを超えて表示され、一部のビューがドロップダウン メニューにオーバーフローすることがあります。
 
-To address this, we've added a new setting: `setting(workbench.panel.showLabels:false)`. When disabled, views are displayed as icons instead of labels, conserving horizontal space and reducing overflow.
+これに対処するために、新しい設定を追加しました: `setting(workbench.panel.showLabels:false)`。無効にすると、ビューはラベルの代わりにアイコンとして表示され、水平スペースを節約し、オーバーフローを減らします。
 
 **`workbench.panel.showLabels: true`**
 
-![Panel area showing the labels for each panel.](https://code.visualstudio.com/assets/updates/1_95/panel-showLabels-on.png)
+![各パネルのラベルを表示するパネル領域。](https://code.visualstudio.com/assets/updates/1_95/panel-showLabels-on.png)
 
 **`workbench.panel.showLabels: false`**
 
-![Panel area showing an icon for each panel and no label.](https://code.visualstudio.com/assets/updates/1_95/panel-showLabels-off.png)
+![各パネルのアイコンのみを表示し、ラベルを表示しないパネル領域。](https://code.visualstudio.com/assets/updates/1_95/panel-showLabels-off.png)
 
-## Editor
+## エディター
 
-### Occurrences Highlight Delay
+### 出現のハイライト遅延
 
-This milestone, we have introduced the setting `setting(editor.occurrencesHighlightDelay)` to give you control over the delay before occurrences are highlighted in the editor. Lowering this delay value can lead to an editor experience that feels more responsive when working with semantic highlighting.
+このマイルストーンでは、エディターで出現がハイライトされるまでの遅延を制御するための設定 `setting(editor.occurrencesHighlightDelay)` を導入しました。この遅延値を下げると、セマンティック ハイライトを使用する際にエディターの応答性が向上します。
 
-## VS Code for the Web
+## Web 用 VS Code
 
-### VS Code for the Web supports local file events
+### Web 用 VS Code はローカル ファイル イベントをサポートします
 
-When using Chrome or Edge as of version 129, opening <https://insiders.vscode.dev> with a local folder now supports file events. If you make changes to files and folders of the opened workspace outside the browser, these changes are reflected immediately inside the browser.
+バージョン 129 以降の Chrome または Edge を使用する場合、ローカル フォルダーを使用して <https://insiders.vscode.dev> を開くと、ファイル イベントがサポートされるようになりました。ブラウザー外で開かれたワークスペースのファイルやフォルダーに変更を加えると、これらの変更がブラウザー内ですぐに反映されます。
 
-This feature leverages the new [`FileSystemObserver`](https://chromestatus.com/feature/4622243656630272) interface that is proposed as new API for the web.
+この機能は、新しい API として提案されている [`FileSystemObserver`](https://chromestatus.com/feature/4622243656630272) インターフェイスを活用しています。
 
-## Contributions to extensions
+## 拡張機能への貢献
 
-### Copilot extensions showcase
+### Copilot 拡張機能の紹介 {#copilot-extensions-showcase}
 
-This milestone, the team worked on building several extensions that showcase [Copilot extensibility in VS Code](https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview). These extensions demonstrate the following capabilities:
+このマイルストーンでは、[VS Code での Copilot 拡張機能](https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview)を紹介するいくつかの拡張機能の構築に取り組みました。これらの拡張機能は、次の機能を示しています:
 
-* [Chat Participant & Tool APIs](https://code.visualstudio.com/api/references/vscode-api)
+* [チャット参加者 & ツール API](https://code.visualstudio.com/api/references/vscode-api)
 * [prompt-tsx](https://github.com/microsoft/vscode-prompt-tsx)
-* How to leverage the language models provided by GitHub Copilot
+* GitHub Copilot が提供する言語モデルを活用する方法
 
-Try these extensions and see how you can extend Copilot in your own extensions.
+これらの拡張機能を試して、独自の拡張機能で Copilot をどのように拡張できるかを確認してください。
 
-| Extension |Links |
+| 拡張機能 |リンク |
 |-----------|------|
-| GitHub Pull Requests               | [Marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)  |
-| Web Search for Copilot             | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-websearchforcopilot), [source code](https://github.com/microsoft/vscode-websearchforcopilot)  |
-| MermAId diagram generation with Copilot | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.copilot-mermaid-diagram)  |
-| Data Analysis for Copilot          | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-copilot-data-analysis), [source code](https://github.com/microsoft/vscode-data-analysis-for-copilot)  |
-| VS Code Commander                  | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-commander)  |
-| Vision for Copilot Preview         | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-copilot-vision)  |
+| GitHub プル リクエスト               | [Marketplace](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github)  |
+| Copilot 用 Web 検索             | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-websearchforcopilot), [ソース コード](https://github.com/microsoft/vscode-websearchforcopilot)  |
+| Copilot を使用した MermAId 図の生成 | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.copilot-mermaid-diagram)  |
+| Copilot 用データ分析          | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-copilot-data-analysis), [ソース コード](https://github.com/microsoft/vscode-data-analysis-for-copilot)  |
+| VS Code コマンダー                  | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-commander)  |
+| Copilot プレビューのビジョン         | [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-copilot-vision)  |
 
-#### GitHub Pull Requests
+#### GitHub プル リクエスト
 
-Version [0.100.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01000) of the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension adds Copilot integration:
+[GitHub プル リクエスト](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能のバージョン [0.100.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01000) には、Copilot 統合が追加されました:
 
-* Use the `@githubpr` chat participant in the Chat view to search for issues, summarize issues/prs, and suggest fixes for issues. `@githubpr` uses a number of Language Model tools to accomplish this.
-* There's also a new **Notifications** view that shows GitHub notifications, with an action to prioritize them with Copilot.
+* チャット ビューで `@githubpr` チャット参加者を使用して、問題を検索したり、問題/プルリクエストを要約したり、問題の修正を提案したりできます。`@githubpr` は、これを実現するために多くの言語モデル ツールを使用します。
+* GitHub 通知を表示する新しい **通知** ビューもあり、Copilot を使用して通知を優先順位付けするアクションがあります。
 
-To try everything out, you can set the following settings:
+すべてを試すには、次の設定を行います:
 
 * `setting(githubPullRequests.experimental.chat:true)`
 * `setting(githubPullRequests.experimental.notificationsView:true)`
 
-##### Issue Search with Copilot
+##### Copilot を使用した問題検索
 
-The new `@githubpr` Chat participant can search for issues on GitHub.
+新しい `@githubpr` チャット参加者は、GitHub で問題を検索できます。
 
-![Copilot issue search for most open bugs.](https://code.visualstudio.com/assets/updates/1_95/copilot-issue-search-most-bugs.png)
+![最も多くのバグを含む Copilot の問題検索。](https://code.visualstudio.com/assets/updates/1_95/copilot-issue-search-most-bugs.png)
 
-When displaying issues, `@githubpr` shows a Markdown table and tries to pick the best columns to show, based on the search.
+問題を表示する際、`@githubpr` は Markdown テーブルを表示し、検索に基づいて最適な列を選択しようとします。
 
-![Copilot issue search for closed October issues.](https://code.visualstudio.com/assets/updates/1_95/copilot-issue-search.png)
+![10 月に閉じられた問題の Copilot 問題検索。](https://code.visualstudio.com/assets/updates/1_95/copilot-issue-search.png)
 
-##### Summarizing and Fixing with Copilot
+##### Copilot を使用した要約と修正
 
-Each issue listed in the **Issues** view now has a new action, **Summarize With Copilot**, that opens the Chat panel and summarizes the selected issue. We also added another action, **Fix With Copilot**, that summarizes the selected issue and uses the workspace context to suggest a fix for it.
+**問題** ビューにリストされている各問題には、選択した問題を要約する **Copilot で要約** アクションが新たに追加されました。また、選択した問題を要約し、ワークスペース コンテキストを使用して修正を提案する **Copilot で修正** アクションも追加しました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/fix-summarize-issue.mp4" title="Summarize and Fix GitHub issue" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/fix-summarize-issue.mp4" title="GitHub の問題を要約および修正する" autoplay loop controls muted></video>
 
-##### Notification Prioritization with Copilot (Experimental)
+##### Copilot を使用した通知の優先順位付け (実験的)
 
-This milestone, we added an experimental **Notifications** view that lists your unread notifications across repositories. By default, the notifications are sorted by most recently updated descending, but you can use the **Sort by Priority using Copilot** action from the view title's `...` menu to have Copilot prioritize the notifications. Selecting each notification triggers an action to summarize the notification using Copilot. The view also contains easily accessible actions to mark a notification as read, or to open the notification on GitHub.com.
+このマイルストーンでは、リポジトリ全体の未読通知をリストする実験的な **通知** ビューを追加しました。デフォルトでは、通知は最新の更新順に降順で並べ替えられますが、ビュー タイトルの `...` メニューから **Copilot を使用して優先順位を付ける** アクションを使用して、Copilot に通知の優先順位を付けさせることができます。各通知を選択すると、Copilot を使用して通知を要約するアクションがトリガーされます。このビューには、通知を既読としてマークしたり、GitHub.com で通知を開いたりするための簡単にアクセスできるアクションも含まれています。
 
-![Notifications View](https://code.visualstudio.com/assets/updates/1_95/notifications-view.png)
+![通知ビュー](https://code.visualstudio.com/assets/updates/1_95/notifications-view.png)
 
-#### Web Search for Copilot
+#### Copilot 用 Web 検索
 
-This extension showcases:
+この拡張機能は次の機能を示しています:
 
-* Chat Participant & Tool APIs
+* チャット参加者 & ツール API
 * [prompt-tsx](https://github.com/microsoft/vscode-prompt-tsx)
-* How to leverage the language models provided by GitHub Copilot
+* GitHub Copilot が提供する言語モデルを活用する方法
 
-The source code is [available on GitHub here](https://github.com/microsoft/vscode-websearchforcopilot).
+ソース コードは[GitHub でこちらにあります](https://github.com/microsoft/vscode-websearchforcopilot)。
 
-##### Description
+##### 説明
 
-Get the most up-to-date and relevant information from the web right in Copilot.
+Copilot で Web から最新かつ関連性の高い情報を取得します。
 
-This is powered by one of two different search engines, configured by `setting(websearch.preferredEngine)`:
+これは、`setting(websearch.preferredEngine)` で構成された 2 つの異なる検索エンジンのいずれかによって提供されます:
 
-* [Tavily](http://tavily.com) (default)
+* [Tavily](http://tavily.com) (デフォルト)
 * [Bing](https://bing.com)
 
-As a user, you'll need to acquire an API key from one of these services to use this extension. Upon first use, it asks you for that key and stores it using VS Code's built-in secret storage, and can be managed via VS Code's authentication stack as well just as you would for your GitHub account.
+ユーザーとして、この拡張機能を使用するには、これらのサービスのいずれかから API キーを取得する必要があります。初回使用時にそのキーを要求し、VS Code の組み込みシークレット ストレージを使用して保存し、GitHub アカウントと同様に VS Code の認証スタックを介して管理できます。
 
-##### Chat participant
+##### チャット参加者
 
-This extension contributes the `@websearch` chat participant, which is capable of handling questions that likely need live information from the internet.
-You can invoke it manually using `@websearch when did Workspace Trust ship in vscode?`
+この拡張機能は、インターネットからのライブ情報が必要な質問を処理できる `@websearch` チャット参加者を提供します。
+`@websearch when did Workspace Trust ship in vscode?` を手動で使用して呼び出すことができます。
 
-![The question "when did Workspace Trust ship in vscode" and the answer showing the references and details.](https://code.visualstudio.com/assets/updates/1_95/websearch-participant.png)
+![質問「Workspace Trust は vscode でいつ出荷されましたか」と回答が表示され、参照と詳細が表示されます。](https://code.visualstudio.com/assets/updates/1_95/websearch-participant.png)
 
-##### Chat tool
+##### チャット ツール
 
-This extension contributes the `#websearch` chat language model tool as well, which is similar to the participant but is useful for providing context from the web in other chat participants. For example:
+この拡張機能は、`#websearch` チャット言語モデル ツールも提供します。これは参加者と似ていますが、他のチャット参加者で Web からのコンテキストを提供するのに役立ちます。たとえば:
 
 * `@workspace /new #websearch create a new web app written in Python using the most popular framework`
 
-![The question "create a new web app written in Python using the most popular framework" using the websearch variable with /new. The result is a project using Django.](https://code.visualstudio.com/assets/updates/1_95/websearch-tool.png)
+![最も人気のあるフレームワークを使用して Python で記述された新しい Web アプリを作成するという質問。結果は Django を使用したプロジェクトです。](https://code.visualstudio.com/assets/updates/1_95/websearch-tool.png)
 
-Additionally, if you are working on your own Chat particpant or tool, you can consume this Chat tool via the `vscode.lm.invokeTool` API.
+さらに、独自のチャット参加者またはツールを作成している場合は、`vscode.lm.invokeTool` API を介してこのチャット ツールを使用できます。
 
-#### MermAId diagram generation with Copilot
+#### Copilot を使用した MermAId 図の生成
 
-The vscode-mermAId (`vscode:extension/ms-vscode.copilot-mermaid-diagram`) extension contributes a new chat participant to GitHub Copilot to build and modify visualizations for your code with Mermaid, a Markdown-inspired diagraming and charting tool.
+vscode-mermAId (`vscode:extension/ms-vscode.copilot-mermaid-diagram`) 拡張機能は、GitHub Copilot に新しいチャット参加者を提供し、Mermaid を使用してコードの視覚化を作成および変更します。Mermaid は、Markdown にインスパイアされた図表およびチャート作成ツールです。
 
-##### Create and render diagrams
+##### 図の作成とレンダリング
 
-Create any type of Mermaid-supported diagrams through chat conversations and use the `/iterate` slash command to refine the diagram. Slash commands are available for specific diagrams to provide extra guidance to the model.
+チャット会話を通じて Mermaid がサポートする任意のタイプの図を作成し、`/iterate` スラッシュ コマンドを使用して図を洗練させます。スラッシュ コマンドは、モデルに追加のガイダンスを提供するために特定の図に対して利用できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/iterate-on-sequence-diagram.mp4" title="Create a sequence diagram then iterate to remove a participant" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/iterate-on-sequence-diagram.mp4" title="シーケンス図を作成し、参加者を削除するために反復します" autoplay loop controls muted></video>
 
-Links are added for certain diagram types, like flow, to point back to the references that were gathered to build the diagram.
+フローなどの特定の図の種類には、図を作成するために収集された参照に戻るリンクが追加されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/diagram-with-links-short.mp4" title="Generate a diagram then click a link back to a referenced piece of code" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/diagram-with-links-short.mp4" title="図を生成し、参照されたコードの部分に戻るリンクをクリックします" autoplay loop controls muted></video>
 
-##### Mermaid Visual Outline view
+##### Mermaid ビジュアル アウトライン ビュー
 
-Open the **Visual Outline** view to dynamically generate diagrams from the active editor. You can break out into chat for finer control.
+**ビジュアル アウトライン** ビューを開いて、アクティブなエディターから動的に図を生成します。詳細な制御のためにチャットに分岐できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/mermaid-outline-view-iterate.mp4" title="Uses the mermaid visual outline view to generate a diagram and then iterate on it with chat" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/mermaid-outline-view-iterate.mp4" title="Mermaid ビジュアル アウトライン ビューを使用して図を生成し、チャットで反復します" autoplay loop controls muted></video>
 
-##### Chat tool
+##### チャット ツール
 
-The extension contributes a tool to gather symbol information within files or the entire workspace and that can be consumed by other chat participants when this extension is installed.
+この拡張機能は、ファイルまたはワークスペース全体内のシンボル情報を収集するツールを提供し、この拡張機能がインストールされている場合に他のチャット参加者が使用できます。
 
-#### Data Analysis for Copilot
+#### Copilot 用データ分析
 
-The Data Analysis for Copilot extension empowers people in the data science field. From cleaning up a `.csv` file, to performing higher-level data analysis by leveraging different statistics measures, graphs, and predictive models, the `@data` chat participant helps make more advanced and informed decisions by offering tailored insights and interactivity for data tasks.
+Copilot 用データ分析拡張機能は、データ サイエンス分野の人々に力を与えます。`.csv` ファイルのクリーンアップから、さまざまな統計測定、グラフ、予測モデルを活用した高度なデータ分析まで、`@data` チャット参加者は、データ タスクに対してより高度で情報に基づいた意思決定を行うためのカスタマイズされた洞察とインタラクティビティを提供します。
 
-The extension contributes a tool where the LLM can ask to execute Python code by using [Pyodide](https://pyodide.org/en/stable/) and get the result of the relevant Python code execution. It is also able to smartly retry for better or more appropriate execution results in case of errors. You can also export the code that is used to perform the analysis (or generate visualizations) into a Jupyter Notebook or a Python file.
+この拡張機能は、[Pyodide](https://pyodide.org/en/stable/) を使用して Python コードを実行し、関連する Python コードの実行結果を取得するために LLM が使用できるツールを提供します。エラーが発生した場合に、より適切または適切な実行結果を得るためにスマートに再試行することもできます。分析を実行するために使用されるコード (または視覚化を生成するコード) を Jupyter Notebook または Python ファイルにエクスポートすることもできます。
 
-You can download the extension from [the marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-copilot-data-analysis) and the source is [available on GitHub here](https://github.com/microsoft/vscode-data-analysis-for-copilot).
+拡張機能は[マーケットプレイス](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-copilot-data-analysis)からダウンロードでき、ソースは[GitHub でこちらにあります](https://github.com/microsoft/vscode-data-analysis-for-copilot)。
 
-##### Data analysis and visualizations
+##### データ分析と視覚化
 
-* Given a CSV file, enter a prompt such as `Analyze the file #<file name>` or write a more specific prompt (see below recording)
-* Provide follow-up prompts to request the generation of visualizations, such as charts, plots, and more
+* CSV ファイルが与えられた場合、`Analyze the file #<file name>` などのプロンプトを入力するか、より具体的なプロンプトを入力します (以下の録画を参照)。
+* フォローアップ プロンプトを提供して、チャート、プロットなどの視覚化の生成をリクエストします
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/data-analysis-chat-participant.mp4" title="Analyzing CSV file using data analysis chat participant in Copilot." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/data-analysis-chat-participant.mp4" title="Copilot でデータ分析チャット参加者を使用して CSV ファイルを分析します。" autoplay loop controls muted></video>
 
-##### Exporting the code used to perform the data analysis
+##### データ分析を実行するために使用されるコードのエクスポート
 
-* The Python code used to perform the analysis and generate visualizations can be viewed
-* The Code can be exported in a Jupyter notebook or a Python file
+* 分析を実行し、視覚化を生成するために使用される Python コードを表示できます
+* コードを Jupyter Notebook または Python ファイルにエクスポートできます
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/data-analysis-export-chat-participant.mp4" title="Exporting code used to perform data analysis and generate visualizations." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/data-analysis-export-chat-participant.mp4" title="データ分析を実行し、視覚化を生成するために使用されるコードをエクスポートします。" autoplay loop controls muted></video>
 
-##### Editor and explorer integrations for CSV files
+##### CSV ファイルのエディターおよびエクスプローラー統合
 
-* Right-click on a CSV file to analyze it
-* Open a CSV file and use the Copilot icon to analyze the file
+* CSV ファイルを右クリックして分析します
+* CSV ファイルを開き、Copilot アイコンを使用してファイルを分析します
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/data-analysis-csv-chat-participant.mp4" title="Exporting code used to perform data analysis and generate visualizations." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/data-analysis-csv-chat-participant.mp4" title="データ分析を実行し、視覚化を生成するために使用されるコードをエクスポートします。" autoplay loop controls muted></video>
 
-#### VS Code Commander extension
+#### VS Code コマンダー拡張機能
 
-The VS Code Commander extension (`vscode:extension/ms-vscode.vscode-commander`) acts as your personal assistant within VS Code. This powerful tool enables you to configure your VS Code environment by using conversational, free-form text. With the VS Code Commander, you can:
+VS Code コマンダー拡張機能 (`vscode:extension/ms-vscode.vscode-commander`) は、VS Code 内での個人アシスタントとして機能します。この強力なツールを使用すると、会話形式の自由形式のテキストを使用して VS Code 環境を構成できます。VS Code コマンダーを使用すると、次のことができます:
 
-* Discover and explore various settings and commands
-* Tailor your development environment to your needs
+* さまざまな設定やコマンドを発見して探索します
+* 開発環境をニーズに合わせて調整します
 
-These actions can be performed through a simple and intuitive chat interface, making it easier than ever to manage your VS Code configuration.
+これらのアクションは、シンプルで直感的なチャット インターフェイスを通じて実行できるため、VS Code 構成の管理がこれまで以上に簡単になります。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/vscode-commander-demo.mp4" title="Showing off VS Code Commander capabilities in the copilot chat view" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/vscode-commander-demo.mp4" title="Copilot チャット ビューで VS Code コマンダーの機能を紹介します" autoplay loop controls muted></video>
 
-#### Vision for Copilot Preview extension
+#### Copilot プレビュー拡張機能のビジョン
 
-The Vision for Copilot Preview extension (`vscode:extension/ms-vscode.vscode-copilot-vision`) enables you to attach images directly as contextual input, enriching conversations and enabling more dynamic, visually-supported responses. This extension will be eventually deprecated in favor of built-in image flow in Github Copilot Chat.
+Copilot プレビュー拡張機能のビジョン (`vscode:extension/ms-vscode.vscode-copilot-vision`) を使用すると、画像をコンテキスト入力として直接添付でき、会話が豊かになり、より動的で視覚的にサポートされた応答が可能になります。この拡張機能は、最終的に GitHub Copilot チャットの組み込み画像フローに置き換えられます。
 
-##### Vision in Chat
+##### チャットでのビジョン
 
-For now, you can experience the image attachment flow in the Chat view by using your own OpenAI, Azure OpenAI, Anthropic, or Gemini keys. Get started by easily attaching images from the clipboard or dragging them directly into the chat.
+現在のところ、独自の OpenAI、Azure OpenAI、Anthropic、または Gemini キーを使用して、チャット ビューで画像添付フローを体験できます。クリップボードから画像を簡単に添付するか、チャットに直接ドラッグして開始します。
 
-![Screenshot of a chat exchange. A user asks for HTML and CSS for a landing page. The response provides a basic HTML structure with a header, navigation links (Home, About, Contact), and a link to an external CSS file.](https://code.visualstudio.com/assets/updates/1_95/demo.gif)
+![チャットのやり取りのスクリーンショット。ユーザーがランディング ページの HTML と CSS を要求します。応答には、ヘッダー、ナビゲーション リンク (ホーム、アバウト、コンタクト)、および外部 CSS ファイルへのリンクを含む基本的な HTML 構造が提供されます。](https://code.visualstudio.com/assets/updates/1_95/demo.gif)
 
-_Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire))_
+_テーマ: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (プレビュー [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire))_
 
-##### Vision with Quick Fixes
+##### クイック修正を使用したビジョン
 
-Additionally, you can generate or refine alt text for images in markdown, HTML, JSX, or TSX documents with the provided code actions, simplifying the process of incorporating descriptive text for better context and accessibility. Alt text quick fixes work for images in the workspace and image URLs.
+さらに、提供されたコード アクションを使用して、Markdown、HTML、JSX、または TSX ドキュメント内の画像の代替テキストを生成または洗練することで、説明テキストを簡単に組み込んでコンテキストとアクセシビリティを向上させることができます。代替テキストのクイック修正は、ワークスペース内の画像と画像 URL に対して機能します。
 
-![An example markdown document displays a quick fix feature for generating alt text, resulting in the automatic insertion of an alt tag and a value. The user is then prompted with a different quick fix to refine the alt text using an input box. After the user enters and submits their refined description, the alt text is updated accordingly.](https://code.visualstudio.com/assets/updates/1_95/demo-alt-text.gif)
+![例の Markdown ドキュメントには、代替テキストを生成するためのクイック修正機能が表示され、alt タグと値が自動的に挿入されます。次に、ユーザーは入力ボックスを使用して代替テキストを洗練するための別のクイック修正修正を促されます。ユーザーが洗練された説明を入力して送信すると、代替テキストがそれに応じて更新されます。](https://code.visualstudio.com/assets/updates/1_95/demo-alt-text.gif)
 
-This extension uses the `ChatReferenceBinaryData` proposed API. Feel free to check out an example of how it's used in the source code, [available on GitHub here](https://github.com/microsoft/vscode-copilot-vision).
+この拡張機能は、提案された `ChatReferenceBinaryData` API を使用します。ソース コードの使用例を確認するには、[GitHub でこちらにあります](https://github.com/microsoft/vscode-copilot-vision)。
 
 ### Python
 
-#### Native REPL Variables view
+#### ネイティブ REPL 変数ビュー
 
-The Native Python REPL now provides up-to-date variables for the built-in Variables view. This lets you dig into the state of the interpreter as you execute code from files or through the REPL input box.
+ネイティブ Python REPL は、組み込みの変数ビューの最新の変数を提供します。これにより、ファイルからコードを実行したり、REPL 入力ボックスを通じてコードを実行したりする際に、インタープリターの状態を詳しく調べることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/python-variable-view.mp4" title="Opening the variable view within the debug panel after executing code in the native REPL" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/python-variable-view.mp4" title="ネイティブ REPL でコードを実行した後、デバッグ パネル内の変数ビューを開きます" autoplay loop controls muted></video>
 
-#### Generate docstrings with Pylance
+#### Pylance を使用してドックストリングを生成する {#generate-docstrings-with-pylance}
 
-You can now more conveniently generate documentation for your Python code with [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)'s docstrings template generation feature! You can generate a docstring template for classes or methods by typing `"""` or `'''`, pressing `kbstyle(Ctrl+Space)`, or selecting the lightbulb to invoke the **Generate Docstring** code action. The generated docstring includes fields for the function's description, parameters, parameter types, return and return types.
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) のドックストリング テンプレート生成機能を使用して、Python コードのドキュメントをより便利に生成できるようになりました! `"""` または `'''` を入力し、`kbstyle(Ctrl+Space)` を押すか、電球を選択して **ドックストリングの生成** コード アクションを呼び出すことで、クラスまたはメソッドのドックストリング テンプレートを生成できます。生成されたドックストリングには、関数の説明、パラメーター、パラメーターの種類、戻り値、および戻り値の種類のフィールドが含まれます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/pylance-generate-docstring.mp4" title="Generating docstring templates for a function with Pylance by invoking Ctrl+Space inside a pair of triple quotes." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/pylance-generate-docstring.mp4" title="Pylance を使用して関数のドックストリング テンプレートを生成し、トリプル クォート内で Ctrl+Space を呼び出します。" autoplay loop controls muted></video>
 
-This feature is currently behind an experimental setting, but we look forward to making it the default experience soon. You can try it out today by enabling the `setting(python.analysis.supportDocstringTemplate:true)` setting.
+この機能は現在実験的な設定の背後にありますが、すぐにデフォルトのエクスペリエンスにする予定です。`setting(python.analysis.supportDocstringTemplate:true)` 設定を有効にして、今日から試してみてください。
 
-#### Fold all docstrings
+#### すべてのドックストリングを折りたたむ
 
-Documentation strings are great for providing context and explanations for your code, but sometimes you might want to fold them to focus on the code itself. You can now more easily do so by folding docstrings with the new **Pylance: Fold All Docstrings** command, which can also be bound to a keybinding of your choice. To unfold them, use the **Pylance: Unfold All Docstrings** command.
+ドキュメント ストリングは、コードにコンテキストや説明を提供するのに最適ですが、コード自体に集中するために折りたたみたい場合があります。新しい **Pylance: すべてのドックストリングを折りたたむ** コマンドを使用して、ドックストリングを折りたたむことができるようになりました。このコマンドは、選択したキー バインディングにバインドすることもできます。折りたたみを解除するには、**Pylance: すべてのドックストリングを折りたたみ解除** コマンドを使用します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/pylance-fold-docstrings.mp4" title="Folding and unfolding docstrings with Pylance's new commands." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/pylance-fold-docstrings.mp4" title="Pylance の新しいコマンドを使用してドックストリングを折りたたみおよび折りたたみ解除します。" autoplay loop controls muted></video>
 
-#### Improved import suggestions
+#### インポート提案の改善
 
-One of Pylance's powerful features is its ability to provide auto-import suggestions. By default, Pylance offers the import suggestion from where the symbol is defined, but you might want it to import it from a file where the symbol is imported (i.e. aliased). With the new `setting(python.analysis.includeAliasesFromUserFiles:true)` setting, you can now control whether Pylance includes alias symbols from user files in its auto-import suggestions or in the add import Quick Fix.
+Pylance の強力な機能の 1 つは、自動インポート提案を提供する機能です。デフォルトでは、Pylance はシンボルが定義されている場所からインポート提案を提供しますが、シンボルがインポートされているファイル (つまり、エイリアス) からインポートすることを希望する場合があります。新しい `setting(python.analysis.includeAliasesFromUserFiles:true)` 設定を使用して、Pylance が自動インポート提案やインポートの追加クイック修正でユーザー ファイルからエイリアス シンボルを含めるかどうかを制御できるようになりました。
 
-Note that enabling this setting can negatively impact performance, especially in large codebases, as Pylance may need to index more symbols and monitor more files for changes, which can increase resource usage.
+この設定を有効にすると、特に大規模なコードベースでは、Pylance がより多くのシンボルをインデックス化し、変更のためにより多くのファイルを監視する必要があるため、パフォーマンスに悪影響を与える可能性があることに注意してください。これにより、リソース使用量が増加する可能性があります。
 
-#### Experimental AI Code Action: Implement Abstract Classes
+#### 実験的な AI コード アクション: 抽象クラスの実装
 
-You can now get the best of both worlds with AI and static analysis with the new experimental Code Action to implement abstract classes! This feature requires both [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) and the [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions. To try it out, you can select the **Implement all inherited abstract classes with Copilot** Code Action when defining a class that inherits from an abstract one.
+新しい実験的なコード アクションを使用して、AI と静的解析の両方の利点を享受できます! この機能には、[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) 拡張機能と [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) 拡張機能の両方が必要です。試してみるには、抽象クラスを継承するクラスを定義するときに **Copilot を使用してすべての継承された抽象クラスを実装** コード アクションを選択します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/pylance-ai-code-action.mp4" title="Implementing methods from an inherited abstract class with code action from Pylance and Copilot." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/pylance-ai-code-action.mp4" title="Pylance と Copilot のコード アクションを使用して、継承された抽象クラスからメソッドを実装します。" autoplay loop controls muted></video>
 
-You can disable this feature by setting `"python.analysis.aiCodeActions": {"implementAbstractClasses": false}` in your User settings.
+この機能を無効にするには、ユーザー設定で `"python.analysis.aiCodeActions": {"implementAbstractClasses": false}` を設定します。
 
-## Extension Authoring
+## 拡張機能の作成
 
-### Tools for language models
+### 言語モデルのツール
 
-We have finalized our [`LanguageModelTool` API](https://code.visualstudio.com/api/references/vscode-api#lm.tools)! This API enables chat extensions to build more powerful experiences by connecting language models to external data sources, or take actions. The API comes with two major parts:
+[`LanguageModelTool` API](https://code.visualstudio.com/api/references/vscode-api#lm.tools) を最終化しました! この API を使用すると、チャット拡張機能が言語モデルを外部データ ソースに接続したり、アクションを実行したりすることで、より強力なエクスペリエンスを構築できます。API には 2 つの主要な部分があります:
 
-1. The ability for extensions to register a *tool*. A tool is a piece of functionality that is meant to be used by language models. For example, reading the Git history of a file. When a tool is registered using the `lm.registerTool` method, it's accessible to other extensions as well, in the `lm.tools` list. This will enable chat extensions to seamlessly integrate with other extensions via an ecosystem of shared tools.
+1. 拡張機能が*ツール*を登録する機能。ツールは、言語モデルによって使用されることを目的とした機能の一部です。たとえば、ファイルの Git 履歴を読み取ることができます。ツールは `lm.registerTool` メソッドを使用して登録されると、`lm.tools` リスト内の他の拡張機能でもアクセスできます。これにより、共有ツールのエコシステムを介してチャット拡張機能が他の拡張機能とシームレスに統合できるようになります。
 
-2. The mechanics for language models to support tools, such as extensions passing tools when making a request, language models requesting a tool invocation, and extensions communicating back the result of a tool invocation.
+2. 言語モデルがツールをサポートするためのメカニズム。たとえば、拡張機能がリクエスト時にツールを渡し、言語モデルがツールの呼び出しを要求し、拡張機能がツールの呼び出し結果を拡張機能に通知するメカニズムです。
 
-The use of language model tools is complex, and this API does not hide that complexity. If you want to register a tool or make use of tools in your chat participant, we recommend starting with the [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample).
+言語モデル ツールの使用は複雑であり、この API はその複雑さを隠しません。ツールを登録したり、チャット参加者でツールを使用したりする場合は、[拡張機能サンプル](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample)から始めることをお勧めします。
 
-### Chat participant detection
+### チャット参加者の検出
 
-We have finalized our API for chat participant detection, which allows GitHub Copilot to automatically select your chat participant or participant command to handle a user's question. Please check out [our documentation](/api/extension-guides/chat.md#implement-participant-detection) for a detailed tutorial and recommendations.
+GitHub Copilot がユーザーの質問を処理するためにチャット参加者または参加者コマンドを自動的に選択できるようにするための API を最終化しました。詳細なチュートリアルと推奨事項については、[ドキュメント](https://code.visualstudio.com/api/extension-guides/chat#implement-participant-detection)を確認してください。
 
 ### VS Code Speech
 
-The [VS Code Speech](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-speech) extension is updated to the August version of the [Azure Speech SDK](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/releasenotes?tabs=speech-sdk#speech-sdk-140-2024-august-release) and comes with newer models for speech-to-text recognition. You should see improved results with this update for the [speech-to-text integrations in VS Code](https://code.visualstudio.com/docs/editor/voice), such as Copilot Chat.
+[VS Code Speech](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-speech) 拡張機能は、[Azure Speech SDK](https://learn.microsoft.com/en-us/azure/ai-services/speech-service/releasenotes?tabs=speech-sdk#speech-sdk-140-2024-august-release)の 8 月バージョンに更新され、音声からテキストへの認識のための新しいモデルが提供されます。この更新により、Copilot チャットなどの [VS Code での音声からテキストへの統合](https://code.visualstudio.com/docs/editor/voice)で改善された結果が得られるはずです。
 
-### Comment Thread `collapsibleState`
+### コメント スレッド `collapsibleState`
 
-The expand/collapse state of a `CommentThread` can be changed using the new `CommentThread.collapsibleState` property, even once the thread has already been shown. Previously, this property would only be respected the first time the comment thread was shown.
+`CommentThread` の展開/折りたたみ状態は、新しい `CommentThread.collapsibleState` プロパティを使用して変更できます。以前は、このプロパティはコメント スレッドが最初に表示されたときにのみ尊重されていました。
 
-### Codicons in welcome views
+### ウェルカム ビューでの Codicons
 
-Welcome views now support the ability to render codicons. You can do so using the usual `$(icon-name)` in your welcome view.
+ウェルカム ビューは、codicons をレンダリングする機能をサポートするようになりました。ウェルカム ビューで通常の `$(icon-name)` を使用してこれを行うことができます。
 
-![A sample welcome view showing the use of text, links, buttons, and codicons.](https://code.visualstudio.com/assets/updates/1_95/welcome-view-codicons.png)
+![テキスト、リンク、ボタン、および codicons の使用を示すサンプルのウェルカム ビュー。](https://code.visualstudio.com/assets/updates/1_95/welcome-view-codicons.png)
 
-### Chat participant access to model picker
+### モデル ピッカーへのチャット参加者アクセス
 
-You may have noticed the model picker in the Chat view, which lets you select the model that is used for a chat request.
+チャット ビューにあるモデル ピッカーに気付いたかもしれません。これを使用すると、チャット リクエストに使用されるモデルを選択できます。
 
-![Copilot model picker control in the Chat view enables switching to another language model.](https://code.visualstudio.com/assets/updates/1_94/copilot-model-picker.png)
+![チャット ビューの Copilot モデル ピッカー コントロールを使用すると、別の言語モデルに切り替えることができます。](https://code.visualstudio.com/assets/updates/1_94/copilot-model-picker.png)
 
-Your chat participant extension needs to adopt a new API in order to use this model picker. We just finalized a new `model` property on the `ChatRequest` object, which will be set to the `LanguageModelChat` instance for the model in the picker. You can use this instead of the `lm.selectChatModels` method. If your extension wants to use a particular model besides the selected one, you can still use `lm.selectChatModels` instead.
+このモデル ピッカーを使用するには、チャット参加者拡張機能が新しい API を採用する必要があります。`ChatRequest` オブジェクトに新しい `model` プロパティを追加しました。これは、ピッカー内のモデルの `LanguageModelChat` インスタンスに設定されます。これを `lm.selectChatModels` メソッドの代わりに使用できます。拡張機能が選択されたモデル以外の特定のモデルを使用したい場合は、代わりに `lm.selectChatModels` を使用できます。
 
-## Preview Features
+## プレビュー機能
 
 ### TypeScript 5.7
 
-We've continued improving our support for the upcoming TypeScript 5.7 release. Check out the [TypeScript 5.7 beta blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7-beta/) and the [TypeScript 5.7 plan](https://github.com/microsoft/TypeScript/issues/59905) for details.
+次期 TypeScript 5.7 リリースのサポートを引き続き改善しています。詳細については、[TypeScript 5.7 ベータ ブログ投稿](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7-beta/)および [TypeScript 5.7 プラン](https://github.com/microsoft/TypeScript/issues/59905)を参照してください。
 
-To start using preview builds of TypeScript 5.7, install the [TypeScript Nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next).
+TypeScript 5.7 のプレビュー ビルドを使用するには、[TypeScript Nightly 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next)をインストールします。
 
-### Update imports on paste for JavaScript and TypeScript
+### JavaScript および TypeScript の貼り付け時のインポートの更新
 
-Tired of having to add imports after moving code between files? Try out our experimental support for updating imports on paste! When you copy and paste code between editors, VS Code automatically adds imports when the code is pasted:
+ファイル間でコードを移動した後にインポートを追加する必要があることにうんざりしていませんか? インポートの更新を貼り付け時に試してみてください! エディター間でコードをコピーして貼り付けると、VS Code はコードが貼り付けられたときに自動的にインポートを追加します:
 
-<video src="https://code.visualstudio.com/assets/updates/1_95/jsts-update-imports-paste.mp4" title="Title" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_95/jsts-update-imports-paste.mp4" title="タイトル" autoplay loop controls muted></video>
 
-Notice how it not only added imports, it even added a new export for a local variable that was used in the pasted code!
+インポートが追加されただけでなく、貼り付けられたコードで使用されていたローカル変数の新しいエクスポートも追加されたことに注目してください!
 
-To try this out today, make sure you are using TypeScript 5.7+. Then enable `javascript.experimental.updateImportsOnPaste`/`typescript.experimental.updateImportsOnPaste`. Currently this is only supported when pasting between text editors in the same VS Code window.
+今日からこれを試してみるには、TypeScript 5.7 以降を使用していることを確認してください。次に、`javascript.experimental.updateImportsOnPaste`/`typescript.experimental.updateImportsOnPaste` を有効にします。現在、これは同じ VS Code ウィンドウ内のテキスト エディター間で貼り付ける場合にのみサポートされています。
 
-## Proposed APIs
+## 提案された API
 
-### Chat Reference Binary Data for image attachments
+### 画像添付のためのチャット参照バイナリ データ
 
-We now allow images (`png`, `jpeg`, `bmp`, `gif`, and `tiff`) to be pasted in chat if there is an extension that uses the `ChatReferencebinaryData` proposed API.
+拡張機能が提案された `ChatReferencebinaryData` API を使用している場合、チャットに画像 (`png`、`jpeg`、`bmp`、`gif`、および `tiff`) を貼り付けることができるようになりました。
 
 ```typescript
 export class ChatReferenceBinaryData {
 	/**
-	 * The MIME type of the binary data.
+	 * バイナリ データの MIME タイプ。
 	 */
 	readonly mimeType: string;
 
 	/**
-	 * Retrieves the binary data of the reference.
-	 * @returns A promise that resolves to the binary data as a Uint8Array.
+	 * 参照のバイナリ データを取得します。
+	 * @returns Uint8Array としてのバイナリ データに解決される promise。
 	 */
 	data(): Thenable<Uint8Array>;
 
 	/**
-	 * @param mimeType The MIME type of the binary data.
-	 * @param data The binary data of the reference.
+	 * @param mimeType バイナリ データの MIME タイプ。
+	 * @param data 参照のバイナリ データ。
 	 */
 	constructor(mimeType: string, data: () => Thenable<Uint8Array>);
 }
 ```
 
-Extension authors can access this after creating a chat handler via `request.references`, which can be a `URI` when images are attached via drag and drop or from the quick pick, or will be `ChatReferenceBinaryData` for pasted images.
+拡張機能の作成者は、画像がドラッグ アンド ドロップまたはクイック ピックから添付された場合は `URI`、貼り付けられた画像の場合は `ChatReferenceBinaryData` になる `request.references` を介してチャット ハンドラーを作成した後にこれにアクセスできます。
 
-## Engineering
+## エンジニアリング
 
-### Prompt building library for LLMs
+### LLM 用のプロンプト作成ライブラリ
 
-This month, we open sourced our [@vscode/prompt-tsx](https://www.npmjs.com/package/@vscode/prompt-tsx) library, which we've developed and used in Copilot Chat over the past year for crafting language model prompts. The library enables developers to create their prompts using TSX/JSX syntax, similar to React, and includes a variety of tools to make the best use of prompts' token budget.
+今月、言語モデル プロンプトの作成に過去 1 年間 Copilot チャットで開発および使用してきた [@vscode/prompt-tsx](https://www.npmjs.com/package/@vscode/prompt-tsx) ライブラリをオープンソース化しました。このライブラリを使用すると、React に似た TSX/JSX 構文を使用してプロンプトを作成でき、プロンプトのトークン予算を最大限に活用するためのさまざまなツールが含まれています。
 
-### AMD code removal and more ESM use in web
+### Web での AMD コードの削除と ESM の使用の拡大
 
-We removed the last traces of AMD (Asynchronous Module Definition) from our sources, mainly from the build scripts that we still kept for supporting AMD in case needed for a recovery release.
+ソースから AMD (非同期モジュール定義) の最後の痕跡を削除しました。主に、リカバリ リリースが必要な場合に AMD をサポートするために保持していたビルド スクリプトから削除しました。
 
-In addition, <https://vscode.dev> is now also running 100% with ESM (ECMAScript Modules) only.
+さらに、<https://vscode.dev> も現在 100% ESM (ECMAScript モジュール) のみで実行されています。
 
-### Migration to ESLint 9
+### ESLint 9 への移行
 
-We've updated both the main VS Code repo and all of our [extension samples](https://github.com/microsoft/vscode-extension-samples) to use ESLint 9. This included migrating all of our ESLint configuration to use modern [flat configs](https://eslint.org/blog/2023/10/flat-config-rollout-plans/).
+メインの VS Code リポジトリとすべての[拡張機能サンプル](https://github.com/microsoft/vscode-extension-samples)を ESLint 9 を使用するように更新しました。これには、すべての ESLint 構成を最新の[フラット構成](https://eslint.org/blog/2023/10/flat-config-rollout-plans/)を使用するように移行することが含まれていました。
 
-### Electron 32 update
+### Electron 32 の更新
 
-In this milestone, we are promoting the Electron 32 update to users on our stable release. This update comes with Chromium 128.0.6613.186 and Node.js 20.18.0. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+このマイルストーンでは、安定版リリースのユーザーに Electron 32 の更新を提供しています。この更新には、Chromium 128.0.6613.186 および Node.js 20.18.0 が含まれています。Insiders ビルドでセルフホストして早期フィードバックを提供してくれた皆さんに感謝します。
 
-## Notable fixes
+## 注目の修正
 
-* [177046](https://github.com/microsoft/vscode/issues/177046) will crash after searching at extension panel
+* [177046](https://github.com/microsoft/vscode/issues/177046) 拡張機能パネルで検索した後にクラッシュする
 
-## Thank you
+## ありがとう
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆様に心からの感謝を申し上げます。
 
-### Issue tracking
+### 問題追跡
 
-Contributions to our issue tracking:
+問題追跡への貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 
-### Pull requests
+### プルリクエスト
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@Abrifq (Arda Aydın)](https://github.com/Abrifq): Change `window.experimentalControlOverlay`'s scope to application [PR #230593](https://github.com/microsoft/vscode/pull/230593)
-* [@asemdreibati (Asem Dreibati)](https://github.com/asemdreibati): handle edge case in slice function in Iterable namespace (#230683) [PR #232134](https://github.com/microsoft/vscode/pull/232134)
+* [@Abrifq (Arda Aydın)](https://github.com/Abrifq): `window.experimentalControlOverlay` のスコープをアプリケーションに変更する [PR #230593](https://github.com/microsoft/vscode/pull/230593)
+* [@asemdreibati (Asem Dreibati)](https://github.com/asemdreibati): Iterable 名前空間の slice 関数のエッジケースを処理する (#230683) [PR #232134](https://github.com/microsoft/vscode/pull/232134)
 * [@BABA983 (BABA)](https://github.com/BABA983)
-  * Add developer action to show gpu status [PR #222291](https://github.com/microsoft/vscode/pull/222291)
-  * Fix debug console is cleared on style changed [PR #224694](https://github.com/microsoft/vscode/pull/224694)
-  * Support open in editor in git editor [PR #226967](https://github.com/microsoft/vscode/pull/226967)
-* [@Bistard (SIHAN LI)](https://github.com/Bistard): Fix typo: context view anchor option might be dismissed when using `||` [PR #228896](https://github.com/microsoft/vscode/pull/228896)
-* [@cobey (Cody Beyer)](https://github.com/cobey): added mistral ai npm package [PR #229865](https://github.com/microsoft/vscode/pull/229865)
-* [@elias-pap (Elias Papavasileiou)](https://github.com/elias-pap): fix: improve settings descriptions for actions triggered on save [PR #230052](https://github.com/microsoft/vscode/pull/230052)
-* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Correct Menu Contexts info on extension's Commands page (fix #229258) [PR #229260](https://github.com/microsoft/vscode/pull/229260)
-* [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): style: simplify string formatting for readability [PR #231763](https://github.com/microsoft/vscode/pull/231763)
-* [@injust (Justin Su)](https://github.com/injust): Fix "in none full screen mode" typo [PR #229914](https://github.com/microsoft/vscode/pull/229914)
-* [@jamesharris-garmin (James Harris)](https://github.com/jamesharris-garmin): Fix missing __dirname in --locate-shell-integration-path [PR #231423](https://github.com/microsoft/vscode/pull/231423)
-* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): Fix if logOutputChannel is created again after being disposed, it will disappear [PR #225709](https://github.com/microsoft/vscode/pull/225709)
-* [@Kaidesuyoo (Kaidesuyo)](https://github.com/Kaidesuyoo): Performance optimization [PR #230804](https://github.com/microsoft/vscode/pull/230804)
-* [@kkshinkai (Kk Shinkai)](https://github.com/kkshinkai): Correctly trigger the `onDidAddListener` event in emitter options [PR #230259](https://github.com/microsoft/vscode/pull/230259)
-* [@Parasaran-Python (Parasaran)](https://github.com/Parasaran-Python): 228640: Hiding prelaunch task popup if the setting to hide it is enabled [PR #231225](https://github.com/microsoft/vscode/pull/231225)
-* [@quiple (Minseo Lee)](https://github.com/quiple): Change Korean font priority [PR #230195](https://github.com/microsoft/vscode/pull/230195)
-* [@r3m0t (Tomer Chachamu)](https://github.com/r3m0t): Fix scrolling of Test Results when a new test starts (fixes #229531) [PR #229532](https://github.com/microsoft/vscode/pull/229532)
-* [@sandersn (Nathan Shively-Sanders)](https://github.com/sandersn): TS extension: register call to CopilotRelated with copilot extension [PR #228610](https://github.com/microsoft/vscode/pull/228610)
-* [@ShadowRZ (夜坂雅)](https://github.com/ShadowRZ): fix: Use a proper desktop name in package.json [PR #231472](https://github.com/microsoft/vscode/pull/231472)
-* [@trevor-scheer (Trevor Scheer)](https://github.com/trevor-scheer): Marker message white-space `nowrap` -> `pre` [PR #229454](https://github.com/microsoft/vscode/pull/229454)
-* [@vietanhtwdk](https://github.com/vietanhtwdk): rerender on resize stickyscroll [PR #227400](https://github.com/microsoft/vscode/pull/227400)
-* [@yanglb (Yanblb)](https://github.com/yanglb): add type checking to decorators [PR #230626](https://github.com/microsoft/vscode/pull/230626)
+  * GPU ステータスを表示する開発者アクションを追加する [PR #222291](https://github.com/microsoft/vscode/pull/222291)
+  * スタイル変更時にデバッグ コンソールがクリアされる問題を修正する [PR #224694](https://github.com/microsoft/vscode/pull/224694)
+  * git エディターでエディターを開くことをサポートする [PR #226967](https://github.com/microsoft/vscode/pull/226967)
+* [@Bistard (SIHAN LI)](https://github.com/Bistard): 修正: `||` を使用する場合、コンテキスト ビュー アンカー オプションが解除される可能性があるタイプミス [PR #228896](https://github.com/microsoft/vscode/pull/228896)
+* [@cobey (Cody Beyer)](https://github.com/cobey): mistral ai npm パッケージを追加する [PR #229865](https://github.com/microsoft/vscode/pull/229865)
+* [@elias-pap (Elias Papavasileiou)](https://github.com/elias-pap): 修正: 保存時にトリガーされるアクションの設定説明を改善する [PR #230052](https://github.com/microsoft/vscode/pull/230052)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): 拡張機能のコマンド ページのメニュー コンテキスト情報を修正する (fix #229258) [PR #229260](https://github.com/microsoft/vscode/pull/229260)
+* [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): スタイル: 読みやすさのために文字列フォーマットを簡素化する [PR #231763](https://github.com/microsoft/vscode/pull/231763)
+* [@injust (Justin Su)](https://github.com/injust): 「フルスクリーン モードではない」タイプミスを修正する [PR #229914](https://github.com/microsoft/vscode/pull/229914)
+* [@jamesharris-garmin (James Harris)](https://github.com/jamesharris-garmin): --locate-shell-integration-path で __dirname が欠落している問題を修正する [PR #231423](https://github.com/microsoft/vscode/pull/231423)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): logOutputChannel が破棄された後に再作成されると消える問題を修正する [PR #225709](https://github.com/microsoft/vscode/pull/225709)
+* [@Kaidesuyoo (Kaidesuyo)](https://github.com/Kaidesuyoo): パフォーマンスの最適化 [PR #230804](https://github.com/microsoft/vscode/pull/230804)
+* [@kkshinkai (Kk Shinkai)](https://github.com/kkshinkai): エミッター オプションで `onDidAddListener` イベントを正しくトリガーする [PR #230259](https://github.com/microsoft/vscode/pull/230259)
+* [@Parasaran-Python (Parasaran)](https://github.com/Parasaran-Python): 228640: 非表示にする設定が有効な場合、プレランチ タスク ポップアップを非表示にする [PR #231225](https://github.com/microsoft/vscode/pull/231225)
+* [@quiple (Minseo Lee)](https://github.com/quiple): 韓国語フォントの優先順位を変更する [PR #230195](https://github.com/microsoft/vscode/pull/230195)
+* [@r3m0t (Tomer Chachamu)](https://github.com/r3m0t): 新しいテストが開始されるときのテスト結果のスクロールを修正する (fixes #229531) [PR #229532](https://github.com/microsoft/vscode/pull/229532)
+* [@sandersn (Nathan Shively-Sanders)](https://github.com/sandersn): TS 拡張機能: CopilotRelated を copilot 拡張機能に登録する [PR #228610](https://github.com/microsoft/vscode/pull/228610)
+* [@ShadowRZ (夜坂雅)](https://github.com/ShadowRZ): 修正: package.json で適切なデスクトップ名を使用する [PR #231472](https://github.com/microsoft/vscode/pull/231472)
+* [@trevor-scheer (Trevor Scheer)](https://github.com/trevor-scheer): マーカー メッセージのホワイトスペース `nowrap` -> `pre` [PR #229454](https://github.com/microsoft/vscode/pull/229454)
+* [@vietanhtwdk](https://github.com/vietanhtwdk): スティッキー スクロールのリサイズ時に再レンダリングする [PR #227400](https://github.com/microsoft/vscode/pull/227400)
+* [@yanglb (Yanblb)](https://github.com/yanglb): デコレーターに型チェックを追加する [PR #230626](https://github.com/microsoft/vscode/pull/230626)
 
-Contributions to `vscode-docs`:
+`vscode-docs` への貢献:
 
 * [@Cecil0o0 (hj)](https://github.com/Cecil0o0)
-  * doesn't provide built-in language support in the core editor [PR #7679](https://github.com/microsoft/vscode-docs/pull/7679)
-  * location is restricted in a limited area for debug toolbar as `floating` [PR #7704](https://github.com/microsoft/vscode-docs/pull/7704)
-  * Outdated command title [PR #7705](https://github.com/microsoft/vscode-docs/pull/7705)
-* [@echofly](https://github.com/echofly): Update v1_94.md [PR #7677](https://github.com/microsoft/vscode-docs/pull/7677)
+  * コア エディターで組み込みの言語サポートを提供しない [PR #7679](https://github.com/microsoft/vscode-docs/pull/7679)
+  * `floating` としてデバッグ ツールバーの場所が制限されている [PR #7704](https://github.com/microsoft/vscode-docs/pull/7704)
+  * 古いコマンド タイトル [PR #7705](https://github.com/microsoft/vscode-docs/pull/7705)
+* [@echofly](https://github.com/echofly): v1_94.md を更新する [PR #7677](https://github.com/microsoft/vscode-docs/pull/7677)
 * [@ghosted-sound](https://github.com/ghosted-sound)
-  * Update aksextensions.md [PR #7693](https://github.com/microsoft/vscode-docs/pull/7693)
-  * Update package-management.md [PR #7694](https://github.com/microsoft/vscode-docs/pull/7694)
+  * aksextensions.md を更新する [PR #7693](https://github.com/microsoft/vscode-docs/pull/7693)
+  * package-management.md を更新する [PR #7694](https://github.com/microsoft/vscode-docs/pull/7694)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
-  * Document the `hide` property [PR #7643](https://github.com/microsoft/vscode-docs/pull/7643)
-  * Fix typo [PR #7687](https://github.com/microsoft/vscode-docs/pull/7687)
-* [@oleschri](https://github.com/oleschri): add argument --update-extensions [PR #7681](https://github.com/microsoft/vscode-docs/pull/7681)
-* [@partev](https://github.com/partev): fix URL redirect [PR #7640](https://github.com/microsoft/vscode-docs/pull/7640)
-* [@ptrptrd](https://github.com/ptrptrd): docs: remove double entries in theme color references [PR #7639](https://github.com/microsoft/vscode-docs/pull/7639)
-* [@RonakRahane](https://github.com/RonakRahane): Added documentation for new Code Coverage in C# Fixes #7635 [PR #7664](https://github.com/microsoft/vscode-docs/pull/7664)
+  * `hide` プロパティを文書化する [PR #7643](https://github.com/microsoft/vscode-docs/pull/7643)
+  * タイプミスを修正する [PR #7687](https://github.com/microsoft/vscode-docs/pull/7687)
+* [@oleschri](https://github.com/oleschri): 引数 --update-extensions を追加する [PR #7681](https://github.com/microsoft/vscode-docs/pull/7681)
+* [@partev](https://github.com/partev): URL リダイレクトを修正する [PR #7640](https://github.com/microsoft/vscode-docs/pull/7640)
+* [@ptrptrd](https://github.com/ptrptrd): ドキュメント: テーマ カラー参照の重複エントリを削除する [PR #7639](https://github.com/microsoft/vscode-docs/pull/7639)
+* [@RonakRahane](https://github.com/RonakRahane): C# の新しいコード カバレッジのドキュメントを追加する Fixes #7635 [PR #7664](https://github.com/microsoft/vscode-docs/pull/7664)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@marcusball (Marcus Ball)](https://github.com/marcusball): feat: use `remoteHostHeader` option when looking up websocket address [PR #2111](https://github.com/microsoft/vscode-js-debug/pull/2111)
+* [@marcusball (Marcus Ball)](https://github.com/marcusball): 機能: websocket アドレスを検索する際に `remoteHostHeader` オプションを使用する [PR #2111](https://github.com/microsoft/vscode-js-debug/pull/2111)
 
-Contributions to `vscode-languageserver-node`:
+`vscode-languageserver-node` への貢献:
 
-* [@DanTup (Danny Tuppeny)](https://github.com/DanTup): Add support for CompletionList "applyKind" to control how defaults and per-item commitCharacters/data are combined [PR #1558](https://github.com/microsoft/vscode-languageserver-node/pull/1558)
+* [@DanTup (Danny Tuppeny)](https://github.com/DanTup): デフォルトとアイテムごとの commitCharacters/data がどのように組み合わされるかを制御するために CompletionList "applyKind" をサポートする [PR #1558](https://github.com/microsoft/vscode-languageserver-node/pull/1558)
 
-Contributions to `vscode-mypy`:
+`vscode-mypy` への貢献:
 
-* [@jwhitaker-gridcog (Jarrad)](https://github.com/jwhitaker-gridcog): run mypy in the directory of the nearest pyproject.toml or mypy.ini [PR #316](https://github.com/microsoft/vscode-mypy/pull/316)
+* [@jwhitaker-gridcog (Jarrad)](https://github.com/jwhitaker-gridcog): 最寄りの pyproject.toml または mypy.ini のディレクトリで mypy を実行する [PR #316](https://github.com/microsoft/vscode-mypy/pull/316)
 
-Contributions to `vscode-vsce`:
+`vscode-vsce` への貢献:
 
-* [@andrewlayer](https://github.com/andrewlayer): Added unpublish to api.ts [PR #1061](https://github.com/microsoft/vscode-vsce/pull/1061)
-* [@deribaucourt (Enguerrand de Ribaucourt)](https://github.com/deribaucourt): Fix regression with workdir symlinks [PR #1053](https://github.com/microsoft/vscode-vsce/pull/1053)
-* [@dtivel (Damon Tivel)](https://github.com/dtivel): Quote `filename` value in `Content-Disposition` header [PR #1060](https://github.com/microsoft/vscode-vsce/pull/1060)
+* [@andrewlayer](https://github.com/andrewlayer): api.ts に unpublish を追加する [PR #1061](https://github.com/microsoft/vscode-vsce/pull/1061)
+* [@deribaucourt (Enguerrand de Ribaucourt)](https://github.com/deribaucourt): 作業ディレクトリのシンボリック リンクに関する回帰を修正する [PR #1053](https://github.com/microsoft/vscode-vsce/pull/1053)
+* [@dtivel (Damon Tivel)](https://github.com/dtivel): `Content-Disposition` ヘッダーの `filename` 値を引用する [PR #1060](https://github.com/microsoft/vscode-vsce/pull/1060)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
 * [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721)
-  * add systemd [PR #2034](https://github.com/microsoft/language-server-protocol/pull/2034)
-  * add 3 lsp [PR #2046](https://github.com/microsoft/language-server-protocol/pull/2046)
-* [@DanTup (Danny Tuppeny)](https://github.com/DanTup): Add support for `completionList.applyKind` to determine how values from `completionList.itemDefaults` and `completion` are combined. [PR #2018](https://github.com/microsoft/language-server-protocol/pull/2018)
-* [@DavyLandman (Davy Landman)](https://github.com/DavyLandman): Added Rascal to relevant LSP implementor sections [PR #2029](https://github.com/microsoft/language-server-protocol/pull/2029)
-* [@g-plane (Pig Fang)](https://github.com/g-plane): fix punctuation typo [PR #2048](https://github.com/microsoft/language-server-protocol/pull/2048)
-* [@nthykier (Niels Thykier)](https://github.com/nthykier): Add the `debputy` language server [PR #2044](https://github.com/microsoft/language-server-protocol/pull/2044)
-* [@RainCmd (渴望蓝天)](https://github.com/RainCmd): Add Rain language server to  LSP [PR #2039](https://github.com/microsoft/language-server-protocol/pull/2039)
-* [@WilsonZiweiWang (ziweiwang)](https://github.com/WilsonZiweiWang): Add BitBake language server [PR #2049](https://github.com/microsoft/language-server-protocol/pull/2049)
-* [@yasmewad (Yash Mewada)](https://github.com/yasmewad): Add Smithy language server links to LSP [PR #2036](https://github.com/microsoft/language-server-protocol/pull/2036)
+  * systemd を追加する [PR #2034](https://github.com/microsoft/language-server-protocol/pull/2034)
+  * 3 つの lsp を追加する [PR #2046](https://github.com/microsoft/language-server-protocol/pull/2046)
+* [@DanTup (Danny Tuppeny)](https://github.com/DanTup): `completionList.itemDefaults` と `completion` からの値がどのように組み合わされるかを決定するために `completionList.applyKind` をサポートする。 [PR #2018](https://github.com/microsoft/language-server-protocol/pull/2018)
+* [@DavyLandman (Davy Landman)](https://github.com/DavyLandman): Rascal を関連する LSP 実装者セクションに追加する [PR #2029](https://github.com/microsoft/language-server-protocol/pull/2029)
+* [@g-plane (Pig Fang)](https://github.com/g-plane): 句読点のタイプミスを修正する [PR #2048](https://github.com/microsoft/language-server-protocol/pull/2048)
+* [@nthykier (Niels Thykier)](https://github.com/nthykier): `debputy` 言語サーバーを追加する [PR #2044](https://github.com/microsoft/language-server-protocol/pull/2044)
+* [@RainCmd (渴望蓝天)](https://github.com/RainCmd): Rain 言語サーバーを LSP に追加する [PR #2039](https://github.com/microsoft/language-server-protocol/pull/2039)
+* [@WilsonZiweiWang (ziweiwang)](https://github.com/WilsonZiweiWang): BitBake 言語サーバーを追加する [PR #2049](https://github.com/microsoft/language-server-protocol/pull/2049)
+* [@yasmewad (Yash Mewada)](https://github.com/yasmewad): Smithy 言語サーバーのリンクを LSP に追加する [PR #2036](https://github.com/microsoft/language-server-protocol/pull/2036)
 
-Contributions to `lsprotocol`:
+`lsprotocol` への貢献:
 
-* [@nobodywasishere (Margret Riegert)](https://github.com/nobodywasishere): Add Crystal plugin to README [PR #403](https://github.com/microsoft/lsprotocol/pull/403)
+* [@nobodywasishere (Margret Riegert)](https://github.com/nobodywasishere): README に Crystal プラグインを追加する [PR #403](https://github.com/microsoft/lsprotocol/pull/403)
 
-Contributions to `tolerant-php-parser`:
+`tolerant-php-parser` への貢献:
 
-* [@TysonAndre (Tyson Andre)](https://github.com/TysonAndre): Fix php 8.4 notices about implicitly nullable parameters [PR #410](https://github.com/microsoft/tolerant-php-parser/pull/410)
+* [@TysonAndre (Tyson Andre)](https://github.com/TysonAndre): 暗黙的に null 許容のパラメーターに関する php 8.4 の通知を修正する [PR #410](https://github.com/microsoft/tolerant-php-parser/pull/410)
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>


### PR DESCRIPTION
Translate the two release notes for September (v1_94) and October (v1_95) 2024.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MtkN1/vscode-docs-ja?shareId=f8867696-0a19-427e-8894-b713d2a73102).