### PR TITLE
Translate November 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,25 +3,42 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 permissions:
   contents: write
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: astral-sh/setup-uv@v3
+      - uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
       - run: apt-get install pngquant
-      - name: mkdocs gh-deploy
+      - name: mkdocs build
         run: |
           gh auth setup-git
-          uv run --with "git+$MKDOCS_MATERIAL_INSIDERS_GIT_URL" mkdocs gh-deploy --force
+          uv run --with "git+$MKDOCS_MATERIAL_INSIDERS_GIT_URL" mkdocs build --strict
         env:
           GH_TOKEN: ${{ secrets.MKDOCS_MATERIAL_INSIDERS_TOKEN }}
           MKDOCS_MATERIAL_INSIDERS_GIT_URL: ${{ vars.MKDOCS_MATERIAL_INSIDERS_GIT_URL }}
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    permissions:
+      id-token: write
+      pages: write
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@v5
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/release-notes/v1_96.md
+++ b/docs/release-notes/v1_96.md
@@ -38,13 +38,13 @@ Last milestone, we introduced [Copilot Edits](https://code.visualstudio.com/docs
 
 Copilot Edits can make multiple changes across different files. You can now more clearly see its progress as edits stream in. And with the editor overlay controls, you can easily cycle through all changes and accept or discard them.
 
-<video src="images/1_96/chat-edits.mp4" title="Copilot Edits changing a file" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/chat-edits.mp4" title="Copilot Edits changing a file" autoplay loop controls muted></video>
 
 #### Move chat session to Copilot Edits
 
 You might use the Chat view to explore some ideas for making changes to your code. Instead of applying individual code blocks, you can now move the chat session to Copilot Edits to apply all code suggestions from the session.
 
-![Edit with Copilot showing for a chat exchange.](images/1_96/chat-move.png)
+![Edit with Copilot showing for a chat exchange.](https://code.visualstudio.com/assets/updates/1_96/chat-move.png)
 
 #### Working set suggested files
 
@@ -52,7 +52,7 @@ In Copilot Edits, the working set determines the files that Copilot Edits can su
 
 Copilot shows suggested files alongside the **Add Files** button in the working set. You can also select **Add Files** and then select **Related Files** to choose from a list of suggested files.
 
-<video src="images/1_96/working-set-suggested-files.mp4" title="Add suggested files to Copilot Edits working set." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/working-set-suggested-files.mp4" title="Add suggested files to Copilot Edits working set." autoplay loop controls muted></video>
 
 #### Restore Edit sessions after restart
 
@@ -62,17 +62,17 @@ Edit sessions are now fully restored after restarting VS Code. This includes the
 
 You can add files to your Copilot Edits working set with the new **Add File to Copilot Edits** context menu action for search results in the Search view and for files in the Explorer view. Additionally, you can also attach a text selection to Copilot Edits from the editor context menu.
 
-![Add a file from the explorer view to Copilot Edits](images/1_96/add-file-to-edits.png)
+![Add a file from the explorer view to Copilot Edits](https://code.visualstudio.com/assets/updates/1_96/add-file-to-edits.png)
 
 ### Debugging with Copilot
 
 Configuring debugging can be tricky, especially when you're working with a new project or language. This milestone, we're introducing a new `copilot-debug` terminal command to help you debug your programs using VS Code. You can use it by prefixing the command that you would normally run with `copilot-debug`. For example, if you normally run your program using the command `python foo.py`, you can now run `copilot-debug python foo.py` to start a debugging session.
 
-<video src="images/1_96/copilot-debug.mp4" title="Use the copilot-debug command to debug a Go program." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/copilot-debug.mp4" title="Use the copilot-debug command to debug a Go program." autoplay loop controls muted></video>
 
 After your program exits, you are given options to rerun your program or to view, save, or regenerate the VS Code [launch configuration](https://code.visualstudio.com/docs/editor//debugging#launch-configurations) that was used to debug your program.
 
-![The terminal shows options to rerun, regenerate, save, or the launch config after a debugging session.](./images/1_96/copilot-debug.png)
+![The terminal shows options to rerun, regenerate, save, or the launch config after a debugging session.](https://code.visualstudio.com/assets/updates/1_96/copilot-debug.png)
 _Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
 
 #### Tasks Support
@@ -87,31 +87,31 @@ We’ve added new ways to include symbols and folders as context in Copilot Chat
 
 Symbols can now easily be added to Copilot Chat and Copilot Edits by dragging and dropping them from the Outline View or Breadcrumbs into the Chat view.
 
-<video src="images/1_96/context_symbols_dnd.mp4" title="Dragging and dropping symbols from the outline view and editor breadcrumbs into copilot chat" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_dnd.mp4" title="Dragging and dropping symbols from the outline view and editor breadcrumbs into copilot chat" autoplay loop controls muted></video>
 
 We’ve also introduced symbol completion in the chat input. By typing `#` followed by the symbol name, you’ll see suggestions for symbols from files you've recently worked on.
 
-<video src="images/1_96/context_symbols_completion.mp4" title="After typing # completions show for files and symbols and further typing enables to filter down the completion items" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_completion.mp4" title="After typing # completions show for files and symbols and further typing enables to filter down the completion items" autoplay loop controls muted></video>
 
 To reference symbols across your entire project, you can use `#sym` to open a global symbols picker.
 
-<video src="images/1_96/context_symbols_sym.mp4" title="Writing #sym allows to see the completion item #sym to open a global symbol picker" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_sym.mp4" title="Writing #sym allows to see the completion item #sym to open a global symbol picker" autoplay loop controls muted></video>
 
 #### Folders
 
 Folders can now be added as context by dragging them from the Explorer, Breadcrumbs, or other views into Copilot Chat.
 
-<video src="images/1_96/context_folder_chat.mp4" title="Dragging and dropping the @types folder into copilot chat and asking how to implement a share provider" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_folder_chat.mp4" title="Dragging and dropping the @types folder into copilot chat and asking how to implement a share provider" autoplay loop controls muted></video>
 
 When a folder is dragged into Copilot Edits, all files within the folder are included in the working set.
 
-<video src="images/1_96/context_folder_edits.mp4" title="Dragging and dropping a folder into copilot edits adds all files in the folder to copilot edits" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_folder_edits.mp4" title="Dragging and dropping a folder into copilot edits adds all files in the folder to copilot edits" autoplay loop controls muted></video>
 
 ### Copilot usage graph
 
 VS Code extensions can use the VS Code API to [build on the capabilities of Copilot](https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview). You can now see a graph of an extension's Copilot usage in the Runtime Status view. This graph shows the number of chat requests that were made by the extension over the last 30 days.
 
-![Copilot usage graph in the Runtime Status view](images/1_96/copilot-usage-chart.png)
+![Copilot usage graph in the Runtime Status view](https://code.visualstudio.com/assets/updates/1_96/copilot-usage-chart.png)
 
 ### Custom instructions for commit message generation
 
@@ -125,7 +125,7 @@ This milestone, we have further improved the user experience of Inline Chat: we 
 
 Also, we have continued to improve our pseudo-code detection and now show a hint that you can continue with Inline Chat when a line is mostly natural language. This functionality lets you type pseudo code in the editor, which is then used as a prompt for Inline Chat. You can also trigger this flow by pressing `kb(inlineChat.startWithCurrentLine)`.
 
-![Inline Chat hint for a line that is dominated by natural language.](images/1_96/inline-chat-nl-hint.png)
+![Inline Chat hint for a line that is dominated by natural language.](https://code.visualstudio.com/assets/updates/1_96/inline-chat-nl-hint.png)
 
 Additionally, there is a new, experimental, setting to make an Inline Chat hint appear on empty lines. This setting can be enabled via `setting(inlineChat.lineEmptyHint)`. By default, this setting is disabled.
 
@@ -133,7 +133,7 @@ Additionally, there is a new, experimental, setting to make an Inline Chat hint 
 
 Terminal Inline Chat has a fresh coat of paint that brings the look and feel much closer to editor Inline Chat:
 
-![Terminal inline chat looks a lot like editor chat now](images/1_96/copilot-terminal-chat.png)
+![Terminal inline chat looks a lot like editor chat now](https://code.visualstudio.com/assets/updates/1_96/copilot-terminal-chat.png)
 
 Here are some other improvements of note that were made:
 
@@ -165,19 +165,19 @@ We introduced a new setting to improve accessibility when working in the REPL. W
 
 When you search for extensions using free-form text in the Extensions view, installed extensions now appear at the top of the search results. This makes it easier to find and manage your installed extensions when searching through the Marketplace.
 
-![Installed extensions shown at top of search results.](images/1_96/extension-search-order.png)
+![Installed extensions shown at top of search results.](https://code.visualstudio.com/assets/updates/1_96/extension-search-order.png)
 
 ### Download extensions from the Extensions view
 
 You can now download extensions directly from VS Code by using the download action in the context menu of an extension in the Extensions view. This can be useful if you want to download an extension without installing it.
 
-![Context menu option to download an extension from the Extensions view.](images/1_96/extensions-download.png)
+![Context menu option to download an extension from the Extensions view.](https://code.visualstudio.com/assets/updates/1_96/extensions-download.png)
 
 ### Extension disk space
 
 You can now see the memory usage of an extension on disk in the Extensions editor. This can help you understand how much disk space an extension is using.
 
-![Extension memory usage on disk shown in the Extensions view.](images/1_96/extension-memory-usage-on-disk.png)
+![Extension memory usage on disk shown in the Extensions view.](https://code.visualstudio.com/assets/updates/1_96/extension-memory-usage-on-disk.png)
 
 ### Find in Explorer improvements
 
@@ -185,21 +185,21 @@ In the September release, we introduced the ability to find files in the Explore
 
 In this release, we’re bringing back highlight mode. This feature allows you to easily locate files and folders across your workspace, with matching results highlighted for better visibility. Additionally, we’ve introduced a new visual indicator on collapsed folders, showing if matches are hidden within them.
 
-<video src="images/1_96/explorer_find_highlight.mp4" title="Find in the Explorer highlights all matching results and adds a badge to folders indicating the number of matches inside." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/explorer_find_highlight.mp4" title="Find in the Explorer highlights all matching results and adds a badge to folders indicating the number of matches inside." autoplay loop controls muted></video>
 
 The filter toggle remains available, enabling you to focus only on files and folders that match your query by hiding non-matching items. We also reenabled all context menu actions we had to disable in a previous release.
 
-<video src="images/1_96/explorer_find_filter.mp4" title="Find in the Explorer with filter mode enabled shows only the files and folders that match the search term." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/explorer_find_filter.mp4" title="Find in the Explorer with filter mode enabled shows only the files and folders that match the search term." autoplay loop controls muted></video>
 
 We’ve also improved the user experience when using the find control. When scrolled to the top of the file explorer, additional space is created at the top, ensuring the control doesn’t obstruct your search results.
 
-![The find control is rendered above the first file or folder in the explorer when scrolled to the top.](images/1_96/explorer_find_empty_space.png)
+![The find control is rendered above the first file or folder in the explorer when scrolled to the top.](https://code.visualstudio.com/assets/updates/1_96/explorer_find_empty_space.png)
 
 ### Move views between Primary and Secondary Side Bar
 
 You could already [move a view container](https://code.visualstudio.com/docs/editor/custom-layout#_drag-and-drop-views-and-panels) to another location by using drag and drop or by using the **Move View** command. You can now directly use the Move To context menu action on a view container to move it between the Primary Side Bar, Secondary Side Bar, or Panel area.
 
-<video src="images/1_96/move-views.mp4" title="Move view containers" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/move-views.mp4" title="Move view containers" autoplay loop controls muted></video>
 
 ### Hide navigation controls in the title area
 
@@ -207,7 +207,7 @@ Some people prefer to keep the title area as clean as possible. We added a new s
 
 You can also access this setting by right-clicking in the title area, and selecting **Navigation Controls**.
 
-![Navigation Controls context menu when right-clicking the VS Code title area.](images/1_96/nav-controls.png)
+![Navigation Controls context menu when right-clicking the VS Code title area.](https://code.visualstudio.com/assets/updates/1_96/nav-controls.png)
 
 ## Editor
 
@@ -253,7 +253,7 @@ Finally, you can now also specify a preferred paste style when setting up a `edi
 
 The Find control now can persist the search history across sessions and restores it across VS Code restarts. The search history is stored per workspace and can be disabled via the `setting(editor.find.history)` setting.
 
-<video src="images/1_96/editor-find-history.mp4" title="Demo of the persistence of editor find history" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/editor-find-history.mp4" title="Demo of the persistence of editor find history" autoplay loop controls muted></video>
 
 ### Overtype mode
 
@@ -261,7 +261,7 @@ On popular request, we added overtype mode to overwrite text in the editor inste
 
 This mode can be toggled with the command **View: Toggle Overtype/Insert Mode**. When you're in overtype mode, the Status Bar shows an `OVR` indicator. In addition, there is a setting `setting(editor.overtypeOnPaste)`, which determines whether pasting in overtype mode should overwrite or insert. The default behavior is to insert pasted text.
 
-<video src="images/1_96/overtype.mp4" title="Overtype mode" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/overtype.mp4" title="Overtype mode" autoplay loop controls muted></video>
 
 It is possible to change the cursor style while in overtype mode by using the setting `setting(editor.overtypeCursorStyle)`.
 
@@ -271,7 +271,7 @@ It is possible to change the cursor style while in overtype mode by using the se
 
 This milestone, we have added experimental support for displaying blame information using editor decorations and a Status Bar item. You can enable this functionality by using the `setting(git.blame.editorDecoration.enabled:true)` and `setting(git.blame.statusBarItem.enabled:true)` settings. You can hover over the blame information to see more commit details.
 
-<video src="images/1_96/git-blame.mp4" title="Show git blame information in editor and Status Bar." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/git-blame.mp4" title="Show git blame information in editor and Status Bar." autoplay loop controls muted></video>
 
 You can customize the format of the message that is shown in the editor and in the Status Bar with the `setting(git.blame.editorDecoration.template)` and `setting(git.blame.statusBarItem.template)` settings. You can use variables for the most common information. For example, the following template shows the subject of the commit, the author's name, and the author's date relative to now:
 
@@ -291,7 +291,7 @@ Based on user feedback, we have brought back the Pull, and Push actions to the S
 
 If you do not want to use these actions, or any other actions from the Source Control Graph view title bar, you can right-click on the title bar and hide them.
 
-![Source Control Graph title actions and context menu to hide specific items.](images/1_96/source-control-graph-title-actions.png)
+![Source Control Graph title actions and context menu to hide specific items.](https://code.visualstudio.com/assets/updates/1_96/source-control-graph-title-actions.png)
 
 ## Notebooks
 
@@ -299,25 +299,25 @@ If you do not want to use these actions, or any other actions from the Source Co
 
 Selection highlighting is now supported within notebooks, allowing for textual selection based highlights across multiple cells. This is controlled with the preexisting setting `setting(editor.selectionHighlight)`.
 
-<video src="images/1_96/notebook-selection-highlight.mp4" title="Notebook selection highlighting demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-selection-highlight.mp4" title="Notebook selection highlighting demo" autoplay loop controls muted></video>
 
 ### Multi Cursor: Select All Occurrences of Find Match
 
 Notebooks now support the keyboard shortcut for **Select All Occurrences of Find Match**. This can be found with the command id `notebook.selectAllFindMatches` and can be used by default with the keystroke `kb(notebook.selectAllFindMatches)`.
 
-<video src="images/1_96/notebook-select-all-occurrences.mp4" title="Notebook select all occurrences multicursor demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-select-all-occurrences.mp4" title="Notebook select all occurrences multicursor demo" autoplay loop controls muted></video>
 
 ### Run Cells in Section for Markdown
 
 Notebooks now have the **Run Cells in Section** action exposed to the cell toolbar of Markdown cells. If the Markdown cell has a header, all cells contained within the section and children sections are executed. If there is no header, this executes all cells in the surrounding section, if possible.
 
-<video src="images/1_96/notebook-md-toolbar-run-in-section.mp4" title="Notebook run in section from markdown cell toolbar demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-md-toolbar-run-in-section.mp4" title="Notebook run in section from markdown cell toolbar demo" autoplay loop controls muted></video>
 
 ### Cell execution time verbosity
 
 The execution time information within the cell status bar now has an option for increased verbosity. This can be turned on with the setting `setting(notebook.cellExecutionTimeVerbosity)` and is able to display the execution timestamp in addition to the duration.
 
-![Verbose cell execution time within cell status bar.](images/1_96/notebook-verbose-execution-time.png)
+![Verbose cell execution time within cell status bar.](https://code.visualstudio.com/assets/updates/1_96/notebook-verbose-execution-time.png)
 
 ## Terminal
 
@@ -325,7 +325,7 @@ The execution time information within the cell status bar now has an option for 
 
 Ligatures are now supported in the terminal, regardless of whether [GPU acceleration](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration) is being used. This feature can be turned on with the setting `setting(terminal.integrated.fontLigatures)`:
 
-![Fonts that support ligatures like ->, ==>, and so on will now visually look like single characters](images/1_96/terminal-ligatures.png)
+![Fonts that support ligatures like ->, ==>, and so on will now visually look like single characters](https://code.visualstudio.com/assets/updates/1_96/terminal-ligatures.png)
 
 In order to use this feature, make sure you also use a font that supports ligatures `setting(terminal.integrated.fontFamily)`.
 
@@ -336,16 +336,16 @@ What text appears in terminal tabs is determines by the `terminal.integrated.tab
 - `${shellType}` - The detected type of shell that is being used in the terminal. This is similar the default value, but it will not change to `git` for example when running a git command.
 - `${shellCommand}` - The command that is being run in the terminal. This requires [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration).
 
-  ![alt text](images/1_96/terminal_shellCommand.png)
+  ![alt text](https://code.visualstudio.com/assets/updates/1_96/terminal_shellCommand.png)
 - `${shellPromptInput}` - The command that is being run in the terminal or the current detected prompt input. This requires [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration).
 
-  ![Typing "echo hello" in the terminal will show "echo hello|" in the tab when configured](images/1_96/terminal_shellPromptInput.png)
+  ![Typing "echo hello" in the terminal will show "echo hello|" in the tab when configured](https://code.visualstudio.com/assets/updates/1_96/terminal_shellPromptInput.png)
 
 ### Run recent command now shows the history source file
 
 The [run recent command](https://code.visualstudio.com/docs/terminal/shell-integration#_run-recent-command) shell integration feature now includes full size headers for the source of the command, including the history file where relevant and a convenient button to open it.
 
-![alt text](images/1_96/terminal-run-recent-command.png)
+![alt text](https://code.visualstudio.com/assets/updates/1_96/terminal-run-recent-command.png)
 
 The default keybinding for this command is `Ctrl+Alt+R`.
 
@@ -359,7 +359,7 @@ Links with the format `/path/to/file.ext, <line>` should now be detected as link
 
 This milestone, we finalized an API that enables extensions to provide coverage on a per-test basis, so you can see exactly what code any given test executed. When attributable coverage is available, a filter button is available in the Test Coverage view, in editor actions, in the Test Coverage toolbar when toggled on (via the **Test: Test Coverage Toolbar** command), or simply by using the **Test: Filter Coverage by Test** command.
 
-<video src="images/1_96/per-test-coverage.mp4" title="Demo of the per-test coverage feature." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/per-test-coverage.mp4" title="Demo of the per-test coverage feature." autoplay loop controls muted></video>
 
 _Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
 
@@ -367,7 +367,7 @@ _Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor431
 
 We reworked test failure messages to be both more eye-catching and less obtrusive. This is particularly useful for busy scenarios, such as in diffs from SCM or Copilot Edits. Selecting the failure message still opens a peek control to show the complete details of the failure.
 
-![Image of new test error messages in the editor.](./images/1_96/test-errors.png)
+![Image of new test error messages in the editor.](https://code.visualstudio.com/assets/updates/1_96/test-errors.png)
 
 ### Improvements to the continuous run UI
 
@@ -387,13 +387,13 @@ You can read all about the TypeScript 5.7 release on the [TypeScript blog](https
 
 Tired of having to add imports after moving code between files? Try the Paste with imports feature for TypeScript 5.7+. Now whenever you copy and paste code between JavaScript or TypeScript, VS Code can add imports for the pasted code.
 
-<video src="images/1_96/jsts-update-imports-paste.mp4" title="Imports are automatically updated when pasting code between files in JS and TS." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/jsts-update-imports-paste.mp4" title="Imports are automatically updated when pasting code between files in JS and TS." autoplay loop controls muted></video>
 
 Notice how not only imports are added, even a new export was added for a local variable that was used in the pasted code!
 
 While we think this feature is a huge time saver, we also are sensitive to disrupting your existing workflow. That's why, by default, we've kept it so copy and paste always inserts just the pasted text. If a `paste with imports` edit is available, you then see the paste control, which lets you select the `paste with imports` edit.
 
-![Paste control that shows options to insert plain text or paste with imports.](images/1_96/jsts-paste-widget.png)
+![Paste control that shows options to insert plain text or paste with imports.](https://code.visualstudio.com/assets/updates/1_96/jsts-paste-widget.png)
 
 If you prefer always pasting with imports, you can use the new [`editor.pasteAs.preferences` setting](#configure-paste-and-drop-behavior):
 
@@ -580,7 +580,7 @@ The `python.analysis.languageServerMode` setting now changes the default values 
 
 This milestone, we made it possible to view expanded/contracted information from the TS server. The extension uses the Expandable Hover API to show `+` and `-` markers in the editor hover to display more or less information.
 
-<video src="images/1_96/expandable-hover.mp4" title="TypeScript Expandable Hover" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/expandable-hover.mp4" title="TypeScript Expandable Hover" autoplay loop controls muted></video>
 
 The experimental setting can be enabled using `setting(typescript.experimental.expandableHover)`. For this setting to work, you must be on TypeScript version 5.8 or above. You can change the TypeScript version by using the `TypeScript: Select TypeScript Version...` command.
 
@@ -590,7 +590,7 @@ In order to ensure a strong security baseline for Microsoft authentication, we'v
 
 One of the stand out features of this work is WAM (Web Account Manager... also known as [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) integration. Put simply, rather than going to the browser for Microsoft authentication flows, we now talk to the OS directly, which is the recommended way of acquiring a Microsoft authentication session. Additionally, it's faster since we're able to leverage the accounts that you're already logged into on the OS.
 
-![An authentication popup that the OS shows over VS Code.](images/1_96/showingBrokerOSDialog.png)
+![An authentication popup that the OS shows over VS Code.](https://code.visualstudio.com/assets/updates/1_96/showingBrokerOSDialog.png)
 
 Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
 
@@ -632,7 +632,7 @@ To try this out, copy some code and paste it in Inline Chat, Quick Chat, or the 
 ]
 ```
 
-![Attaching code as context in Copilot Chat using the paste control.](images/1_96/paste-code-context.gif)
+![Attaching code as context in Copilot Chat using the paste control.](https://code.visualstudio.com/assets/updates/1_96/paste-code-context.gif)
 
 ### Terminal completions for more shells
 
@@ -641,7 +641,7 @@ We added experimental support for terminal completions in `pwsh` in prior iterat
 You can try out the current work in progress by setting `setting(terminal.integrated.suggest.enabled)` and
 `setting(terminal.integrated.suggest.enableExtensionCompletions)`. Currently only `cd`, `code`, and `code-insiders` arguments are supported.
 
-![The command `code` is typed on the terminal, which shows suggestions. Then `--` is typed and options are provided, `--locale` is selected. Completions are requested with ctrl+space and all locales are shown. `e` is typed and the list is filtered to `en` and `es`.](images/1_96/terminal-completions.gif)
+![The command `code` is typed on the terminal, which shows suggestions. Then `--` is typed and options are provided, `--locale` is selected. Completions are requested with ctrl+space and all locales are shown. `e` is typed and the list is filtered to `en` and `es`.](https://code.visualstudio.com/assets/updates/1_96/terminal-completions.gif)
 
 ## Proposed APIs
 
@@ -663,7 +663,7 @@ qp.items = [
 qp.show();
 ```
 
-![A couple of characters are selected in the quick pick's input box.](images/1_96/valueSelectionQuickPick.png)
+![A couple of characters are selected in the quick pick's input box.](https://code.visualstudio.com/assets/updates/1_96/valueSelectionQuickPick.png)
 
 Try out the [valueSelectionInQuickPick proposal](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.valueSelectionInQuickPick.d.ts) and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/233274)!
 
@@ -709,7 +709,7 @@ This is still early and not ready to test out, but we wanted to share some detai
 
 Here's a screenshot of the feature in action, note the yellow line in the gutter tells us what lines are using fallback rendering. This particular case uses fallback rendering due to the `dontShow` parameter having an inline decoration as it's unused:
 
-![GPU rendering looks mostly the same as DOM rendering currently, a yellow line appears for lines rendered via the DOM](images/1_96/editor-gpu.png)
+![GPU rendering looks mostly the same as DOM rendering currently, a yellow line appears for lines rendered via the DOM](https://code.visualstudio.com/assets/updates/1_96/editor-gpu.png)
 
 The issue tracking this work is [#221145](https://github.com/microsoft/vscode/issues/221145) which has frequent updates and more details on progress as it's made.
 

--- a/docs/release-notes/v1_96.md
+++ b/docs/release-notes/v1_96.md
@@ -1,0 +1,842 @@
+---
+Order: 105
+TOCTitle: November 2024
+PageTitle: Visual Studio Code November 2024
+MetaDescription: Learn what is new in the Visual Studio Code November 2024 Release (1.96)
+MetaSocialImage: 1_96/release-highlights.png
+Date: 2024-12-11
+DownloadVersion: 1.96.0
+---
+# November 2024 (version 1.96)
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the November 2024 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* [Overtype mode](#overtype-mode) - Switch between overwrite or insert mode in the editor
+* [Add imports on paste](#configure-paste-and-drop-behavior) - Automatically add missing TS/JS imports when pasting code
+* [Test coverage](#attributable-coverage) - Quickly filter which code is covered by a specific test
+* [Move views](#move-views-between-primary-and-secondary-side-bar) - Easily move views between the Primary and Secondary Side Bar
+* [Terminal ligatures](#ligature-support) - Use ligatures in the terminal
+* [Extension allow list](#configure-allowed-extensions) - Configure which extensions can be installed in your organization
+* [Debug with Copilot](#debugging-with-copilot) - Use `copilot-debug` terminal command to start a debugging session
+* [Chat context](#add-context) - Add symbols and folders as context Chat and Edits
+* [Move from chat to Copilot Edits](#move-chat-session-to-copilot-edits) - Switch to Copilot Edits to apply code suggestions from Chat
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## GitHub Copilot
+
+### Copilot Edits
+
+Last milestone, we introduced [Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-edits) (currently in preview), which allows you to quickly edit multiple files at once using natural language. Since then, we've continued to iterate on the experience. You can try out Copilot Edits by opening the Copilot menu in the Command Center, and then selecting Open Copilot Edits, or by triggering `kb(workbench.action.chat.openEditSession)`.
+
+#### Progress and editor controls
+
+Copilot Edits can make multiple changes across different files. You can now more clearly see its progress as edits stream in. And with the editor overlay controls, you can easily cycle through all changes and accept or discard them.
+
+<video src="images/1_96/chat-edits.mp4" title="Copilot Edits changing a file" autoplay loop controls muted></video>
+
+#### Move chat session to Copilot Edits
+
+You might use the Chat view to explore some ideas for making changes to your code. Instead of applying individual code blocks, you can now move the chat session to Copilot Edits to apply all code suggestions from the session.
+
+![Edit with Copilot showing for a chat exchange.](images/1_96/chat-move.png)
+
+#### Working set suggested files
+
+In Copilot Edits, the working set determines the files that Copilot Edits can suggest changes for. To help you add relevant files to the working set, for a Git repo, Copilot Edits can now suggest additional files based on the files you've already added. For example, Copilot Edits will suggest files that are often changed together with the files you've already added.
+
+Copilot shows suggested files alongside the **Add Files** button in the working set. You can also select **Add Files** and then select **Related Files** to choose from a list of suggested files.
+
+<video src="images/1_96/working-set-suggested-files.mp4" title="Add suggested files to Copilot Edits working set." autoplay loop controls muted></video>
+
+#### Restore Edit sessions after restart
+
+Edit sessions are now fully restored after restarting VS Code. This includes the working set, acceptance state, as well as the file state of all past edit steps.
+
+#### Add to working set from Explorer, Search, and editor
+
+You can add files to your Copilot Edits working set with the new **Add File to Copilot Edits** context menu action for search results in the Search view and for files in the Explorer view. Additionally, you can also attach a text selection to Copilot Edits from the editor context menu.
+
+![Add a file from the explorer view to Copilot Edits](images/1_96/add-file-to-edits.png)
+
+### Debugging with Copilot
+
+Configuring debugging can be tricky, especially when you're working with a new project or language. This milestone, we're introducing a new `copilot-debug` terminal command to help you debug your programs using VS Code. You can use it by prefixing the command that you would normally run with `copilot-debug`. For example, if you normally run your program using the command `python foo.py`, you can now run `copilot-debug python foo.py` to start a debugging session.
+
+<video src="images/1_96/copilot-debug.mp4" title="Use the copilot-debug command to debug a Go program." autoplay loop controls muted></video>
+
+After your program exits, you are given options to rerun your program or to view, save, or regenerate the VS Code [launch configuration](https://code.visualstudio.com/docs/editor//debugging#launch-configurations) that was used to debug your program.
+
+![The terminal shows options to rerun, regenerate, save, or the launch config after a debugging session.](./images/1_96/copilot-debug.png)
+_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+
+#### Tasks Support
+
+Copilot's debugging features, including `copilot-debug` and the `/startDebugging` intent, now generate `preLaunchTask`s as needed for code that needs a compilation step before debugging. This is often the case for compiled languages, such as Rust and C++.
+
+### Add Context
+
+We’ve added new ways to include symbols and folders as context in Copilot Chat and Copilot Edits, making it easier to reference relevant information during your workflow.
+
+#### Symbols
+
+Symbols can now easily be added to Copilot Chat and Copilot Edits by dragging and dropping them from the Outline View or Breadcrumbs into the Chat view.
+
+<video src="images/1_96/context_symbols_dnd.mp4" title="Dragging and dropping symbols from the outline view and editor breadcrumbs into copilot chat" autoplay loop controls muted></video>
+
+We’ve also introduced symbol completion in the chat input. By typing `#` followed by the symbol name, you’ll see suggestions for symbols from files you've recently worked on.
+
+<video src="images/1_96/context_symbols_completion.mp4" title="After typing # completions show for files and symbols and further typing enables to filter down the completion items" autoplay loop controls muted></video>
+
+To reference symbols across your entire project, you can use `#sym` to open a global symbols picker.
+
+<video src="images/1_96/context_symbols_sym.mp4" title="Writing #sym allows to see the completion item #sym to open a global symbol picker" autoplay loop controls muted></video>
+
+#### Folders
+
+Folders can now be added as context by dragging them from the Explorer, Breadcrumbs, or other views into Copilot Chat.
+
+<video src="images/1_96/context_folder_chat.mp4" title="Dragging and dropping the @types folder into copilot chat and asking how to implement a share provider" autoplay loop controls muted></video>
+
+When a folder is dragged into Copilot Edits, all files within the folder are included in the working set.
+
+<video src="images/1_96/context_folder_edits.mp4" title="Dragging and dropping a folder into copilot edits adds all files in the folder to copilot edits" autoplay loop controls muted></video>
+
+### Copilot usage graph
+
+VS Code extensions can use the VS Code API to [build on the capabilities of Copilot](https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview). You can now see a graph of an extension's Copilot usage in the Runtime Status view. This graph shows the number of chat requests that were made by the extension over the last 30 days.
+
+![Copilot usage graph in the Runtime Status view](images/1_96/copilot-usage-chart.png)
+
+### Custom instructions for commit message generation
+
+Copilot can help you generate commit messages based on the changes you've made. This milestone, we added support for custom instructions when generating a commit message. For example, if your commit messages need to follow a specific format, you can describe this in the custom instructions.
+
+You can use the `setting(github.copilot.chat.commitMessageGeneration.instructions)` setting to either specify the custom instructions or specify a file from your workspace that contains the custom instructions. These instructions are appended to the prompt that is used to generate the commit message. Get more information on how to [use custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
+
+### Inline Chat
+
+This milestone, we have further improved the user experience of Inline Chat: we made the progress reporting more subtle, while streaming in changes squiggles are disabled, and detected commands are rendered more nicely.
+
+Also, we have continued to improve our pseudo-code detection and now show a hint that you can continue with Inline Chat when a line is mostly natural language. This functionality lets you type pseudo code in the editor, which is then used as a prompt for Inline Chat. You can also trigger this flow by pressing `kb(inlineChat.startWithCurrentLine)`.
+
+![Inline Chat hint for a line that is dominated by natural language.](images/1_96/inline-chat-nl-hint.png)
+
+Additionally, there is a new, experimental, setting to make an Inline Chat hint appear on empty lines. This setting can be enabled via `setting(inlineChat.lineEmptyHint)`. By default, this setting is disabled.
+
+### Terminal Chat
+
+Terminal Inline Chat has a fresh coat of paint that brings the look and feel much closer to editor Inline Chat:
+
+![Terminal inline chat looks a lot like editor chat now](images/1_96/copilot-terminal-chat.png)
+
+Here are some other improvements of note that were made:
+
+* The layout and positioning of the widget is improved and generally behaves better
+* There's a model picker
+* The buttons on the bottom are now more consistent
+
+### Performance improvements for `@workspace`
+
+When you use [`@workspace`](https://code.visualstudio.com/docs/copilot/workspace-context) to ask Copilot about your currently opened workspace, we first need to narrow the workspace down into a set of relevant code snippets that we can hand off to Copilot as context. If your workspaces is backed by a GitHub repo, we can find these relevant snippets quickly by using Github code search. However, as the code search index tracks the main branch of your repository, we couldn't rely on it for local changes or when on a branch.
+
+This milestone, we've worked bring the speed benefits of Github search to branches and pull requests. This means that we now search both the remote index based on your repo's main branch, along with searching any locally changed files. We then merge these results together, giving Copilot a fast and up to date set of snippets to work with. You can read more about [Github code search and how to enable it](https://docs.github.com/en/enterprise-cloud@latest/copilot/github-copilot-enterprise/copilot-chat-in-github/using-github-copilot-chat-in-githubcom#asking-a-question-about-a-specific-repository-file-or-symbol).
+
+## Accessibility
+
+### Code Action accessibility signals
+
+Some code actions can take a long time to complete, for example a quick fix that calls an external service to generate image alt text. It might not be obvious when they were triggered or when they're fully applied. Therefore, we added accessibility signals to indicate that a code action was triggered or applied.
+
+You can enable these signals with the `setting(accessibility.signals.codeActionTriggered)` and `setting(accessibility.signals.codeActionApplied)` settings.
+
+### Automatic focus management in the REPL
+
+We introduced a new setting to improve accessibility when working in the REPL. With `setting(accessibility.replEditor.autoFocusReplExecution)`, you can now specify whether focus remains unchanged (`none`), moves to the input box (`input`), or shifts to the most recently executed cell (`lastExecution`) whenever code is executed. By default, the focus moves to the input box.
+
+## Workbench
+
+### Improved extension search results
+
+When you search for extensions using free-form text in the Extensions view, installed extensions now appear at the top of the search results. This makes it easier to find and manage your installed extensions when searching through the Marketplace.
+
+![Installed extensions shown at top of search results.](images/1_96/extension-search-order.png)
+
+### Download extensions from the Extensions view
+
+You can now download extensions directly from VS Code by using the download action in the context menu of an extension in the Extensions view. This can be useful if you want to download an extension without installing it.
+
+![Context menu option to download an extension from the Extensions view.](images/1_96/extensions-download.png)
+
+### Extension disk space
+
+You can now see the memory usage of an extension on disk in the Extensions editor. This can help you understand how much disk space an extension is using.
+
+![Extension memory usage on disk shown in the Extensions view.](images/1_96/extension-memory-usage-on-disk.png)
+
+### Find in Explorer improvements
+
+In the September release, we introduced the ability to find files in the Explorer across the entire project, a capability that was previously unavailable. However, this update temporarily removed highlight mode and limited certain actions.
+
+In this release, we’re bringing back highlight mode. This feature allows you to easily locate files and folders across your workspace, with matching results highlighted for better visibility. Additionally, we’ve introduced a new visual indicator on collapsed folders, showing if matches are hidden within them.
+
+<video src="images/1_96/explorer_find_highlight.mp4" title="Find in the Explorer highlights all matching results and adds a badge to folders indicating the number of matches inside." autoplay loop controls muted></video>
+
+The filter toggle remains available, enabling you to focus only on files and folders that match your query by hiding non-matching items. We also reenabled all context menu actions we had to disable in a previous release.
+
+<video src="images/1_96/explorer_find_filter.mp4" title="Find in the Explorer with filter mode enabled shows only the files and folders that match the search term." autoplay loop controls muted></video>
+
+We’ve also improved the user experience when using the find control. When scrolled to the top of the file explorer, additional space is created at the top, ensuring the control doesn’t obstruct your search results.
+
+![The find control is rendered above the first file or folder in the explorer when scrolled to the top.](images/1_96/explorer_find_empty_space.png)
+
+### Move views between Primary and Secondary Side Bar
+
+You could already [move a view container](https://code.visualstudio.com/docs/editor/custom-layout#_drag-and-drop-views-and-panels) to another location by using drag and drop or by using the **Move View** command. You can now directly use the Move To context menu action on a view container to move it between the Primary Side Bar, Secondary Side Bar, or Panel area.
+
+<video src="images/1_96/move-views.mp4" title="Move view containers" autoplay loop controls muted></video>
+
+### Hide navigation controls in the title area
+
+Some people prefer to keep the title area as clean as possible. We added a new setting `setting(workbench.navigationControl.enabled)` that enables you to hide the back/forward buttons in the title area.
+
+You can also access this setting by right-clicking in the title area, and selecting **Navigation Controls**.
+
+![Navigation Controls context menu when right-clicking the VS Code title area.](images/1_96/nav-controls.png)
+
+## Editor
+
+### Configure paste and drop behavior
+
+When you drag and drop or copy & paste a file into a text editor, VS Code provides multiple ways to insert it into that file. By default, VS Code tries to insert the file's workspace relative path. Now you can use the drop/paste control to switch how the resource is inserted. Extensions can also provide customized edits, such as in Markdown, which [provides edits that insert Markdown links](https://code.visualstudio.com/updates/v1_67#_markdown-drop-into-editor-to-create-link).
+
+With the new `setting(editor.pasteAs.preferences)` and `setting(editor.dropIntoEditor.preferences)` settings, you can now specify a preference for which edit type will be used by default. For example, if you'd like copy/paste to always insert the absolute path of pasted files, just set:
+
+```json
+"editor.pasteAs.preferences": [
+    "uri.path.absolute"
+]
+```
+
+These settings are ordered lists of edit kinds. The first matching edit of a preferred kind is applied by default. You can still use the drop/paste control to change to a different type of edit after the default edit is applied.
+
+These new settings play nicely with our [new copy and paste with imports support in JavaScript and TypeScript](#paste-with-imports-for-javascript-and-typescript). This feature automatically adds imports when copy and pasting code across JavaScript or TypeScript files. To avoid disrupting your workflows, by default, we decided that paste just inserts plain text and `paste with imports` is offered as an option in the paste control. However, if you'd like VS Code to always try to paste with imports, just set:
+
+```json
+"editor.pasteAs.preferences": [
+    "text.updateImports"
+]
+```
+
+Now, VS Code automatically tries to paste with imports when possible, falling back to pasting plain text if no paste with imports edit is available. Right now, this only works for JavaScript and TypeScript, but we hope additional languages will adopt support over time.
+
+Finally, you can now also specify a preferred paste style when setting up a `editor.action.pasteAs` keybinding. The keybinding below will always try pasting and updating imports:
+
+```json
+{
+    "key": "ctrl+shift+v",
+    "command": "editor.action.pasteAs",
+    "args": {
+        "preferences": [
+            "text.updateImports"
+        ]
+    }
+}
+```
+
+### Persist editor find history
+
+The Find control now can persist the search history across sessions and restores it across VS Code restarts. The search history is stored per workspace and can be disabled via the `setting(editor.find.history)` setting.
+
+<video src="images/1_96/editor-find-history.mp4" title="Demo of the persistence of editor find history" autoplay loop controls muted></video>
+
+### Overtype mode
+
+On popular request, we added overtype mode to overwrite text in the editor instead of inserting it when typing. A useful scenario for this is when editing Markdown tables, where you want to keep the table cell boundaries nicely aligned.
+
+This mode can be toggled with the command **View: Toggle Overtype/Insert Mode**. When you're in overtype mode, the Status Bar shows an `OVR` indicator. In addition, there is a setting `setting(editor.overtypeOnPaste)`, which determines whether pasting in overtype mode should overwrite or insert. The default behavior is to insert pasted text.
+
+<video src="images/1_96/overtype.mp4" title="Overtype mode" autoplay loop controls muted></video>
+
+It is possible to change the cursor style while in overtype mode by using the setting `setting(editor.overtypeCursorStyle)`.
+
+## Source Control
+
+### Git blame information (Experimental)
+
+This milestone, we have added experimental support for displaying blame information using editor decorations and a Status Bar item. You can enable this functionality by using the `setting(git.blame.editorDecoration.enabled:true)` and `setting(git.blame.statusBarItem.enabled:true)` settings. You can hover over the blame information to see more commit details.
+
+<video src="images/1_96/git-blame.mp4" title="Show git blame information in editor and Status Bar." autoplay loop controls muted></video>
+
+You can customize the format of the message that is shown in the editor and in the Status Bar with the `setting(git.blame.editorDecoration.template)` and `setting(git.blame.statusBarItem.template)` settings. You can use variables for the most common information. For example, the following template shows the subject of the commit, the author's name, and the author's date relative to now:
+
+```json
+{
+  "git.blame.editorDecoration.template": "${subject}, ${authorName} (${authorDateAgo})"
+}
+```
+
+If you would like to adjust the color of the editor decoration, use the `git.blame.editorDecorationForeground` theme color.
+
+Give this experimental feature a try and let us know what you think.
+
+### Source Control Graph title actions
+
+Based on user feedback, we have brought back the Pull, and Push actions to the Source Control Graph view title bar. These actions are enabled if the current history item reference is shown in the Source Control Graph.
+
+If you do not want to use these actions, or any other actions from the Source Control Graph view title bar, you can right-click on the title bar and hide them.
+
+![Source Control Graph title actions and context menu to hide specific items.](images/1_96/source-control-graph-title-actions.png)
+
+## Notebooks
+
+### Selection highlight across cells
+
+Selection highlighting is now supported within notebooks, allowing for textual selection based highlights across multiple cells. This is controlled with the preexisting setting `setting(editor.selectionHighlight)`.
+
+<video src="images/1_96/notebook-selection-highlight.mp4" title="Notebook selection highlighting demo" autoplay loop controls muted></video>
+
+### Multi Cursor: Select All Occurrences of Find Match
+
+Notebooks now support the keyboard shortcut for **Select All Occurrences of Find Match**. This can be found with the command id `notebook.selectAllFindMatches` and can be used by default with the keystroke `kb(notebook.selectAllFindMatches)`.
+
+<video src="images/1_96/notebook-select-all-occurrences.mp4" title="Notebook select all occurrences multicursor demo" autoplay loop controls muted></video>
+
+### Run Cells in Section for Markdown
+
+Notebooks now have the **Run Cells in Section** action exposed to the cell toolbar of Markdown cells. If the Markdown cell has a header, all cells contained within the section and children sections are executed. If there is no header, this executes all cells in the surrounding section, if possible.
+
+<video src="images/1_96/notebook-md-toolbar-run-in-section.mp4" title="Notebook run in section from markdown cell toolbar demo" autoplay loop controls muted></video>
+
+### Cell execution time verbosity
+
+The execution time information within the cell status bar now has an option for increased verbosity. This can be turned on with the setting `setting(notebook.cellExecutionTimeVerbosity)` and is able to display the execution timestamp in addition to the duration.
+
+![Verbose cell execution time within cell status bar.](images/1_96/notebook-verbose-execution-time.png)
+
+## Terminal
+
+### Ligature support
+
+Ligatures are now supported in the terminal, regardless of whether [GPU acceleration](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration) is being used. This feature can be turned on with the setting `setting(terminal.integrated.fontLigatures)`:
+
+![Fonts that support ligatures like ->, ==>, and so on will now visually look like single characters](images/1_96/terminal-ligatures.png)
+
+In order to use this feature, make sure you also use a font that supports ligatures `setting(terminal.integrated.fontFamily)`.
+
+### New variables for customizing terminal tabs
+
+What text appears in terminal tabs is determines by the `terminal.integrated.tabs.title` and `terminal.integrated.tabs.description` settings which allow the use of a collection of variables. We now support the following new variables:
+
+- `${shellType}` - The detected type of shell that is being used in the terminal. This is similar the default value, but it will not change to `git` for example when running a git command.
+- `${shellCommand}` - The command that is being run in the terminal. This requires [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration).
+
+  ![alt text](images/1_96/terminal_shellCommand.png)
+- `${shellPromptInput}` - The command that is being run in the terminal or the current detected prompt input. This requires [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration).
+
+  ![Typing "echo hello" in the terminal will show "echo hello|" in the tab when configured](images/1_96/terminal_shellPromptInput.png)
+
+### Run recent command now shows the history source file
+
+The [run recent command](https://code.visualstudio.com/docs/terminal/shell-integration#_run-recent-command) shell integration feature now includes full size headers for the source of the command, including the history file where relevant and a convenient button to open it.
+
+![alt text](images/1_96/terminal-run-recent-command.png)
+
+The default keybinding for this command is `Ctrl+Alt+R`.
+
+### New supported link format
+
+Links with the format `/path/to/file.ext, <line>` should now be detected as links in the terminal.
+
+## Testing
+
+### Attributable coverage
+
+This milestone, we finalized an API that enables extensions to provide coverage on a per-test basis, so you can see exactly what code any given test executed. When attributable coverage is available, a filter button is available in the Test Coverage view, in editor actions, in the Test Coverage toolbar when toggled on (via the **Test: Test Coverage Toolbar** command), or simply by using the **Test: Filter Coverage by Test** command.
+
+<video src="images/1_96/per-test-coverage.mp4" title="Demo of the per-test coverage feature." autoplay loop controls muted></video>
+
+_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+
+### Reworked inline failure messages
+
+We reworked test failure messages to be both more eye-catching and less obtrusive. This is particularly useful for busy scenarios, such as in diffs from SCM or Copilot Edits. Selecting the failure message still opens a peek control to show the complete details of the failure.
+
+![Image of new test error messages in the editor.](./images/1_96/test-errors.png)
+
+### Improvements to the continuous run UI
+
+Previously, the global state of continuous test runs, togglable via the "eye" icon in the Test Explorer view, would toggle on or off continuous running with the default set of run profiles.
+
+We reworked the continuous run UI to include a drop-down menu to turn continuous run on or off individually per-profile. Selecting the indicator toggles the last used set of run profiles on or off.
+
+## Languages
+
+### TypeScript 5.7
+
+Our JavaScript and TypeScript support now uses TypeScript 5.7. This major update includes a number of language and tooling improvements, along with important bug fixes and performance optimizations.
+
+You can read all about the TypeScript 5.7 release on the [TypeScript blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/). We've also included a few tooling highlights in the following sections.
+
+### Paste with imports for JavaScript and TypeScript
+
+Tired of having to add imports after moving code between files? Try the Paste with imports feature for TypeScript 5.7+. Now whenever you copy and paste code between JavaScript or TypeScript, VS Code can add imports for the pasted code.
+
+<video src="images/1_96/jsts-update-imports-paste.mp4" title="Imports are automatically updated when pasting code between files in JS and TS." autoplay loop controls muted></video>
+
+Notice how not only imports are added, even a new export was added for a local variable that was used in the pasted code!
+
+While we think this feature is a huge time saver, we also are sensitive to disrupting your existing workflow. That's why, by default, we've kept it so copy and paste always inserts just the pasted text. If a `paste with imports` edit is available, you then see the paste control, which lets you select the `paste with imports` edit.
+
+![Paste control that shows options to insert plain text or paste with imports.](images/1_96/jsts-paste-widget.png)
+
+If you prefer always pasting with imports, you can use the new [`editor.pasteAs.preferences` setting](#configure-paste-and-drop-behavior):
+
+```json
+"editor.pasteAs.preferences": [
+    "text.updateImports"
+]
+```
+
+This will always try pasting with imports if an edit is available.
+
+You can also setup a keybinding to paste with imports if available:
+
+```json
+{
+    "key": "ctrl+shift+v",
+    "command": "editor.action.pasteAs",
+    "args": {
+        "preferences": [
+            "text.updateImports"
+        ]
+    }
+}
+```
+
+If you prefer, you can even do the reverse and make paste with imports the default and add a keybinding to paste as plain text:
+
+```json
+"editor.pasteAs.preferences": [
+    "text.updateImports"
+]
+```
+
+```json
+{
+    "key": "ctrl+shift+v",
+    "command": "editor.action.pasteAs",
+    "args": {
+        "preferences": [
+            "text.plain"
+        ]
+    }
+}
+```
+
+Finally, if you want to fully disable `paste with imports`, you can use `setting(typescript.updateImportsOnPaste.enabled)` and `setting(javascript.updateImportsOnPaste.enabled)`.
+
+## Remote Development
+
+The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+
+Highlights include:
+
+* `remote-ssh` Copilot chat participant
+* Enhanced session logging
+
+You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_96.md).
+
+## Enterprise support
+
+### Configure allowed extensions
+
+You can now control which extensions can be installed in VS Code using the `setting(extensions.allowed)` setting.  This setting allows you to specify allowed or blocked extensions by publisher, specific extensions and versions. If an extension or version is blocked, it will be disabled if already installed. You can specify the following types of extension selectors:
+
+* Allow or block all extensions from a publisher
+* Allow or block specific extensions
+* Allow specific extension versions
+* Allow specific extension versions and platforms
+* Allow only stable versions of an extension
+* Allow only stable extension versions from a publisher
+
+The following JSON snippet shows examples of the different setting values:
+
+```json
+"extensions.allowed": {
+    // Allow all extensions from the 'microsoft' publisher. If the key does not have a '.', it means it is a publisher ID.
+    "microsoft": true,
+
+    // Allow all extensions from the 'github' publisher
+    "github": true,
+
+    // Allow prettier extension
+    "esbenp.prettier-vscode": true,
+
+    // Do not allow docker extension
+    "ms-azuretools.vscode-docker": false,
+
+    // Allow only version 3.0.0 of the eslint extension
+    "dbaeumer.vscode-eslint": ["3.0.0"],
+
+    // Allow multiple versions of the figma extension
+    "figma.figma-vscode-extension": ["3.0.0", "4.2.3", "4.1.2"]
+
+    // Allow version 5.0.0 of the rust extension on Windows and macOS
+    "rust-lang.rust-analyzer": ["5.0.0@win32-x64", "5.0.0@darwin-x64"]
+
+    // Allow only stable versions of the GitHub Pull Requests extension
+    "github.vscode-pull-request-github": "stable",
+
+    // Allow only stable versions from redhat publisher
+    "redhat": "stable",
+}
+```
+
+Specify publishers by their publisher ID. If a key does not have a period (`.`), it is considered a publisher ID. If a key has a period, it is considered an extension ID. The use of wildcards is currently not supported.
+
+You can use `microsoft` as the publisher ID to refer to all extensions published by Microsoft, even though they might have different publisher IDs.
+
+Version ranges are not supported. If you want to allow multiple versions of an extension, you must specify each version individually. To further restrict versions by platform, use the `@` symbol to specify the platform. For example, `"rust-lang.rust-analyzer": ["5.0.0@win32-x64", "5.0.0@darwin-x64"]`.  For more details, refer to the [enterprise documentation](https://code.visualstudio.com/docs/setup/enterprise#configure-allowed-extensions).
+
+Administrators can also configure this setting via group policy on Windows. For more information, see the [Group Policy on Windows](https://code.visualstudio.com/docs/setup/enterprise#group-policy-on-windows) section in the enterprise documentation.
+
+## Set up VS Code with preinstalled extensions
+
+You can set up VS Code with a set of preinstalled extensions (*bootstrap*). This functionality is useful in cases where you prepare a machine image, virtual machine, or cloud workstation where VS Code is preinstalled and specific extensions are immediately available for users.
+
+> **Note**: Support for preinstalling extensions is currently only available on Windows.
+
+Follow these steps to bootstrap extensions:
+
+1. Create a folder `bootstrap\extensions` in the VS Code installation directory.
+
+1. Download the [VSIX files](https://code.visualstudio.com/docs/editor/extension-marketplace#_can-i-download-an-extension-directly-from-the-marketplace) for the extensions that you want to preinstall and place them in the `bootstrap\extensions` folder.
+
+1. When a user launches VS Code for the first time, all extensions in the `bootstrap\extensions` folder are installed silently in the background.
+
+Users can still uninstall extensions that were preinstalled. Restarting VS Code after uninstalling an extension will not reinstall the extension.
+
+## Contributions to extensions
+
+### Python
+
+#### Python Environments extension
+
+In this release we are introducing the Python Environments extension, now available in preview on the Marketplace.
+
+This extension simplifies Python environment management, offering a UI to create, delete, and manage environments, along with package management for installing and uninstalling packages.
+
+Designed to integrate seamlessly with your preferred environment managers via various APIs, it supports Global Python interpreters, venv, and Conda by default. Developers can build extensions to add support for their favorite Python environment managers and integrate with our extension UI, enhancing functionality and user experience.
+
+You can download the Python Environments in the Marketplace, and use it with the pre-release version of the Python extension.
+
+#### Python testing enhancements
+
+* The `--rootdir` argument for pytest is now dynamically adjusted based on the presence of a `python.testing.cwd` setting in your workspace.
+* Restarting a test debugging session now reruns only the specified tests.
+* Coverage support updated to handle `NoSource` exceptions.
+* `pytest-describe` plugin is supported with test detection and execution in the UI.
+* Testing Rewrite now leverages FIFO instead of UDS for interprocess communication allowing users to harness pytest plugins like `pytest_socket` in their own testing design.
+* **Rewrite Nearing Default Status:** This release addresses [the final known issue](https://github.com/microsoft/vscode-python/issues/23279) in the testing rewrite, and unless further issues arrive, the rewrite experiment will be turned off and the rewrite set to default in early 2025.
+
+#### Python REPL enhancements
+
+* Leave focus on editor after smart-send to Native REPL
+* Improved handling after reload for Native REPL
+* Fix indentation error issues with Python 3.13 in VS Code terminal
+
+#### Pylance "full" language server mode
+
+The `python.analysis.languageServerMode` setting now also supports `full` mode, enabling you to take advantage of the complete range of Pylance's functionality and the most comprehensive IntelliSense experience. It's worth noting that this comes at the cost of lower performance, as it can cause Pylance to be resource-intensive, particularly in large codebases.
+
+The `python.analysis.languageServerMode` setting now changes the default values of the following settings, depending on whether it's set to `light`, `default` or `full`:
+
+| Setting                                                | light    | default | full |
+|--------------------------------------------------------|----------|---------|------|
+| python.analysis.exclude                                | \["**"\] | []      | []   |
+| python.analysis.useLibraryCodeForTypes                 | false    | true    | true |
+| python.analysis.enablePytestSupport                    | false    | true    | true |
+| python.analysis.indexing                               | false    | true    | true |
+| python.analysis.autoImportCompletions                  | false    | false   | true |
+| python.analysis.showOnlyDirectDependenciesInAutoImport | false    | false   | true |
+| python.analysis.packageIndexDepths                     | ```[ { "name": "sklearn", "depth": 2 }, { "name": "matplotlib", "depth": 2 }, { "name": "scipy", "depth": 2 }, { "name": "django", "depth": 2 }, { "name": "flask", "depth": 2 }, { "name": "fastapi", "depth": 2 } ]``` | ```[ { "name": "sklearn", "depth": 2 }, { "name": "matplotlib", "depth": 2 }, { "name": "scipy", "depth": 2 }, { "name": "django", "depth": 2 }, { "name": "flask", "depth": 2 }, { "name": "fastapi", "depth": 2 } ]``` | ```{ "name": "", "depth": 4,  "includeAllSymbols": true }``` |
+| python.analysis.regenerateStdLibIndices                | false    | false   | true |
+| python.analysis.userFileIndexingLimit                  | 2000     | 2000    | -1   |
+| python.analysis.includeAliasesFromUserFiles            | false    | false   | true |
+| python.analysis.functionReturnTypes                    | false    | false   | true |
+| python.analysis.pytestParameters                       | false    | false   | true |
+| python.analysis.supportRestructuredText                | false    | false   | true |
+| python.analysis.supportDocstringTemplate               | false    | false   | true |
+
+### TypeScript
+
+#### TypeScript expandable hover (Experimental)
+
+This milestone, we made it possible to view expanded/contracted information from the TS server. The extension uses the Expandable Hover API to show `+` and `-` markers in the editor hover to display more or less information.
+
+<video src="images/1_96/expandable-hover.mp4" title="TypeScript Expandable Hover" autoplay loop controls muted></video>
+
+The experimental setting can be enabled using `setting(typescript.experimental.expandableHover)`. For this setting to work, you must be on TypeScript version 5.8 or above. You can change the TypeScript version by using the `TypeScript: Select TypeScript Version...` command.
+
+### Microsoft Account now uses MSAL (with WAM support on Windows)
+
+In order to ensure a strong security baseline for Microsoft authentication, we've adopted the [Microsoft Authentication Library](https://github.com/AzureAD/microsoft-authentication-library-for-js) in the Microsoft Account extension.
+
+One of the stand out features of this work is WAM (Web Account Manager... also known as [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) integration. Put simply, rather than going to the browser for Microsoft authentication flows, we now talk to the OS directly, which is the recommended way of acquiring a Microsoft authentication session. Additionally, it's faster since we're able to leverage the accounts that you're already logged into on the OS.
+
+![An authentication popup that the OS shows over VS Code.](images/1_96/showingBrokerOSDialog.png)
+
+Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
+
+## Extension Authoring
+
+### @vscode/chat-extension-utils
+
+We've had our [chat](https://code.visualstudio.com/api/references/vscode-api#chat) and [language model](https://code.visualstudio.com/api/references/vscode-api#lm) extension APIs available for several months to let extension authors integrate with GitHub Copilot. But we've found that working with LLMs and building high-quality chat extensions is inherently complex, especially if you want to make use of tool calling.
+
+We've published an npm package, `@vscode/chat-extension-utils`, that aims to make it as easy as possible to get a chat participant up and running. It takes over several things that you would otherwise have to do yourself, so that your chat participant can be implemented in a just a few lines of code. The package also contains a collection of useful, high-quality elements to use with [@vscode/prompt-tsx](https://github.com/microsoft/vscode-prompt-tsx).
+
+You can view the full documentation in the [`chat-extension-utils` repository](https://github.com/microsoft/vscode-chat-extension-utils/blob/main/README.md) and see it in action in the [sample chat extension](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample). Our new [LanguageModelTool API docs](https://code.visualstudio.com/api/extension-guides/tools) also describe how to use it.
+
+### Attributable Coverage API
+
+The test coverage APIs now enable extensions to provide coverage information on a per-test basis. To implement this API, populate the the `includesTests?: TestItem[]` property on the `FileCoverage` to indicate which tests executed code in that file, and implement `TestRunProfile.loadDetailedCoverageForTest` to provide statement and declaration coverage.
+
+See the [Attributable Coverage section above](#attributable-coverage) for an example of what this looks like for users.
+
+### Contributing to a JavaScript Debug Terminal
+
+The JavaScript debugger now has a mechanism for other extensions to participate in the creation of JavaScript Debug Terminals. This enables frameworks, or runtimes aside from Node.js, to enable debugging in the same familiar place. Refer to the [JavaScript Debugger documentation](https://github.com/microsoft/vscode-js-debug/blob/main/EXTENSION_AUTHORS.md#extension-api) for more information.
+
+### Proxy support for Node.js `fetch` API
+
+The global `fetch` function now comes with proxy support enabled (`setting(http.fetchAdditionalSupport)`). This is similar to the `https` module, which already had proxy support.
+
+## Preview Features
+
+### Paste code to attach chat context
+
+Previously, you could already attach files as context to Copilot Chat. For more fine-grained control over the context, you can now paste a code fragment to attach it as context for chat. This adds the necessary file information and corresponding line numbers. You can only paste code coming from files in the current workspace.
+
+To try this out, copy some code and paste it in Inline Chat, Quick Chat, or the Chat view. Select the paste control that shows up and select `Pasted Code Attachment.` Alternatively, you can set the `setting(editor.pasteAs.preferences)` setting:
+
+```json
+"editor.pasteAs.preferences": [
+    "chat.attach.text"
+]
+```
+
+![Attaching code as context in Copilot Chat using the paste control.](images/1_96/paste-code-context.gif)
+
+### Terminal completions for more shells
+
+We added experimental support for terminal completions in `pwsh` in prior iterations. This release, we have started working on expanding this to other shells. Specifically targeting `bash` and `zsh` for now, but since this new approach is powered by an extension host API, we plan on having general support for most shells.
+
+You can try out the current work in progress by setting `setting(terminal.integrated.suggest.enabled)` and
+`setting(terminal.integrated.suggest.enableExtensionCompletions)`. Currently only `cd`, `code`, and `code-insiders` arguments are supported.
+
+![The command `code` is typed on the terminal, which shows suggestions. Then `--` is typed and options are provided, `--locale` is selected. Completions are requested with ctrl+space and all locales are shown. `e` is typed and the list is filtered to `en` and `es`.](images/1_96/terminal-completions.gif)
+
+## Proposed APIs
+
+### Proposed Value Selection API on Quick Pick
+
+For `InputBox` you have been able to set the "value selection", which enables you to programmatically select part or all of the input. This milestone, we added a proposed API for value selection in a QuickPick.
+
+Here's an example of what that might look like:
+
+```ts
+const qp = vscode.window.createQuickPick();
+qp.value = '12345678';
+qp.valueSelection = [4, 6];
+qp.items = [
+	{ label: '12345678', description: 'desc 1' },
+	{ label: '12345678', description: 'desc 2' },
+	{ label: '12345678', description: 'desc 3' },
+];
+qp.show();
+```
+
+![A couple of characters are selected in the quick pick's input box.](images/1_96/valueSelectionQuickPick.png)
+
+Try out the [valueSelectionInQuickPick proposal](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.valueSelectionInQuickPick.d.ts) and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/233274)!
+
+### Proposed Native Window Handle API
+
+This milestone, we added a new proposed API to retrieve the native window handle of the focused window. The native window handle is an OS concept that essentially provides a pointer to a particular window. This is useful if you are interacting with native code and need to, for example, render a native dialog on top of a window.
+
+```ts
+declare module 'vscode' {
+
+	export namespace window {
+		/**
+		 * Retrieves the native window handle of the current active window.
+		 * This will be updated when the active window changes.
+		 */
+		export const nativeHandle: Uint8Array | undefined;
+	}
+}
+```
+
+This was added specifically for Microsoft Authentication's [adoption of MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md#window-parenting), so that we could pass the native handle down to the OS so it could render an auth dialog overtop VS Code.
+
+If you have a use case or feedback for the [nativeWindowHandle proposal](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts), let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/233106)!
+
+## Engineering
+
+### Optimized extension updates with vscode-unpkg service
+
+To reduce the load on the Marketplace infrastructure, VS Code now uses the newly added endpoint from the `vscode-unpkg` service to check for extension updates. The service implements server-side caching with a 10-minute TTL, which significantly reduces the number direct requests to the Marketplace. The optimization is controlled via the `setting(extensions.gallery.useUnpkgResourceApi)` setting (enabled by default).
+
+If you notice issues with extension updates, you can disable this functionality with `setting(extensions.gallery.useUnpkgResourceApi:false)`, and revert back to direct Marketplace version checks.
+
+### Ground work for GPU acceleration in the editor
+
+We are excited to announce that we have started work on enabling GPU acceleration in the editor, [similar to the terminal](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration). The goals of this effort are to improve the overall coding experience primarily by reducing input latency and improving scrolling performance.
+
+This is still early and not ready to test out, but we wanted to share some details about the progress that has been made:
+
+* The GPU renderer is using WebGPU behind the scenes.
+* We're focusing currently on feature parity and correctness over performance.
+* There's a fallback mechanism when GPU acceleration is enabled that allows lines to "fallback" to DOM rendering when it's not fully supported. This means that we can self-host early on and currently incompatible lines will show using the DOM approach instead. Some examples of lines that currently fallback lines over 200 characters, lines with certain monaco decorations (eg. fading unused variables), lines that wrap, and so on.
+* Monaco's inline decorations which allow styling the actual elements containing the characters posed a big challenge for this feature as they are styled using CSS. The approach we're using to support most inline decorations without breaking or changing API is to detect the CSS attached to these decorations and then support a subset of common CSS properties, falling back if not all styles are supported.
+
+Here's a screenshot of the feature in action, note the yellow line in the gutter tells us what lines are using fallback rendering. This particular case uses fallback rendering due to the `dontShow` parameter having an inline decoration as it's unused:
+
+![GPU rendering looks mostly the same as DOM rendering currently, a yellow line appears for lines rendered via the DOM](images/1_96/editor-gpu.png)
+
+The issue tracking this work is [#221145](https://github.com/microsoft/vscode/issues/221145) which has frequent updates and more details on progress as it's made.
+
+### EOL warning for macOS 10.15
+
+VS Code desktop will be updating to [Electron 33](https://github.com/microsoft/vscode/issues/232993) in the next couple of milestones. With the Electron 33 update, VS Code desktop will no longer run on **macOS Catalina**. In this milestone, we have added deprecation notices for the users on this affected platform to prepare them for migration. If you are a user of the aforementioned OS version, please take a look at our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
+
+## Notable fixes
+
+* [233915](https://github.com/microsoft/vscode/issues/233915) Share an extension with others by using the **Copy Link** action in the context menu of an extension in the Extensions view.
+* [231542](https://github.com/microsoft/vscode/issues/231542) Frequently unable to save file or file data gets erased with error EBUSY
+* [233304](https://github.com/microsoft/vscode/issues/233304) `onDidChangeCheckboxState` broken in 1.95
+* [232263](https://github.com/microsoft/vscode/issues/232263) Optimize tree view such that cross process calls are batched
+* [156723](https://github.com/microsoft/vscode/issues/156723) Drag and drop support fixed when running with wayland
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@sahin52 (Sahin Kasap)](https://github.com/sahin52)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Add support for a border between sidebar and panel titles and views [PR #157318](https://github.com/microsoft/vscode/pull/157318)
+* [@aravind-n (Aravind Nidadavolu)](https://github.com/aravind-n): Fix fish shell integration execution order [PR #226589](https://github.com/microsoft/vscode/pull/226589)
+* [@BABA983 (BABA)](https://github.com/BABA983): Correct ShellIntegrationDecorationsEnabled in markdownDescription [PR #233387](https://github.com/microsoft/vscode/pull/233387)
+* [@BenLocal (benshi)](https://github.com/BenLocal): Cli serve_web sets the path prefix to /<quality>-<commit>/, commit value parsing error [PR #233986](https://github.com/microsoft/vscode/pull/233986)
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): fix: cannot open vscode when use vscode-win32-x64 in Windows [PR #233285](https://github.com/microsoft/vscode/pull/233285)
+* [@BugGambit (Fredrik Anfinsen)](https://github.com/BugGambit): Add support for links 'foo, <line>' [PR #231775](https://github.com/microsoft/vscode/pull/231775)
+* [@cachandlerdev](https://github.com/cachandlerdev): Copy extension link [PR #234210](https://github.com/microsoft/vscode/pull/234210)
+* [@CrafterKolyan (Nikolai Korolev)](https://github.com/CrafterKolyan): Add interface for adding value selection in QuickPick for extension API [PR #233275](https://github.com/microsoft/vscode/pull/233275)
+* [@davidmartos96 (David Martos)](https://github.com/davidmartos96): Fix PATH prepending when using Fish [PR #232291](https://github.com/microsoft/vscode/pull/232291)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): Do not mark interpolation tokens as strings in C# [PR #232772](https://github.com/microsoft/vscode/pull/232772)
+* [@duncpro (Duncan)](https://github.com/duncpro): fix: clickability of create new file/folder button [PR #232130](https://github.com/microsoft/vscode/pull/232130)
+* [@elias-pap (Elias Papavasileiou)](https://github.com/elias-pap): feat: add icon for Vite [PR #234620](https://github.com/microsoft/vscode/pull/234620)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+  * Add `workbench.view.showQuietly` settings object to stop extensions revealing hidden Output view (fix #105270) [PR #205225](https://github.com/microsoft/vscode/pull/205225)
+  * Fix `Go to Current History Item` breakage (fix #235063) [PR #235067](https://github.com/microsoft/vscode/pull/235067)
+  * Enable `Go to Current History Item` correctly after reference picker change (fix #235132) [PR #235134](https://github.com/microsoft/vscode/pull/235134)
+* [@iisaduan (Isabel Duan)](https://github.com/iisaduan): fix typescript organizeImports settings [PR #232676](https://github.com/microsoft/vscode/pull/232676)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): Fixes old extensionHost process is not killed immediately after reloading vscode web tab in the browser [PR #234944](https://github.com/microsoft/vscode/pull/234944)
+* [@Kannav02 (Kannav Sethi)](https://github.com/Kannav02): Change "Organize Imports" command label to "Optimize Imports" [PR #232869](https://github.com/microsoft/vscode/pull/232869)
+* [@LionelJouin (Lionel Jouin)](https://github.com/LionelJouin): Fix: go grammar update (#232142) [PR #232335](https://github.com/microsoft/vscode/pull/232335)
+* [@LitoMore (LitoMore)](https://github.com/LitoMore): Remove Microsoft-related logos [PR #215758](https://github.com/microsoft/vscode/pull/215758)
+* [@Logicer16 (Logicer)](https://github.com/Logicer16): Fix grammar in activeOnStart description [PR #197536](https://github.com/microsoft/vscode/pull/197536)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): Add `.winget` file extension to YAML [PR #232218](https://github.com/microsoft/vscode/pull/232218)
+* [@ribru17 (Riley Bruins)](https://github.com/ribru17): Render JSDoc examples as typescript code [PR #234143](https://github.com/microsoft/vscode/pull/234143)
+* [@sandersn (Nathan Shively-Sanders)](https://github.com/sandersn): Revert register copilotRelated with copilot [PR #233729](https://github.com/microsoft/vscode/pull/233729)
+* [@nickdiego (Nick Yamane)](https://github.com/nickdiego): Fix for drag and drop support when using wayland [Chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/6000277)
+
+Contributions to `vscode-emmet-helper`:
+
+* [@onlurking (Diogo Felix)](https://github.com/onlurking): Add missing HTML tags to emmet [PR #90](https://github.com/microsoft/vscode-emmet-helper/pull/90)
+
+Contributions to `vscode-eslint`:
+
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Update contributing instructions [PR #1947](https://github.com/microsoft/vscode-eslint/pull/1947)
+
+Contributions to `vscode-extension-samples`:
+
+* [@olguzzar (Olivia Guzzardo)](https://github.com/olguzzar): Update Chat tutorial to use request.model [PR #1125](https://github.com/microsoft/vscode-extension-samples/pull/1125)
+* [@phil294 (Philip Waritschlager)](https://github.com/phil294): webview-codicons: Move codicons dependency from devDependencies into dependencies [PR #1005](https://github.com/microsoft/vscode-extension-samples/pull/1005)
+* [@witsaint (gaodingqiang)](https://github.com/witsaint): fix: `lsp-embedded-language-service` cleaninterval args type [PR #1126](https://github.com/microsoft/vscode-extension-samples/pull/1126)
+
+Contributions to `vscode-extension-telemetry`:
+
+* [@kmagiera (Krzysztof Magiera)](https://github.com/kmagiera): Propagate session ID metadata [PR #215](https://github.com/microsoft/vscode-extension-telemetry/pull/215)
+
+Contributions to `vscode-hexeditor`:
+
+* [@Antecer (Antecer)](https://github.com/Antecer): We need a WYSIWYG copy method [PR #540](https://github.com/microsoft/vscode-hexeditor/pull/540)
+* [@Hexa3333 (Alp Yılmaz)](https://github.com/Hexa3333): Fix: DisplayContextSelection read violation (#547) [PR #548](https://github.com/microsoft/vscode-hexeditor/pull/548)
+* [@jogo-](https://github.com/jogo-): Update CHANGELOG.md [PR #549](https://github.com/microsoft/vscode-hexeditor/pull/549)
+* [@tomilho (Tomás Silva)](https://github.com/tomilho): fix: ctrl+f not working with caps lock active [PR #555](https://github.com/microsoft/vscode-hexeditor/pull/555)
+
+Contributions to `vscode-json-languageservice`:
+
+* [@jeremyfiel (Jeremy Fiel)](https://github.com/jeremyfiel): fix: typo in `then` description [PR #251](https://github.com/microsoft/vscode-json-languageservice/pull/251)
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): Fix slow large oneof validation [PR #247](https://github.com/microsoft/vscode-json-languageservice/pull/247)
+* [@sumimakito (Makito)](https://github.com/sumimakito): feat(completion): support detail from schema [PR #243](https://github.com/microsoft/vscode-json-languageservice/pull/243)
+
+Contributions to `vscode-jupyter`:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Add `connor4312.esbuild-problem-matchers` recommendation [PR #16195](https://github.com/microsoft/vscode-jupyter/pull/16195)
+* [@pwang347 (Paul)](https://github.com/pwang347): Add public API event for kernel post-initialization [PR #16214](https://github.com/microsoft/vscode-jupyter/pull/16214)
+
+Contributions to `vscode-mypy`:
+
+* [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): fix: address dev-dependency issues reported by `npm audit` [PR #327](https://github.com/microsoft/vscode-mypy/pull/327)
+* [@taesungh (Taesung Hwang)](https://github.com/taesungh): Use global settings for `ignorePatterns` default [PR #325](https://github.com/microsoft/vscode-mypy/pull/325)
+
+Contributions to `vscode-python-debugger`:
+
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo)
+  * Update debugpy_info for v1.8.8 [PR #500](https://github.com/microsoft/vscode-python-debugger/pull/500)
+  * Update debugpy version to 1.8.9 [PR #505](https://github.com/microsoft/vscode-python-debugger/pull/505)
+
+Contributions to `vscode-python-tools-extension-template`:
+
+* [@oliversen (Oliver Olsen)](https://github.com/oliversen)
+  * Exclude `.dist-info` directories from extension package [PR #215](https://github.com/microsoft/vscode-python-tools-extension-template/pull/215)
+  * Fix glob pattern for `.pyc` files in `.vscodeignore` [PR #216](https://github.com/microsoft/vscode-python-tools-extension-template/pull/216)
+  * Remove duplicate code from `noxfile.py` [PR #217](https://github.com/microsoft/vscode-python-tools-extension-template/pull/217)
+
+Contributions to `vscode-test-web`:
+
+* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): VS Code main has moved back to npm, we could catch it [PR #148](https://github.com/microsoft/vscode-test-web/pull/148)
+
+Contributions to `inno-updater`:
+
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): fix: dialog is show when silent is true [PR #29](https://github.com/microsoft/inno-updater/pull/29)
+
+Contributions to `language-server-protocol`:
+
+* [@EwanDubashinski (Ivan Dubashinskii)](https://github.com/EwanDubashinski): Added link to the PL/SQL language server [PR #2057](https://github.com/microsoft/language-server-protocol/pull/2057)
+* [@gquerret (Gilles Querret)](https://github.com/gquerret): Add OpenEdge ABL in language servers list [PR #2056](https://github.com/microsoft/language-server-protocol/pull/2056)
+* [@orbitalquark](https://github.com/orbitalquark): Added link to client implementation for Textadept. [PR #2058](https://github.com/microsoft/language-server-protocol/pull/2058)
+
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_96.md
+++ b/docs/release-notes/v1_96.md
@@ -1,221 +1,221 @@
 ---
 Order: 105
-TOCTitle: November 2024
-PageTitle: Visual Studio Code November 2024
-MetaDescription: Learn what is new in the Visual Studio Code November 2024 Release (1.96)
+TOCTitle: 2024 年 11 月
+PageTitle: Visual Studio Code 2024 年 11 月
+MetaDescription: Visual Studio Code 2024 年 11 月リリース (1.96) の新機能について学びます
 MetaSocialImage: 1_96/release-highlights.png
 Date: 2024-12-11
 DownloadVersion: 1.96.0
 ---
-# November 2024 (version 1.96)
+# 2024 年 11 月 (バージョン 1.96)
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the November 2024 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2024 年 11 月リリースへようこそ。このバージョンには多くの更新が含まれており、いくつかの主要なハイライトは次のとおりです：
 
-* [Overtype mode](#overtype-mode) - Switch between overwrite or insert mode in the editor
-* [Add imports on paste](#configure-paste-and-drop-behavior) - Automatically add missing TS/JS imports when pasting code
-* [Test coverage](#attributable-coverage) - Quickly filter which code is covered by a specific test
-* [Move views](#move-views-between-primary-and-secondary-side-bar) - Easily move views between the Primary and Secondary Side Bar
-* [Terminal ligatures](#ligature-support) - Use ligatures in the terminal
-* [Extension allow list](#configure-allowed-extensions) - Configure which extensions can be installed in your organization
-* [Debug with Copilot](#debugging-with-copilot) - Use `copilot-debug` terminal command to start a debugging session
-* [Chat context](#add-context) - Add symbols and folders as context Chat and Edits
-* [Move from chat to Copilot Edits](#move-chat-session-to-copilot-edits) - Switch to Copilot Edits to apply code suggestions from Chat
+* [上書きモード](#overtype-mode) - エディターで上書きモードと挿入モードを切り替え
+* [貼り付け時にインポートを追加](#configure-paste-and-drop-behavior) - コードを貼り付けるときに不足している TS/JS インポートを自動的に追加
+* [テストカバレッジ](#attributable-coverage) - 特定のテストによってカバーされているコードをすばやくフィルタリング
+* [ビューの移動](#move-views-between-primary-and-secondary-side-bar) - プライマリおよびセカンダリサイドバー間でビューを簡単に移動
+* [ターミナルのリガチャ](#ligature-support) - ターミナルでリガチャを使用
+* [拡張機能の許可リスト](#configure-allowed-extensions) - 組織内でインストールできる拡張機能を設定
+* [Copilot でデバッグ](#debugging-with-copilot) - `copilot-debug` ターミナルコマンドを使用してデバッグセッションを開始
+* [チャットコンテキスト](#add-context) - シンボルやフォルダーをコンテキストチャットおよび編集として追加
+* [チャットから Copilot Edits への移行](#move-chat-session-to-copilot-edits) - チャットからのコード提案を適用するために Copilot Edits に切り替え
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+>これらのリリースノートをオンラインで読みたい場合は、[Updates](https://code.visualstudio.com/updates) を [code.visualstudio.com](https://code.visualstudio.com) でご覧ください。
+**Insiders:** 新機能をできるだけ早く試してみたいですか？ナイトリー [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新の更新をすぐに試すことができます。
 
-## GitHub Copilot
+## GitHub Copilot {#github-copilot}
 
-### Copilot Edits
+### Copilot Edits {#copilot-edits}
 
-Last milestone, we introduced [Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-edits) (currently in preview), which allows you to quickly edit multiple files at once using natural language. Since then, we've continued to iterate on the experience. You can try out Copilot Edits by opening the Copilot menu in the Command Center, and then selecting Open Copilot Edits, or by triggering `kb(workbench.action.chat.openEditSession)`.
+前回のマイルストーンでは、自然言語を使用して複数のファイルを一度に迅速に編集できる [Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-edits) (現在プレビュー中) を導入しました。それ以来、エクスペリエンスの改善を続けています。Copilot Edits を試すには、コマンドセンターの Copilot メニューを開き、Open Copilot Edits を選択するか、`kb(workbench.action.chat.openEditSession)` をトリガーします。
 
-#### Progress and editor controls
+#### 進行状況とエディターコントロール {#progress-and-editor-controls}
 
-Copilot Edits can make multiple changes across different files. You can now more clearly see its progress as edits stream in. And with the editor overlay controls, you can easily cycle through all changes and accept or discard them.
+Copilot Edits は異なるファイルに複数の変更を加えることができます。編集がストリーミングされると、その進行状況がより明確に表示されるようになりました。また、エディターオーバーレイコントロールを使用して、すべての変更を簡単にサイクルし、それらを受け入れるか破棄することができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/chat-edits.mp4" title="Copilot Edits changing a file" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/chat-edits.mp4" title="Copilot Edits がファイルを変更する様子" autoplay loop controls muted></video>
 
-#### Move chat session to Copilot Edits
+#### チャットセッションを Copilot Edits に移動 {#move-chat-session-to-copilot-edits}
 
-You might use the Chat view to explore some ideas for making changes to your code. Instead of applying individual code blocks, you can now move the chat session to Copilot Edits to apply all code suggestions from the session.
+チャットビューを使用して、コードの変更に関するアイデアを探ることができます。個々のコードブロックを適用する代わりに、チャットセッションを Copilot Edits に移動して、セッションからのすべてのコード提案を適用できます。
 
-![Edit with Copilot showing for a chat exchange.](https://code.visualstudio.com/assets/updates/1_96/chat-move.png)
+![チャット交換のために表示される Copilot で編集](https://code.visualstudio.com/assets/updates/1_96/chat-move.png)
 
-#### Working set suggested files
+#### 作業セットの推奨ファイル {#working-set-suggested-files}
 
-In Copilot Edits, the working set determines the files that Copilot Edits can suggest changes for. To help you add relevant files to the working set, for a Git repo, Copilot Edits can now suggest additional files based on the files you've already added. For example, Copilot Edits will suggest files that are often changed together with the files you've already added.
+Copilot Edits では、作業セットが Copilot Edits が変更を提案できるファイルを決定します。Git リポジトリの場合、Copilot Edits は既に追加したファイルに基づいて追加のファイルを提案できるようになりました。たとえば、Copilot Edits は、既に追加したファイルと一緒に変更されることが多いファイルを提案します。
 
-Copilot shows suggested files alongside the **Add Files** button in the working set. You can also select **Add Files** and then select **Related Files** to choose from a list of suggested files.
+Copilot は作業セットの **Add Files** ボタンの横に推奨ファイルを表示します。また、**Add Files** を選択し、**Related Files** を選択して、推奨ファイルのリストから選択することもできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/working-set-suggested-files.mp4" title="Add suggested files to Copilot Edits working set." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/working-set-suggested-files.mp4" title="Copilot Edits 作業セットに推奨ファイルを追加する" autoplay loop controls muted></video>
 
-#### Restore Edit sessions after restart
+#### 再起動後の編集セッションの復元 {#restore-edit-sessions-after-restart}
 
-Edit sessions are now fully restored after restarting VS Code. This includes the working set, acceptance state, as well as the file state of all past edit steps.
+編集セッションは、VS Code を再起動した後に完全に復元されます。これには、作業セット、受け入れ状態、およびすべての過去の編集ステップのファイル状態が含まれます。
 
-#### Add to working set from Explorer, Search, and editor
+#### エクスプローラー、検索、およびエディターから作業セットに追加 {#add-files-from-explorer-search-and-editor}
 
-You can add files to your Copilot Edits working set with the new **Add File to Copilot Edits** context menu action for search results in the Search view and for files in the Explorer view. Additionally, you can also attach a text selection to Copilot Edits from the editor context menu.
+検索ビューの検索結果やエクスプローラービューのファイルに対して、新しい **Add File to Copilot Edits** コンテキストメニューアクションを使用して、ファイルを Copilot Edits 作業セットに追加できます。さらに、エディターのコンテキストメニューからテキスト選択を Copilot Edits に添付することもできます。
 
-![Add a file from the explorer view to Copilot Edits](https://code.visualstudio.com/assets/updates/1_96/add-file-to-edits.png)
+![エクスプローラービューからファイルを Copilot Edits に追加](https://code.visualstudio.com/assets/updates/1_96/add-file-to-edits.png)
 
-### Debugging with Copilot
+### Copilot でデバッグ {#debugging-with-copilot}
 
-Configuring debugging can be tricky, especially when you're working with a new project or language. This milestone, we're introducing a new `copilot-debug` terminal command to help you debug your programs using VS Code. You can use it by prefixing the command that you would normally run with `copilot-debug`. For example, if you normally run your program using the command `python foo.py`, you can now run `copilot-debug python foo.py` to start a debugging session.
+新しいプロジェクトや言語で作業しているときに、デバッグの設定は難しい場合があります。このマイルストーンでは、VS Code を使用してプログラムをデバッグするのに役立つ新しい `copilot-debug` ターミナルコマンドを導入しています。通常のコマンドの前に `copilot-debug` を付けて使用できます。たとえば、通常は `python foo.py` コマンドを使用してプログラムを実行する場合、`copilot-debug python foo.py` を実行してデバッグセッションを開始できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/copilot-debug.mp4" title="Use the copilot-debug command to debug a Go program." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/copilot-debug.mp4" title="Go プログラムをデバッグするために copilot-debug コマンドを使用する" autoplay loop controls muted></video>
 
-After your program exits, you are given options to rerun your program or to view, save, or regenerate the VS Code [launch configuration](https://code.visualstudio.com/docs/editor//debugging#launch-configurations) that was used to debug your program.
+プログラムが終了した後、プログラムを再実行するか、使用された VS Code [launch configuration](https://code.visualstudio.com/docs/editor//debugging#launch-configurations) を表示、保存、または再生成するオプションが表示されます。
 
-![The terminal shows options to rerun, regenerate, save, or the launch config after a debugging session.](https://code.visualstudio.com/assets/updates/1_96/copilot-debug.png)
-_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+![デバッグセッション後に再実行、再生成、保存、または起動構成のオプションを表示するターミナル](https://code.visualstudio.com/assets/updates/1_96/copilot-debug.png)
+_テーマ: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) ([vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong) でプレビュー)_
 
-#### Tasks Support
+#### タスクサポート {#task-support}
 
-Copilot's debugging features, including `copilot-debug` and the `/startDebugging` intent, now generate `preLaunchTask`s as needed for code that needs a compilation step before debugging. This is often the case for compiled languages, such as Rust and C++.
+Copilot のデバッグ機能には、`copilot-debug` および `/startDebugging` インテントが含まれており、デバッグ前にコンパイルステップが必要なコードのために `preLaunchTask` を生成します。これは、Rust や C++ などのコンパイル言語の場合によくあります。
 
-### Add Context
+### コンテキストの追加 {#add-context}
 
-We’ve added new ways to include symbols and folders as context in Copilot Chat and Copilot Edits, making it easier to reference relevant information during your workflow.
+Copilot Chat および Copilot Edits にシンボルやフォルダーをコンテキストとして含める新しい方法を追加しました。これにより、ワークフロー中に関連情報を参照しやすくなります。
 
-#### Symbols
+#### シンボル {#symbols}
 
-Symbols can now easily be added to Copilot Chat and Copilot Edits by dragging and dropping them from the Outline View or Breadcrumbs into the Chat view.
+シンボルは、アウトラインビューやブレッドクラムからチャットビューにドラッグアンドドロップすることで、簡単に Copilot Chat および Copilot Edits に追加できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_dnd.mp4" title="Dragging and dropping symbols from the outline view and editor breadcrumbs into copilot chat" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_dnd.mp4" title="アウトラインビューとエディターブレッドクラムからシンボルをドラッグアンドドロップして copilot チャットに追加する" autoplay loop controls muted></video>
 
-We’ve also introduced symbol completion in the chat input. By typing `#` followed by the symbol name, you’ll see suggestions for symbols from files you've recently worked on.
+また、チャット入力でシンボル補完を導入しました。`#` に続けてシンボル名を入力すると、最近作業したファイルからのシンボルの提案が表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_completion.mp4" title="After typing # completions show for files and symbols and further typing enables to filter down the completion items" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_completion.mp4" title="`#` を入力するとファイルとシンボルの補完が表示され、さらに入力すると補完アイテムが絞り込まれる" autoplay loop controls muted></video>
 
-To reference symbols across your entire project, you can use `#sym` to open a global symbols picker.
+プロジェクト全体のシンボルを参照するには、`#sym` を使用してグローバルシンボルピッカーを開くことができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_sym.mp4" title="Writing #sym allows to see the completion item #sym to open a global symbol picker" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_symbols_sym.mp4" title="`#sym` を入力するとグローバルシンボルピッカーを開く補完アイテムが表示される" autoplay loop controls muted></video>
 
-#### Folders
+#### フォルダー {#folders}
 
-Folders can now be added as context by dragging them from the Explorer, Breadcrumbs, or other views into Copilot Chat.
+フォルダーは、エクスプローラー、ブレッドクラム、または他のビューから Copilot Chat にドラッグすることでコンテキストとして追加できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/context_folder_chat.mp4" title="Dragging and dropping the @types folder into copilot chat and asking how to implement a share provider" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_folder_chat.mp4" title="@types フォルダーを copilot チャットにドラッグアンドドロップして共有プロバイダーを実装する方法を尋ねる" autoplay loop controls muted></video>
 
-When a folder is dragged into Copilot Edits, all files within the folder are included in the working set.
+フォルダーが Copilot Edits にドラッグされると、フォルダー内のすべてのファイルが作業セットに含まれます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/context_folder_edits.mp4" title="Dragging and dropping a folder into copilot edits adds all files in the folder to copilot edits" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/context_folder_edits.mp4" title="フォルダーを copilot edits にドラッグアンドドロップすると、フォルダー内のすべてのファイルが copilot edits に追加される" autoplay loop controls muted></video>
 
-### Copilot usage graph
+### Copilot 使用状況グラフ {#copilot-usage-graph}
 
-VS Code extensions can use the VS Code API to [build on the capabilities of Copilot](https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview). You can now see a graph of an extension's Copilot usage in the Runtime Status view. This graph shows the number of chat requests that were made by the extension over the last 30 days.
+VS Code 拡張機能は、VS Code API を使用して [Copilot の機能を拡張](https://code.visualstudio.com/docs/copilot/copilot-extensibility-overview) できます。Runtime Status ビューで拡張機能の Copilot 使用状況のグラフを表示できるようになりました。このグラフは、拡張機能が過去 30 日間に行ったチャットリクエストの数を示しています。
 
-![Copilot usage graph in the Runtime Status view](https://code.visualstudio.com/assets/updates/1_96/copilot-usage-chart.png)
+![Runtime Status ビューの Copilot 使用状況グラフ](https://code.visualstudio.com/assets/updates/1_96/copilot-usage-chart.png)
 
-### Custom instructions for commit message generation
+### コミットメッセージ生成のカスタム指示 {#custom-instructions-for-commit-message-generation}
 
-Copilot can help you generate commit messages based on the changes you've made. This milestone, we added support for custom instructions when generating a commit message. For example, if your commit messages need to follow a specific format, you can describe this in the custom instructions.
+Copilot は、行った変更に基づいてコミットメッセージを生成するのに役立ちます。このマイルストーンでは、コミットメッセージを生成する際のカスタム指示のサポートを追加しました。たとえば、コミットメッセージが特定の形式に従う必要がある場合、カスタム指示にその形式を記述できます。
 
-You can use the `setting(github.copilot.chat.commitMessageGeneration.instructions)` setting to either specify the custom instructions or specify a file from your workspace that contains the custom instructions. These instructions are appended to the prompt that is used to generate the commit message. Get more information on how to [use custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
+`setting(github.copilot.chat.commitMessageGeneration.instructions)` 設定を使用して、カスタム指示を指定するか、ワークスペース内のファイルを指定できます。これらの指示は、コミットメッセージを生成するために使用されるプロンプトに追加されます。カスタム指示の使用方法についての詳細は、[カスタム指示の使用](https://code.visualstudio.com/docs/copilot/copilot-customization) を参照してください。
 
-### Inline Chat
+### インラインチャット {#inline-chat}
 
-This milestone, we have further improved the user experience of Inline Chat: we made the progress reporting more subtle, while streaming in changes squiggles are disabled, and detected commands are rendered more nicely.
+このマイルストーンでは、インラインチャットのユーザーエクスペリエンスをさらに改善しました。進行状況の報告をより控えめにし、変更がストリーミングされる間、波線が無効になり、検出されたコマンドがより見やすくレンダリングされます。
 
-Also, we have continued to improve our pseudo-code detection and now show a hint that you can continue with Inline Chat when a line is mostly natural language. This functionality lets you type pseudo code in the editor, which is then used as a prompt for Inline Chat. You can also trigger this flow by pressing `kb(inlineChat.startWithCurrentLine)`.
+また、擬似コード検出を改善し、行が主に自然言語である場合にインラインチャットを続行できるヒントを表示するようになりました。この機能により、エディターで擬似コードを入力し、それがインラインチャットのプロンプトとして使用されます。このフローは、`kb(inlineChat.startWithCurrentLine)` を押すことでトリガーすることもできます。
 
-![Inline Chat hint for a line that is dominated by natural language.](https://code.visualstudio.com/assets/updates/1_96/inline-chat-nl-hint.png)
+![自然言語が支配的な行に対するインラインチャットのヒント](https://code.visualstudio.com/assets/updates/1_96/inline-chat-nl-hint.png)
 
-Additionally, there is a new, experimental, setting to make an Inline Chat hint appear on empty lines. This setting can be enabled via `setting(inlineChat.lineEmptyHint)`. By default, this setting is disabled.
+さらに、空行にインラインチャットのヒントを表示する新しい実験的な設定があります。この設定は `setting(inlineChat.lineEmptyHint)` を介して有効にできます。デフォルトでは、この設定は無効になっています。
 
-### Terminal Chat
+### ターミナルチャット {#terminal-chat}
 
-Terminal Inline Chat has a fresh coat of paint that brings the look and feel much closer to editor Inline Chat:
+ターミナルインラインチャットは、エディターインラインチャットに非常に近い外観と感触を持つように新しいコートを塗られました：
 
-![Terminal inline chat looks a lot like editor chat now](https://code.visualstudio.com/assets/updates/1_96/copilot-terminal-chat.png)
+![ターミナルインラインチャットは現在エディターチャットと非常に似ています](https://code.visualstudio.com/assets/updates/1_96/copilot-terminal-chat.png)
 
-Here are some other improvements of note that were made:
+ここでは、行われた他の注目すべき改善点をいくつか紹介します：
 
-* The layout and positioning of the widget is improved and generally behaves better
-* There's a model picker
-* The buttons on the bottom are now more consistent
+* ウィジェットのレイアウトと位置が改善され、一般的により良い動作をします
+* モデルピッカーがあります
+* 下部のボタンがより一貫性を持つようになりました
 
-### Performance improvements for `@workspace`
+### `@workspace` のパフォーマンス改善 {#workspace-performance-improvements}
 
-When you use [`@workspace`](https://code.visualstudio.com/docs/copilot/workspace-context) to ask Copilot about your currently opened workspace, we first need to narrow the workspace down into a set of relevant code snippets that we can hand off to Copilot as context. If your workspaces is backed by a GitHub repo, we can find these relevant snippets quickly by using Github code search. However, as the code search index tracks the main branch of your repository, we couldn't rely on it for local changes or when on a branch.
+[`@workspace`](https://code.visualstudio.com/docs/copilot/workspace-context) を使用して現在開いているワークスペースについて Copilot に質問するとき、最初にワークスペースを関連するコードスニペットのセットに絞り込み、それを Copilot にコンテキストとして渡す必要があります。ワークスペースが GitHub リポジトリによってバックアップされている場合、GitHub コード検索を使用してこれらの関連するスニペットを迅速に見つけることができます。ただし、コード検索インデックスはリポジトリのメインブランチを追跡しているため、ローカルの変更やブランチにいる場合には信頼できませんでした。
 
-This milestone, we've worked bring the speed benefits of Github search to branches and pull requests. This means that we now search both the remote index based on your repo's main branch, along with searching any locally changed files. We then merge these results together, giving Copilot a fast and up to date set of snippets to work with. You can read more about [Github code search and how to enable it](https://docs.github.com/en/enterprise-cloud@latest/copilot/github-copilot-enterprise/copilot-chat-in-github/using-github-copilot-chat-in-githubcom#asking-a-question-about-a-specific-repository-file-or-symbol).
+このマイルストーンでは、GitHub 検索の速度向上をブランチやプルリクエストに適用する作業を行いました。これにより、リモートインデックスをリポジトリのメインブランチに基づいて検索し、ローカルで変更されたファイルも検索します。これらの結果を統合し、Copilot に迅速かつ最新のスニペットセットを提供します。詳細については、[GitHub コード検索とその有効化方法](https://docs.github.com/en/enterprise-cloud@latest/copilot/github-copilot-enterprise/copilot-chat-in-github/using-github-copilot-chat-in-githubcom#asking-a-question-about-a-specific-repository-file-or-symbol) を参照してください。
 
-## Accessibility
+## アクセシビリティ {#accessibility}
 
-### Code Action accessibility signals
+### コードアクションのアクセシビリティ信号 {#accessibility-signals-for-code-actions}
 
-Some code actions can take a long time to complete, for example a quick fix that calls an external service to generate image alt text. It might not be obvious when they were triggered or when they're fully applied. Therefore, we added accessibility signals to indicate that a code action was triggered or applied.
+一部のコードアクションは完了するまでに時間がかかる場合があります。たとえば、外部サービスを呼び出して画像の alt テキストを生成するクイックフィックスなどです。これらがトリガーされたときや完全に適用されたときに明確でない場合があります。したがって、コードアクションがトリガーされたことや適用されたことを示すアクセシビリティ信号を追加しました。
 
-You can enable these signals with the `setting(accessibility.signals.codeActionTriggered)` and `setting(accessibility.signals.codeActionApplied)` settings.
+これらの信号は、`setting(accessibility.signals.codeActionTriggered)` および `setting(accessibility.signals.codeActionApplied)` 設定を使用して有効にできます。
 
-### Automatic focus management in the REPL
+### REPL の自動フォーカスマネジメント {#auto-focus-management-for-repl}
 
-We introduced a new setting to improve accessibility when working in the REPL. With `setting(accessibility.replEditor.autoFocusReplExecution)`, you can now specify whether focus remains unchanged (`none`), moves to the input box (`input`), or shifts to the most recently executed cell (`lastExecution`) whenever code is executed. By default, the focus moves to the input box.
+REPL で作業する際のアクセシビリティを向上させるために、新しい設定を導入しました。`setting(accessibility.replEditor.autoFocusReplExecution)` を使用して、コードが実行されるたびにフォーカスが変更されない (`none`)、入力ボックスに移動する (`input`)、または最も最近実行されたセルに移動する (`lastExecution`) かを指定できます。デフォルトでは、フォーカスは入力ボックスに移動します。
 
-## Workbench
+## ワークベンチ {#workbench}
 
-### Improved extension search results
+### 拡張機能の検索結果の改善 {#improved-extension-search-results}
 
-When you search for extensions using free-form text in the Extensions view, installed extensions now appear at the top of the search results. This makes it easier to find and manage your installed extensions when searching through the Marketplace.
+拡張機能ビューでフリーフォームテキストを使用して拡張機能を検索すると、インストールされている拡張機能が検索結果の上部に表示されるようになりました。これにより、マーケットプレイスを検索する際にインストールされている拡張機能を見つけて管理しやすくなります。
 
-![Installed extensions shown at top of search results.](https://code.visualstudio.com/assets/updates/1_96/extension-search-order.png)
+![検索結果の上部に表示されるインストール済みの拡張機能](https://code.visualstudio.com/assets/updates/1_96/extension-search-order.png)
 
-### Download extensions from the Extensions view
+### 拡張機能ビューから拡張機能をダウンロード {#download-extensions-from-extension-view}
 
-You can now download extensions directly from VS Code by using the download action in the context menu of an extension in the Extensions view. This can be useful if you want to download an extension without installing it.
+VS Code から直接拡張機能をダウンロードできるようになりました。拡張機能ビューの拡張機能のコンテキストメニューでダウンロードアクションを使用します。これにより、拡張機能をインストールせずにダウンロードすることができます。
 
-![Context menu option to download an extension from the Extensions view.](https://code.visualstudio.com/assets/updates/1_96/extensions-download.png)
+![拡張機能ビューから拡張機能をダウンロードするコンテキストメニューオプション](https://code.visualstudio.com/assets/updates/1_96/extensions-download.png)
 
-### Extension disk space
+### 拡張機能のディスクスペース {#extension-disk-space}
 
-You can now see the memory usage of an extension on disk in the Extensions editor. This can help you understand how much disk space an extension is using.
+拡張機能エディターで拡張機能のディスク上のメモリ使用量を確認できるようになりました。これにより、拡張機能が使用しているディスクスペースの量を理解するのに役立ちます。
 
-![Extension memory usage on disk shown in the Extensions view.](https://code.visualstudio.com/assets/updates/1_96/extension-memory-usage-on-disk.png)
+![拡張機能ビューに表示される拡張機能のディスク上のメモリ使用量](https://code.visualstudio.com/assets/updates/1_96/extension-memory-usage-on-disk.png)
 
-### Find in Explorer improvements
+### エクスプローラーでの検索の改善 {#improved-search-in-explorer}
 
-In the September release, we introduced the ability to find files in the Explorer across the entire project, a capability that was previously unavailable. However, this update temporarily removed highlight mode and limited certain actions.
+9 月のリリースでは、プロジェクト全体でエクスプローラー内のファイルを検索する機能を導入しましたが、この更新によりハイライトモードが一時的に削除され、特定のアクションが制限されました。
 
-In this release, we’re bringing back highlight mode. This feature allows you to easily locate files and folders across your workspace, with matching results highlighted for better visibility. Additionally, we’ve introduced a new visual indicator on collapsed folders, showing if matches are hidden within them.
+このリリースでは、ハイライトモードを復活させました。この機能により、ワークスペース全体のファイルやフォルダーを簡単に見つけることができ、一致する結果が強調表示されて視認性が向上します。さらに、折りたたまれたフォルダーに一致する項目が隠れている場合に新しい視覚的なインジケーターを追加しました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/explorer_find_highlight.mp4" title="Find in the Explorer highlights all matching results and adds a badge to folders indicating the number of matches inside." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/explorer_find_highlight.mp4" title="エクスプローラーでの検索が一致する結果を強調表示し、フォルダーに隠れている一致する項目の数を示すバッジを追加する" autoplay loop controls muted></video>
 
-The filter toggle remains available, enabling you to focus only on files and folders that match your query by hiding non-matching items. We also reenabled all context menu actions we had to disable in a previous release.
+フィルタートグルは引き続き利用可能で、一致する項目以外の項目を非表示にしてクエリに一致するファイルやフォルダーに集中することができます。前のリリースで無効にしたすべてのコンテキストメニューアクションも再度有効にしました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/explorer_find_filter.mp4" title="Find in the Explorer with filter mode enabled shows only the files and folders that match the search term." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/explorer_find_filter.mp4" title="フィルターモードが有効なエクスプローラーでの検索は、検索語に一致するファイルやフォルダーのみを表示する" autoplay loop controls muted></video>
 
-We’ve also improved the user experience when using the find control. When scrolled to the top of the file explorer, additional space is created at the top, ensuring the control doesn’t obstruct your search results.
+検索コントロールを使用する際のユーザーエクスペリエンスも向上させました。ファイルエクスプローラーの上部にスクロールすると、追加のスペースが作成され、コントロールが検索結果を妨げないようにします。
 
-![The find control is rendered above the first file or folder in the explorer when scrolled to the top.](https://code.visualstudio.com/assets/updates/1_96/explorer_find_empty_space.png)
+![エクスプローラーの最初のファイルやフォルダーの上にレンダリングされる検索コントロール](https://code.visualstudio.com/assets/updates/1_96/explorer_find_empty_space.png)
 
-### Move views between Primary and Secondary Side Bar
+### プライマリおよびセカンダリサイドバー間でビューを移動 {#move-views-between-primary-and-secondary-side-bar}
 
-You could already [move a view container](https://code.visualstudio.com/docs/editor/custom-layout#_drag-and-drop-views-and-panels) to another location by using drag and drop or by using the **Move View** command. You can now directly use the Move To context menu action on a view container to move it between the Primary Side Bar, Secondary Side Bar, or Panel area.
+既に [ビューコンテナを移動](https://code.visualstudio.com/docs/editor/custom-layout#_drag-and-drop-views-and-panels) することができましたが、ドラッグアンドドロップや **Move View** コマンドを使用して、ビューコンテナをプライマリサイドバー、セカンダリサイドバー、またはパネルエリアの間で直接移動することができるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/move-views.mp4" title="Move view containers" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/move-views.mp4" title="ビューコンテナを移動" autoplay loop controls muted></video>
 
-### Hide navigation controls in the title area
+### タイトルエリアのナビゲーションコントロールを非表示にする {#hide-navigation-controls-in-title-area}
 
-Some people prefer to keep the title area as clean as possible. We added a new setting `setting(workbench.navigationControl.enabled)` that enables you to hide the back/forward buttons in the title area.
+一部の人々は、タイトルエリアをできるだけクリーンに保つことを好みます。新しい設定 `setting(workbench.navigationControl.enabled)` を追加し、タイトルエリアの戻る/進むボタンを非表示にすることができるようにしました。
 
-You can also access this setting by right-clicking in the title area, and selecting **Navigation Controls**.
+この設定は、タイトルエリアを右クリックし、**Navigation Controls** を選択することでアクセスできます。
 
-![Navigation Controls context menu when right-clicking the VS Code title area.](https://code.visualstudio.com/assets/updates/1_96/nav-controls.png)
+![VS Code タイトルエリアを右クリックしたときのナビゲーションコントロールのコンテキストメニュー](https://code.visualstudio.com/assets/updates/1_96/nav-controls.png)
 
-## Editor
+## エディター {#editor}
 
-### Configure paste and drop behavior
+### 貼り付けおよびドロップの動作を設定する {#configure-paste-and-drop-behavior}
 
-When you drag and drop or copy & paste a file into a text editor, VS Code provides multiple ways to insert it into that file. By default, VS Code tries to insert the file's workspace relative path. Now you can use the drop/paste control to switch how the resource is inserted. Extensions can also provide customized edits, such as in Markdown, which [provides edits that insert Markdown links](https://code.visualstudio.com/updates/v1_67#_markdown-drop-into-editor-to-create-link).
+ファイルをテキストエディターにドラッグアンドドロップまたはコピー＆ペーストすると、VS Code はそのファイルに挿入する方法を複数提供します。デフォルトでは、VS Code はファイルのワークスペース相対パスを挿入しようとします。現在、ドロップ/ペーストコントロールを使用して、リソースの挿入方法を切り替えることができます。拡張機能は、Markdown で [Markdown リンクを挿入する編集を提供する](https://code.visualstudio.com/updates/v1_67#_markdown-drop-into-editor-to-create-link) など、カスタマイズされた編集を提供することもできます。
 
-With the new `setting(editor.pasteAs.preferences)` and `setting(editor.dropIntoEditor.preferences)` settings, you can now specify a preference for which edit type will be used by default. For example, if you'd like copy/paste to always insert the absolute path of pasted files, just set:
+新しい `setting(editor.pasteAs.preferences)` および `setting(editor.dropIntoEditor.preferences)` 設定を使用して、デフォルトで使用される編集タイプの優先順位を指定できるようになりました。たとえば、コピー/ペーストが常に貼り付けられたファイルの絶対パスを挿入するようにするには、次のように設定します：
 
 ```json
 "editor.pasteAs.preferences": [
@@ -223,9 +223,9 @@ With the new `setting(editor.pasteAs.preferences)` and `setting(editor.dropIntoE
 ]
 ```
 
-These settings are ordered lists of edit kinds. The first matching edit of a preferred kind is applied by default. You can still use the drop/paste control to change to a different type of edit after the default edit is applied.
+これらの設定は編集の種類の順序付きリストです。優先される種類の最初の一致する編集がデフォルトで適用されます。デフォルトの編集が適用された後でも、ドロップ/ペーストコントロールを使用して別の種類の編集に変更することができます。
 
-These new settings play nicely with our [new copy and paste with imports support in JavaScript and TypeScript](#paste-with-imports-for-javascript-and-typescript). This feature automatically adds imports when copy and pasting code across JavaScript or TypeScript files. To avoid disrupting your workflows, by default, we decided that paste just inserts plain text and `paste with imports` is offered as an option in the paste control. However, if you'd like VS Code to always try to paste with imports, just set:
+これらの新しい設定は、[JavaScript および TypeScript の新しいコピー＆ペーストとインポートのサポート](#paste-with-imports-for-javascript-and-typescript) とうまく連携します。この機能は、JavaScript または TypeScript ファイル間でコードをコピー＆ペーストするときにインポートを自動的に追加します。ワークフローを中断しないように、デフォルトでは、ペーストはプレーンテキストを挿入し、ペーストコントロールで `paste with imports` オプションが提供されます。ただし、VS Code が常にインポートを使用してペーストするようにしたい場合は、次のように設定します：
 
 ```json
 "editor.pasteAs.preferences": [
@@ -233,9 +233,9 @@ These new settings play nicely with our [new copy and paste with imports support
 ]
 ```
 
-Now, VS Code automatically tries to paste with imports when possible, falling back to pasting plain text if no paste with imports edit is available. Right now, this only works for JavaScript and TypeScript, but we hope additional languages will adopt support over time.
+これで、VS Code は可能な場合に自動的にインポートを使用してペーストし、`paste with imports` 編集が利用できない場合はプレーンテキストのペーストにフォールバックします。現在、これは JavaScript および TypeScript にのみ対応していますが、将来的には他の言語もサポートすることを期待しています。
 
-Finally, you can now also specify a preferred paste style when setting up a `editor.action.pasteAs` keybinding. The keybinding below will always try pasting and updating imports:
+最後に、`editor.action.pasteAs` キーバインディングを設定するときに、優先するペーストスタイルを指定できるようになりました。次のキーバインディングは、常にインポートを更新してペーストしようとします：
 
 ```json
 {
@@ -249,31 +249,31 @@ Finally, you can now also specify a preferred paste style when setting up a `edi
 }
 ```
 
-### Persist editor find history
+### エディター検索履歴の永続化 {#persist-editor-search-history}
 
-The Find control now can persist the search history across sessions and restores it across VS Code restarts. The search history is stored per workspace and can be disabled via the `setting(editor.find.history)` setting.
+検索コントロールは、セッション間で検索履歴を永続化し、VS Code の再起動後に復元できるようになりました。検索履歴はワークスペースごとに保存され、`setting(editor.find.history)` 設定を使用して無効にすることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/editor-find-history.mp4" title="Demo of the persistence of editor find history" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/editor-find-history.mp4" title="エディター検索履歴の永続化のデモ" autoplay loop controls muted></video>
 
-### Overtype mode
+### 上書きモード {#overtype-mode}
 
-On popular request, we added overtype mode to overwrite text in the editor instead of inserting it when typing. A useful scenario for this is when editing Markdown tables, where you want to keep the table cell boundaries nicely aligned.
+多くのリクエストに応じて、エディターでテキストを挿入する代わりに上書きする上書きモードを追加しました。Markdown テーブルを編集する際に、テーブルセルの境界をきれいに整列させたい場合に便利です。
 
-This mode can be toggled with the command **View: Toggle Overtype/Insert Mode**. When you're in overtype mode, the Status Bar shows an `OVR` indicator. In addition, there is a setting `setting(editor.overtypeOnPaste)`, which determines whether pasting in overtype mode should overwrite or insert. The default behavior is to insert pasted text.
+このモードは、**View: Toggle Overtype/Insert Mode** コマンドで切り替えることができます。上書きモードにいるとき、ステータスバーに `OVR` インジケーターが表示されます。さらに、上書きモードでの貼り付けが上書きまたは挿入されるかを決定する設定 `setting(editor.overtypeOnPaste)` があります。デフォルトの動作は、貼り付けテキストを挿入することです。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/overtype.mp4" title="Overtype mode" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/overtype.mp4" title="上書きモード" autoplay loop controls muted></video>
 
-It is possible to change the cursor style while in overtype mode by using the setting `setting(editor.overtypeCursorStyle)`.
+上書きモード中にカーソルスタイルを変更することも可能です。設定 `setting(editor.overtypeCursorStyle)` を使用します。
 
-## Source Control
+## ソースコントロール {#source-control}
 
-### Git blame information (Experimental)
+### Git blame 情報 (実験的) {#experimental-git-blame-information}
 
-This milestone, we have added experimental support for displaying blame information using editor decorations and a Status Bar item. You can enable this functionality by using the `setting(git.blame.editorDecoration.enabled:true)` and `setting(git.blame.statusBarItem.enabled:true)` settings. You can hover over the blame information to see more commit details.
+このマイルストーンでは、エディターデコレーションとステータスバーアイテムを使用して blame 情報を表示する実験的なサポートを追加しました。この機能は、`setting(git.blame.editorDecoration.enabled:true)` および `setting(git.blame.statusBarItem.enabled:true)` 設定を使用して有効にできます。blame 情報にホバーすると、さらに詳細なコミット情報が表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/git-blame.mp4" title="Show git blame information in editor and Status Bar." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/git-blame.mp4" title="エディターとステータスバーに git blame 情報を表示する" autoplay loop controls muted></video>
 
-You can customize the format of the message that is shown in the editor and in the Status Bar with the `setting(git.blame.editorDecoration.template)` and `setting(git.blame.statusBarItem.template)` settings. You can use variables for the most common information. For example, the following template shows the subject of the commit, the author's name, and the author's date relative to now:
+エディターとステータスバーに表示されるメッセージの形式は、`setting(git.blame.editorDecoration.template)` および `setting(git.blame.statusBarItem.template)` 設定を使用してカスタマイズできます。最も一般的な情報の変数を使用できます。たとえば、次のテンプレートは、コミットの件名、著者の名前、および著者の日付を相対的に表示します：
 
 ```json
 {
@@ -281,121 +281,121 @@ You can customize the format of the message that is shown in the editor and in t
 }
 ```
 
-If you would like to adjust the color of the editor decoration, use the `git.blame.editorDecorationForeground` theme color.
+エディターデコレーションの色を調整したい場合は、`git.blame.editorDecorationForeground` テーマカラーを使用します。
 
-Give this experimental feature a try and let us know what you think.
+この実験的な機能を試して、フィードバックをお寄せください。
 
-### Source Control Graph title actions
+### ソースコントロールグラフのタイトルアクション {#source-control-graph-title-actions}
 
-Based on user feedback, we have brought back the Pull, and Push actions to the Source Control Graph view title bar. These actions are enabled if the current history item reference is shown in the Source Control Graph.
+ユーザーのフィードバックに基づいて、ソースコントロールグラフビューのタイトルバーにプルおよびプッシュアクションを復活させました。これらのアクションは、現在の履歴アイテム参照がソースコントロールグラフに表示されている場合に有効になります。
 
-If you do not want to use these actions, or any other actions from the Source Control Graph view title bar, you can right-click on the title bar and hide them.
+これらのアクションやソースコントロールグラフビューのタイトルバーの他のアクションを使用したくない場合は、タイトルバーを右クリックして非表示にすることができます。
 
-![Source Control Graph title actions and context menu to hide specific items.](https://code.visualstudio.com/assets/updates/1_96/source-control-graph-title-actions.png)
+![ソースコントロールグラフのタイトルアクションと特定の項目を非表示にするコンテキストメニュー](https://code.visualstudio.com/assets/updates/1_96/source-control-graph-title-actions.png)
 
-## Notebooks
+## ノートブック {#notebook}
 
-### Selection highlight across cells
+### セル間の選択ハイライト {#selection-highlight-between-cells}
 
-Selection highlighting is now supported within notebooks, allowing for textual selection based highlights across multiple cells. This is controlled with the preexisting setting `setting(editor.selectionHighlight)`.
+ノートブック内で選択ハイライトがサポートされるようになり、複数のセルにわたるテキスト選択に基づくハイライトが可能になりました。これは、既存の設定 `setting(editor.selectionHighlight)` で制御されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-selection-highlight.mp4" title="Notebook selection highlighting demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-selection-highlight.mp4" title="ノートブックの選択ハイライトのデモ" autoplay loop controls muted></video>
 
-### Multi Cursor: Select All Occurrences of Find Match
+### マルチカーソル：検索一致のすべての出現を選択 {#multi-cursor-select-all-occurrences-of-find-matches}
 
-Notebooks now support the keyboard shortcut for **Select All Occurrences of Find Match**. This can be found with the command id `notebook.selectAllFindMatches` and can be used by default with the keystroke `kb(notebook.selectAllFindMatches)`.
+ノートブックは、**検索一致のすべての出現を選択** のキーボードショートカットをサポートするようになりました。これは、コマンド ID `notebook.selectAllFindMatches` で見つけることができ、デフォルトでは `kb(notebook.selectAllFindMatches)` キーストロークで使用できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-select-all-occurrences.mp4" title="Notebook select all occurrences multicursor demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-select-all-occurrences.mp4" title="ノートブックのすべての出現を選択するマルチカーソルのデモ" autoplay loop controls muted></video>
 
-### Run Cells in Section for Markdown
+### Markdown のセクション内のセルを実行 {#run-cells-in-markdown-section}
 
-Notebooks now have the **Run Cells in Section** action exposed to the cell toolbar of Markdown cells. If the Markdown cell has a header, all cells contained within the section and children sections are executed. If there is no header, this executes all cells in the surrounding section, if possible.
+ノートブックには、Markdown セルのセルツールバーに **Run Cells in Section** アクションが表示されるようになりました。Markdown セルにヘッダーがある場合、セクションおよび子セクション内のすべてのセルが実行されます。ヘッダーがない場合、可能であれば周囲のセクション内のすべてのセルが実行されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-md-toolbar-run-in-section.mp4" title="Notebook run in section from markdown cell toolbar demo" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/notebook-md-toolbar-run-in-section.mp4" title="Markdown セルツールバーからセクション内のセルを実行するノートブックのデモ" autoplay loop controls muted></video>
 
-### Cell execution time verbosity
+### セルの実行時間の詳細表示 {#detailed-display-of-cell-execution-time}
 
-The execution time information within the cell status bar now has an option for increased verbosity. This can be turned on with the setting `setting(notebook.cellExecutionTimeVerbosity)` and is able to display the execution timestamp in addition to the duration.
+セルステータスバー内の実行時間情報には、詳細表示のオプションが追加されました。これは、設定 `setting(notebook.cellExecutionTimeVerbosity)` を使用して有効にでき、実行タイムスタンプと実行時間を表示できます。
 
-![Verbose cell execution time within cell status bar.](https://code.visualstudio.com/assets/updates/1_96/notebook-verbose-execution-time.png)
+![セルステータスバー内の詳細な実行時間](https://code.visualstudio.com/assets/updates/1_96/notebook-verbose-execution-time.png)
 
-## Terminal
+## ターミナル {#terminal}
 
-### Ligature support
+### リガチャサポート {#ligature-support}
 
-Ligatures are now supported in the terminal, regardless of whether [GPU acceleration](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration) is being used. This feature can be turned on with the setting `setting(terminal.integrated.fontLigatures)`:
+リガチャは、[GPU アクセラレーション](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration) が使用されているかどうかに関係なく、ターミナルでサポートされるようになりました。この機能は、設定 `setting(terminal.integrated.fontLigatures)` で有効にできます：
 
-![Fonts that support ligatures like ->, ==>, and so on will now visually look like single characters](https://code.visualstudio.com/assets/updates/1_96/terminal-ligatures.png)
+![リガチャをサポートするフォントは、->、==> などの文字が単一の文字のように視覚的に表示される](https://code.visualstudio.com/assets/updates/1_96/terminal-ligatures.png)
 
-In order to use this feature, make sure you also use a font that supports ligatures `setting(terminal.integrated.fontFamily)`.
+この機能を使用するには、リガチャをサポートするフォント `setting(terminal.integrated.fontFamily)` も使用してください。
 
-### New variables for customizing terminal tabs
+### ターミナルタブのカスタマイズ用の新しい変数 {#new-variables-for-customizing-terminal-tabs}
 
-What text appears in terminal tabs is determines by the `terminal.integrated.tabs.title` and `terminal.integrated.tabs.description` settings which allow the use of a collection of variables. We now support the following new variables:
+ターミナルタブに表示されるテキストは、`terminal.integrated.tabs.title` および `terminal.integrated.tabs.description` 設定によって決定され、さまざまな変数を使用できます。次の新しい変数がサポートされるようになりました：
 
-- `${shellType}` - The detected type of shell that is being used in the terminal. This is similar the default value, but it will not change to `git` for example when running a git command.
-- `${shellCommand}` - The command that is being run in the terminal. This requires [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration).
+- `${shellType}` - ターミナルで使用されているシェルの検出されたタイプ。これはデフォルト値に似ていますが、git コマンドを実行しているときに `git` に変更されません。
+- `${shellCommand}` - ターミナルで実行されているコマンド。これには [シェル統合](https://code.visualstudio.com/docs/terminal/shell-integration) が必要です。
 
   ![alt text](https://code.visualstudio.com/assets/updates/1_96/terminal_shellCommand.png)
-- `${shellPromptInput}` - The command that is being run in the terminal or the current detected prompt input. This requires [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration).
+- `${shellPromptInput}` - ターミナルで実行されているコマンドまたは現在の検出されたプロンプト入力。これには [シェル統合](https://code.visualstudio.com/docs/terminal/shell-integration) が必要です。
 
-  ![Typing "echo hello" in the terminal will show "echo hello|" in the tab when configured](https://code.visualstudio.com/assets/updates/1_96/terminal_shellPromptInput.png)
+  ![ターミナルで "echo hello" を入力すると、タブに "echo hello|" が表示されるように設定されている](https://code.visualstudio.com/assets/updates/1_96/terminal_shellPromptInput.png)
 
-### Run recent command now shows the history source file
+### 最近のコマンドの実行に履歴ソースファイルを表示 {#show-history-source-file-for-run-recent-command}
 
-The [run recent command](https://code.visualstudio.com/docs/terminal/shell-integration#_run-recent-command) shell integration feature now includes full size headers for the source of the command, including the history file where relevant and a convenient button to open it.
+[最近のコマンドの実行](https://code.visualstudio.com/docs/terminal/shell-integration#_run-recent-command) シェル統合機能には、履歴ファイルを含むコマンドのソースのフルサイズヘッダーと、便利なボタンが追加されました。
 
 ![alt text](https://code.visualstudio.com/assets/updates/1_96/terminal-run-recent-command.png)
 
-The default keybinding for this command is `Ctrl+Alt+R`.
+このコマンドのデフォルトのキーバインディングは `Ctrl+Alt+R` です。
 
-### New supported link format
+### 新しいサポートされるリンク形式 {#new-supported-link-format}
 
-Links with the format `/path/to/file.ext, <line>` should now be detected as links in the terminal.
+`/path/to/file.ext, <line>` 形式のリンクは、ターミナルでリンクとして検出されるようになりました。
 
-## Testing
+## テスト {#test}
 
-### Attributable coverage
+### 帰属可能なカバレッジ {#attributable-coverage}
 
-This milestone, we finalized an API that enables extensions to provide coverage on a per-test basis, so you can see exactly what code any given test executed. When attributable coverage is available, a filter button is available in the Test Coverage view, in editor actions, in the Test Coverage toolbar when toggled on (via the **Test: Test Coverage Toolbar** command), or simply by using the **Test: Filter Coverage by Test** command.
+このマイルストーンでは、拡張機能がテストごとにカバレッジを提供できる API を最終化しました。これにより、特定のテストが実行したコードを正確に確認できます。帰属可能なカバレッジが利用可能な場合、テストカバレッジビュー、エディターアクション、テストカバレッジツールバー (**Test: Test Coverage Toolbar** コマンドを使用して切り替え) にフィルターボタンが表示されます。または、**Test: Filter Coverage by Test** コマンドを使用します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/per-test-coverage.mp4" title="Demo of the per-test coverage feature." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/per-test-coverage.mp4" title="テストごとのカバレッジ機能のデモ" autoplay loop controls muted></video>
 
-_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+_テーマ: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) ([vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong) でプレビュー)_
 
-### Reworked inline failure messages
+### インラインエラーメッセージの再設計 {#redesign-of-inline-error-messages}
 
-We reworked test failure messages to be both more eye-catching and less obtrusive. This is particularly useful for busy scenarios, such as in diffs from SCM or Copilot Edits. Selecting the failure message still opens a peek control to show the complete details of the failure.
+テストエラーメッセージをより目立ちやすく、邪魔にならないように再設計しました。これは、SCM や Copilot Edits からの差分など、忙しいシナリオで特に役立ちます。エラーメッセージを選択すると、エラーの詳細を表示するピークコントロールが開きます。
 
-![Image of new test error messages in the editor.](https://code.visualstudio.com/assets/updates/1_96/test-errors.png)
+![エディター内の新しいテストエラーメッセージの画像](https://code.visualstudio.com/assets/updates/1_96/test-errors.png)
 
-### Improvements to the continuous run UI
+### 継続的な実行 UI の改善 {#improvements-to-continuous-execution-ui}
 
-Previously, the global state of continuous test runs, togglable via the "eye" icon in the Test Explorer view, would toggle on or off continuous running with the default set of run profiles.
+以前は、テストエクスプローラービューの "目" アイコンを使用して切り替え可能な継続的なテスト実行のグローバル状態は、デフォルトの実行プロファイルセットで継続的な実行をオンまたはオフに切り替えていました。
 
-We reworked the continuous run UI to include a drop-down menu to turn continuous run on or off individually per-profile. Selecting the indicator toggles the last used set of run profiles on or off.
+継続的な実行 UI を再設計し、プロファイルごとに個別に継続的な実行をオンまたはオフにするドロップダウンメニューを追加しました。インジケーターを選択すると、最後に使用した実行プロファイルセットがオンまたはオフに切り替わります。
 
-## Languages
+## 言語 {#language}
 
-### TypeScript 5.7
+### TypeScript 5.7 {#typescript-5-7}
 
-Our JavaScript and TypeScript support now uses TypeScript 5.7. This major update includes a number of language and tooling improvements, along with important bug fixes and performance optimizations.
+JavaScript および TypeScript のサポートは、TypeScript 5.7 を使用するようになりました。この主要なアップデートには、多くの言語およびツールの改善、重要なバグ修正、およびパフォーマンスの最適化が含まれています。
 
-You can read all about the TypeScript 5.7 release on the [TypeScript blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/). We've also included a few tooling highlights in the following sections.
+TypeScript 5.7 リリースの詳細は、[TypeScript ブログ](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7/) をご覧ください。以下のセクションでは、いくつかのツールのハイライトも紹介しています。
 
-### Paste with imports for JavaScript and TypeScript
+### JavaScript および TypeScript のインポート付きペースト {#paste-with-imports-for-javascript-and-typescript}
 
-Tired of having to add imports after moving code between files? Try the Paste with imports feature for TypeScript 5.7+. Now whenever you copy and paste code between JavaScript or TypeScript, VS Code can add imports for the pasted code.
+コードをファイル間で移動した後にインポートを追加するのにうんざりしていませんか？TypeScript 5.7+ のインポート付きペースト機能を試してみてください。JavaScript または TypeScript 間でコードをコピー＆ペーストするたびに、VS Code がペーストされたコードのインポートを追加できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/jsts-update-imports-paste.mp4" title="Imports are automatically updated when pasting code between files in JS and TS." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/jsts-update-imports-paste.mp4" title="JS および TS でファイル間でコードをペーストするときにインポートが自動的に更新される" autoplay loop controls muted></video>
 
-Notice how not only imports are added, even a new export was added for a local variable that was used in the pasted code!
+ペーストされたコードで使用されたローカル変数の新しいエクスポートも追加されることに注目してください！
 
-While we think this feature is a huge time saver, we also are sensitive to disrupting your existing workflow. That's why, by default, we've kept it so copy and paste always inserts just the pasted text. If a `paste with imports` edit is available, you then see the paste control, which lets you select the `paste with imports` edit.
+この機能は大幅な時間節約になると考えていますが、既存のワークフローを中断することにも敏感です。そのため、デフォルトでは、コピー＆ペーストが常にペーストされたテキストのみを挿入するようにしています。`paste with imports` 編集が利用可能な場合、ペーストコントロールが表示され、`paste with imports` 編集を選択できます。
 
-![Paste control that shows options to insert plain text or paste with imports.](https://code.visualstudio.com/assets/updates/1_96/jsts-paste-widget.png)
+![プレーンテキストを挿入するオプションとインポート付きペーストを表示するペーストコントロール](https://code.visualstudio.com/assets/updates/1_96/jsts-paste-widget.png)
 
-If you prefer always pasting with imports, you can use the new [`editor.pasteAs.preferences` setting](#configure-paste-and-drop-behavior):
+常にインポート付きでペーストすることを好む場合は、新しい [`editor.pasteAs.preferences` 設定](#configure-paste-and-drop-behavior) を使用できます：
 
 ```json
 "editor.pasteAs.preferences": [
@@ -403,9 +403,9 @@ If you prefer always pasting with imports, you can use the new [`editor.pasteAs.
 ]
 ```
 
-This will always try pasting with imports if an edit is available.
+これにより、インポート付きのペースト編集が利用可能な場合は常にインポート付きでペーストしようとします。
 
-You can also setup a keybinding to paste with imports if available:
+インポート付きでペーストするためのキーバインディングを設定することもできます：
 
 ```json
 {
@@ -419,7 +419,7 @@ You can also setup a keybinding to paste with imports if available:
 }
 ```
 
-If you prefer, you can even do the reverse and make paste with imports the default and add a keybinding to paste as plain text:
+逆に、インポート付きのペーストをデフォルトにし、プレーンテキストとしてペーストするためのキーバインディングを追加することもできます：
 
 ```json
 "editor.pasteAs.preferences": [
@@ -439,125 +439,125 @@ If you prefer, you can even do the reverse and make paste with imports the defau
 }
 ```
 
-Finally, if you want to fully disable `paste with imports`, you can use `setting(typescript.updateImportsOnPaste.enabled)` and `setting(javascript.updateImportsOnPaste.enabled)`.
+最後に、`paste with imports` を完全に無効にしたい場合は、`setting(typescript.updateImportsOnPaste.enabled)` および `setting(javascript.updateImportsOnPaste.enabled)` を使用できます。
 
-## Remote Development
+## リモート開発 {#remote-development}
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[リモート開発拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) を使用すると、[Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)、SSH 経由のリモートマシンまたは [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels)、または [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) を使用して、フル機能の開発環境を利用できます。
 
-Highlights include:
+ハイライトには次のものが含まれます：
 
-* `remote-ssh` Copilot chat participant
-* Enhanced session logging
+* `remote-ssh` Copilot チャット参加者
+* セッションログの強化
 
-You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_96.md).
+これらの機能の詳細については、[リモート開発リリースノート](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_96.md) をご覧ください。
 
-## Enterprise support
+## エンタープライズサポート {#enterprise-support}
 
-### Configure allowed extensions
+### 許可された拡張機能を設定する {#configure-allowed-extensions}
 
-You can now control which extensions can be installed in VS Code using the `setting(extensions.allowed)` setting.  This setting allows you to specify allowed or blocked extensions by publisher, specific extensions and versions. If an extension or version is blocked, it will be disabled if already installed. You can specify the following types of extension selectors:
+VS Code でインストールできる拡張機能を `setting(extensions.allowed)` 設定を使用して制御できるようになりました。この設定を使用して、パブリッシャー、特定の拡張機能、およびバージョンごとに許可または禁止された拡張機能を指定できます。拡張機能またはバージョンが禁止されている場合、既にインストールされている場合は無効になります。次の種類の拡張機能セレクターを指定できます：
 
-* Allow or block all extensions from a publisher
-* Allow or block specific extensions
-* Allow specific extension versions
-* Allow specific extension versions and platforms
-* Allow only stable versions of an extension
-* Allow only stable extension versions from a publisher
+* パブリッシャーからのすべての拡張機能を許可または禁止する
+* 特定の拡張機能を許可または禁止する
+* 特定の拡張機能バージョンを許可する
+* 特定の拡張機能バージョンおよびプラットフォームを許可する
+* 拡張機能の安定バージョンのみを許可する
+* パブリッシャーからの安定拡張機能バージョンのみを許可する
 
-The following JSON snippet shows examples of the different setting values:
+次の JSON スニペットは、さまざまな設定値の例を示しています：
 
 ```json
 "extensions.allowed": {
-    // Allow all extensions from the 'microsoft' publisher. If the key does not have a '.', it means it is a publisher ID.
+    // 'microsoft' パブリッシャーからのすべての拡張機能を許可します。キーに '.' が含まれていない場合、それはパブリッシャー ID と見なされます。
     "microsoft": true,
 
-    // Allow all extensions from the 'github' publisher
+    // 'github' パブリッシャーからのすべての拡張機能を許可します
     "github": true,
 
-    // Allow prettier extension
+    // prettier 拡張機能を許可します
     "esbenp.prettier-vscode": true,
 
-    // Do not allow docker extension
+    // docker 拡張機能を許可しません
     "ms-azuretools.vscode-docker": false,
 
-    // Allow only version 3.0.0 of the eslint extension
+    // eslint 拡張機能のバージョン 3.0.0 のみを許可します
     "dbaeumer.vscode-eslint": ["3.0.0"],
 
-    // Allow multiple versions of the figma extension
+    // figma 拡張機能の複数のバージョンを許可します
     "figma.figma-vscode-extension": ["3.0.0", "4.2.3", "4.1.2"]
 
-    // Allow version 5.0.0 of the rust extension on Windows and macOS
+    // Windows および macOS で rust 拡張機能のバージョン 5.0.0 を許可します
     "rust-lang.rust-analyzer": ["5.0.0@win32-x64", "5.0.0@darwin-x64"]
 
-    // Allow only stable versions of the GitHub Pull Requests extension
+    // GitHub Pull Requests 拡張機能の安定バージョンのみを許可します
     "github.vscode-pull-request-github": "stable",
 
-    // Allow only stable versions from redhat publisher
+    // redhat パブリッシャーからの安定バージョンのみを許可します
     "redhat": "stable",
 }
 ```
 
-Specify publishers by their publisher ID. If a key does not have a period (`.`), it is considered a publisher ID. If a key has a period, it is considered an extension ID. The use of wildcards is currently not supported.
+パブリッシャーはそのパブリッシャー ID で指定します。キーにピリオド (`.`) が含まれていない場合、それはパブリッシャー ID と見なされます。キーにピリオドが含まれている場合、それは拡張機能 ID と見なされます。ワイルドカードの使用は現在サポートされていません。
 
-You can use `microsoft` as the publisher ID to refer to all extensions published by Microsoft, even though they might have different publisher IDs.
+`microsoft` をパブリッシャー ID として使用して、Microsoft によって公開されたすべての拡張機能を参照できます。これらの拡張機能は異なるパブリッシャー ID を持っている場合でもです。
 
-Version ranges are not supported. If you want to allow multiple versions of an extension, you must specify each version individually. To further restrict versions by platform, use the `@` symbol to specify the platform. For example, `"rust-lang.rust-analyzer": ["5.0.0@win32-x64", "5.0.0@darwin-x64"]`.  For more details, refer to the [enterprise documentation](https://code.visualstudio.com/docs/setup/enterprise#configure-allowed-extensions).
+バージョン範囲はサポートされていません。複数のバージョンの拡張機能を許可する場合は、各バージョンを個別に指定する必要があります。バージョンをプラットフォームごとにさらに制限するには、`@` 記号を使用してプラットフォームを指定します。たとえば、`"rust-lang.rust-analyzer": ["5.0.0@win32-x64", "5.0.0@darwin-x64"]` のようにします。詳細については、[エンタープライズドキュメント](https://code.visualstudio.com/docs/setup/enterprise#configure-allowed-extensions) を参照してください。
 
-Administrators can also configure this setting via group policy on Windows. For more information, see the [Group Policy on Windows](https://code.visualstudio.com/docs/setup/enterprise#group-policy-on-windows) section in the enterprise documentation.
+管理者は、この設定を Windows のグループポリシーを介して設定することもできます。詳細については、エンタープライズドキュメントの [Windows のグループポリシー](https://code.visualstudio.com/docs/setup/enterprise#group-policy-on-windows) セクションを参照してください。
 
-## Set up VS Code with preinstalled extensions
+## 事前インストールされた拡張機能で VS Code をセットアップする {#setup-vs-code-with-pre-installed-extensions}
 
-You can set up VS Code with a set of preinstalled extensions (*bootstrap*). This functionality is useful in cases where you prepare a machine image, virtual machine, or cloud workstation where VS Code is preinstalled and specific extensions are immediately available for users.
+事前インストールされた拡張機能 (*ブートストラップ*) を使用して VS Code をセットアップできます。この機能は、マシンイメージ、仮想マシン、またはクラウドワークステーションを準備し、VS Code が事前インストールされ、特定の拡張機能がすぐに利用可能な場合に役立ちます。
 
-> **Note**: Support for preinstalling extensions is currently only available on Windows.
+> **注**: 拡張機能の事前インストールのサポートは現在 Windows のみで利用可能です。
 
-Follow these steps to bootstrap extensions:
+次の手順に従って拡張機能をブートストラップします：
 
-1. Create a folder `bootstrap\extensions` in the VS Code installation directory.
+1. VS Code インストールディレクトリに `bootstrap\extensions` フォルダーを作成します。
 
-1. Download the [VSIX files](https://code.visualstudio.com/docs/editor/extension-marketplace#_can-i-download-an-extension-directly-from-the-marketplace) for the extensions that you want to preinstall and place them in the `bootstrap\extensions` folder.
+1. 事前インストールしたい拡張機能の [VSIX ファイル](https://code.visualstudio.com/docs/editor/extension-marketplace#_can-i-download-an-extension-directly-from-the-marketplace) をダウンロードし、`bootstrap\extensions` フォルダーに配置します。
 
-1. When a user launches VS Code for the first time, all extensions in the `bootstrap\extensions` folder are installed silently in the background.
+1. ユーザーが VS Code を初めて起動すると、`bootstrap\extensions` フォルダー内のすべての拡張機能がバックグラウンドでサイレントにインストールされます。
 
-Users can still uninstall extensions that were preinstalled. Restarting VS Code after uninstalling an extension will not reinstall the extension.
+ユーザーは事前インストールされた拡張機能をアンインストールすることができます。拡張機能をアンインストールした後に VS Code を再起動しても、拡張機能は再インストールされません。
 
-## Contributions to extensions
+## 拡張機能への貢献 {#contributing-to-extensions}
 
-### Python
+### Python {#python}
 
-#### Python Environments extension
+#### Python Environments 拡張機能 {#python-environments-extension}
 
-In this release we are introducing the Python Environments extension, now available in preview on the Marketplace.
+このリリースでは、Python Environments 拡張機能を導入しており、現在プレビュー版がマーケットプレイスで利用可能です。
 
-This extension simplifies Python environment management, offering a UI to create, delete, and manage environments, along with package management for installing and uninstalling packages.
+この拡張機能は、Python 環境の管理を簡素化し、環境の作成、削除、および管理のための UI を提供し、パッケージ管理のためのインストールおよびアンインストール機能を提供します。
 
-Designed to integrate seamlessly with your preferred environment managers via various APIs, it supports Global Python interpreters, venv, and Conda by default. Developers can build extensions to add support for their favorite Python environment managers and integrate with our extension UI, enhancing functionality and user experience.
+さまざまな API を介して好みの環境マネージャーとシームレスに統合するように設計されており、デフォルトでグローバル Python インタープリター、venv、および Conda をサポートします。開発者は、拡張機能を構築して、お気に入りの Python 環境マネージャーのサポートを追加し、拡張機能の UI と統合して機能とユーザーエクスペリエンスを向上させることができます。
 
-You can download the Python Environments in the Marketplace, and use it with the pre-release version of the Python extension.
+Python Environments をマーケットプレイスでダウンロードし、Python 拡張機能のプレリリースバージョンと一緒に使用できます。
 
-#### Python testing enhancements
+#### Python テストの強化 {#enhancements-to-python-testing}
 
-* The `--rootdir` argument for pytest is now dynamically adjusted based on the presence of a `python.testing.cwd` setting in your workspace.
-* Restarting a test debugging session now reruns only the specified tests.
-* Coverage support updated to handle `NoSource` exceptions.
-* `pytest-describe` plugin is supported with test detection and execution in the UI.
-* Testing Rewrite now leverages FIFO instead of UDS for interprocess communication allowing users to harness pytest plugins like `pytest_socket` in their own testing design.
-* **Rewrite Nearing Default Status:** This release addresses [the final known issue](https://github.com/microsoft/vscode-python/issues/23279) in the testing rewrite, and unless further issues arrive, the rewrite experiment will be turned off and the rewrite set to default in early 2025.
+* pytest の `--rootdir` 引数は、ワークスペースに `python.testing.cwd` 設定が存在するかどうかに基づいて動的に調整されるようになりました。
+* テストデバッグセッションの再起動は、指定されたテストのみを再実行します。
+* カバレッジサポートが `NoSource` 例外を処理するように更新されました。
+* `pytest-describe` プラグインは、テストの検出と UI での実行をサポートします。
+* テストのリライトは、デバッグ前にコンパイルステップが必要なコードのために `preLaunchTask` を生成します。これは、Rust や C++ などのコンパイル言語の場合によくあります。
+* **リライトがデフォルトステータスに近づいています**：このリリースでは、テストのリライトの最後の既知の問題を解決し、さらなる問題が発生しない限り、リライト実験をオフにし、2025 年初頭にリライトをデフォルトに設定します。
 
-#### Python REPL enhancements
+#### Python REPL の強化 {#enhancements-to-python-repl}
 
-* Leave focus on editor after smart-send to Native REPL
-* Improved handling after reload for Native REPL
-* Fix indentation error issues with Python 3.13 in VS Code terminal
+* ネイティブ REPL へのスマート送信後にエディターにフォーカスを残す
+* ネイティブ REPL のリロード後の処理を改善
+* VS Code ターミナルでの Python 3.13 のインデントエラーの問題を修正
 
-#### Pylance "full" language server mode
+#### Pylance の "full" 言語サーバーモード {#full-language-server-mode-for-pylance}
 
-The `python.analysis.languageServerMode` setting now also supports `full` mode, enabling you to take advantage of the complete range of Pylance's functionality and the most comprehensive IntelliSense experience. It's worth noting that this comes at the cost of lower performance, as it can cause Pylance to be resource-intensive, particularly in large codebases.
+`python.analysis.languageServerMode` 設定は、`full` モードもサポートするようになり、Pylance の完全な機能と最も包括的な IntelliSense エクスペリエンスを活用できます。これには、特に大規模なコードベースでリソースを多く消費するため、パフォーマンスが低下するという代償が伴います。
 
-The `python.analysis.languageServerMode` setting now changes the default values of the following settings, depending on whether it's set to `light`, `default` or `full`:
+`python.analysis.languageServerMode` 設定は、`light`、`default`、または `full` に設定されているかどうかに応じて、次の設定のデフォルト値を変更します：
 
-| Setting                                                | light    | default | full |
+| 設定                                                | light    | default | full |
 |--------------------------------------------------------|----------|---------|------|
 | python.analysis.exclude                                | \["**"\] | []      | []   |
 | python.analysis.useLibraryCodeForTypes                 | false    | true    | true |
@@ -574,57 +574,57 @@ The `python.analysis.languageServerMode` setting now changes the default values 
 | python.analysis.supportRestructuredText                | false    | false   | true |
 | python.analysis.supportDocstringTemplate               | false    | false   | true |
 
-### TypeScript
+### TypeScript {#typescript}
 
-#### TypeScript expandable hover (Experimental)
+#### TypeScript 拡張可能なホバー (実験的) {#experimental-expandable-hover-for-typescript}
 
-This milestone, we made it possible to view expanded/contracted information from the TS server. The extension uses the Expandable Hover API to show `+` and `-` markers in the editor hover to display more or less information.
+このマイルストーンでは、TS サーバーからの情報を展開/縮小して表示できるようにしました。拡張機能は、エディターホバーに `+` および `-` マーカーを表示して、情報を表示または非表示にするために Expandable Hover API を使用します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_96/expandable-hover.mp4" title="TypeScript Expandable Hover" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_96/expandable-hover.mp4" title="TypeScript 拡張可能なホバー" autoplay loop controls muted></video>
 
-The experimental setting can be enabled using `setting(typescript.experimental.expandableHover)`. For this setting to work, you must be on TypeScript version 5.8 or above. You can change the TypeScript version by using the `TypeScript: Select TypeScript Version...` command.
+実験的な設定は `setting(typescript.experimental.expandableHover)` を使用して有効にできます。この設定を機能させるには、TypeScript バージョン 5.8 以上を使用する必要があります。TypeScript バージョンを変更するには、`TypeScript: Select TypeScript Version...` コマンドを使用します。
 
-### Microsoft Account now uses MSAL (with WAM support on Windows)
+### Microsoft アカウントは MSAL を使用するようになりました (Windows で WAM サポート) {#microsoft-account-uses-msal}
 
-In order to ensure a strong security baseline for Microsoft authentication, we've adopted the [Microsoft Authentication Library](https://github.com/AzureAD/microsoft-authentication-library-for-js) in the Microsoft Account extension.
+Microsoft 認証の強力なセキュリティベースラインを確保するために、Microsoft アカウント拡張機能で [Microsoft Authentication Library](https://github.com/AzureAD/microsoft-authentication-library-for-js) を採用しました。
 
-One of the stand out features of this work is WAM (Web Account Manager... also known as [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) integration. Put simply, rather than going to the browser for Microsoft authentication flows, we now talk to the OS directly, which is the recommended way of acquiring a Microsoft authentication session. Additionally, it's faster since we're able to leverage the accounts that you're already logged into on the OS.
+この作業の注目すべき機能の 1 つは WAM (Web Account Manager... 別名 [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) 統合です。簡単に言えば、Microsoft 認証フローのためにブラウザに移動する代わりに、OS に直接話しかけることができ、これは Microsoft 認証セッションを取得するための推奨方法です。さらに、OS に既にログインしているアカウントを活用できるため、より高速です。
 
-![An authentication popup that the OS shows over VS Code.](https://code.visualstudio.com/assets/updates/1_96/showingBrokerOSDialog.png)
+![VS Code 上に表示される OS の認証ポップアップ](https://code.visualstudio.com/assets/updates/1_96/showingBrokerOSDialog.png)
 
-Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
+この新しいフローに問題がある場合はお知らせください。重大な問題が発生し、古い Microsoft 認証の動作に戻す必要がある場合は、`setting(microsoft-authentication.implementation)` を使用して (それを `classic` に設定し、VS Code を再起動します) できますが、この設定は長くは続かないことに注意してください。したがって、MSAL フローに問題がある場合は、問題を報告してください。
 
-## Extension Authoring
+## 拡張機能の作成 {#creating-extensions}
 
-### @vscode/chat-extension-utils
+### @vscode/chat-extension-utils {#vscode-chat-extension-utils}
 
-We've had our [chat](https://code.visualstudio.com/api/references/vscode-api#chat) and [language model](https://code.visualstudio.com/api/references/vscode-api#lm) extension APIs available for several months to let extension authors integrate with GitHub Copilot. But we've found that working with LLMs and building high-quality chat extensions is inherently complex, especially if you want to make use of tool calling.
+拡張機能の作成者が GitHub Copilot と統合するための [チャット](https://code.visualstudio.com/api/references/vscode-api#chat) および [言語モデル](https://code.visualstudio.com/api/references/vscode-api#lm) 拡張 API を数か月間提供してきました。しかし、LLM を使用して高品質のチャット拡張機能を構築することは本質的に複雑であり、特にツールコールを使用する場合はそうです。
 
-We've published an npm package, `@vscode/chat-extension-utils`, that aims to make it as easy as possible to get a chat participant up and running. It takes over several things that you would otherwise have to do yourself, so that your chat participant can be implemented in a just a few lines of code. The package also contains a collection of useful, high-quality elements to use with [@vscode/prompt-tsx](https://github.com/microsoft/vscode-prompt-tsx).
+拡張機能の作成者がチャット参加者をできるだけ簡単に立ち上げて実行できるようにすることを目的とした npm パッケージ `@vscode/chat-extension-utils` を公開しました。このパッケージは、他の方法で自分で行う必要があるいくつかのことを引き受けるため、数行のコードでチャット参加者を実装できます。このパッケージには、[@vscode/prompt-tsx](https://github.com/microsoft/vscode-prompt-tsx) で使用するための便利で高品質な要素のコレクションも含まれています。
 
-You can view the full documentation in the [`chat-extension-utils` repository](https://github.com/microsoft/vscode-chat-extension-utils/blob/main/README.md) and see it in action in the [sample chat extension](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample). Our new [LanguageModelTool API docs](https://code.visualstudio.com/api/extension-guides/tools) also describe how to use it.
+完全なドキュメントは [`chat-extension-utils` リポジトリ](https://github.com/microsoft/vscode-chat-extension-utils/blob/main/README.md) で確認でき、[サンプルチャット拡張機能](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample) で実際に動作している様子を見ることができます。新しい [LanguageModelTool API ドキュメント](https://code.visualstudio.com/api/extension-guides/tools) では、その使用方法についても説明しています。
 
-### Attributable Coverage API
+### 帰属可能なカバレッジ API {#attributable-coverage-api}
 
-The test coverage APIs now enable extensions to provide coverage information on a per-test basis. To implement this API, populate the the `includesTests?: TestItem[]` property on the `FileCoverage` to indicate which tests executed code in that file, and implement `TestRunProfile.loadDetailedCoverageForTest` to provide statement and declaration coverage.
+テストカバレッジ API は、拡張機能がテストごとにカバレッジ情報を提供できるようになりました。この API を実装するには、`FileCoverage` の `includesTests?: TestItem[]` プロパティを設定して、そのファイルでコードを実行したテストを示し、`TestRunProfile.loadDetailedCoverageForTest` を実装してステートメントおよび宣言カバレッジを提供します。
 
-See the [Attributable Coverage section above](#attributable-coverage) for an example of what this looks like for users.
+ユーザーにとっての例については、[上記の帰属可能なカバレッジセクション](#attributable-coverage) を参照してください。
 
-### Contributing to a JavaScript Debug Terminal
+### JavaScript デバッグターミナルへの貢献 {#contributing-to-javascript-debug-terminal}
 
-The JavaScript debugger now has a mechanism for other extensions to participate in the creation of JavaScript Debug Terminals. This enables frameworks, or runtimes aside from Node.js, to enable debugging in the same familiar place. Refer to the [JavaScript Debugger documentation](https://github.com/microsoft/vscode-js-debug/blob/main/EXTENSION_AUTHORS.md#extension-api) for more information.
+JavaScript デバッガーには、他の拡張機能が JavaScript デバッグターミナルの作成に参加できるメカニズムがあります。これにより、フレームワークや Node.js 以外のランタイムが同じおなじみの場所でデバッグを有効にできます。詳細については、[JavaScript デバッガードキュメント](https://github.com/microsoft/vscode-js-debug/blob/main/EXTENSION_AUTHORS.md#extension-api) を参照してください。
 
-### Proxy support for Node.js `fetch` API
+### Node.js `fetch` API のプロキシサポート {#proxy-support-for-nodejs-fetch-api}
 
-The global `fetch` function now comes with proxy support enabled (`setting(http.fetchAdditionalSupport)`). This is similar to the `https` module, which already had proxy support.
+グローバル `fetch` 関数には、プロキシサポートが有効になりました (`setting(http.fetchAdditionalSupport)`)。これは、すでにプロキシサポートがあった `https` モジュールに似ています。
 
-## Preview Features
+## プレビュー機能 {#preview-features}
 
-### Paste code to attach chat context
+### チャットコンテキストにコードを貼り付ける {#paste-code-into-chat-context}
 
-Previously, you could already attach files as context to Copilot Chat. For more fine-grained control over the context, you can now paste a code fragment to attach it as context for chat. This adds the necessary file information and corresponding line numbers. You can only paste code coming from files in the current workspace.
+以前は、ファイルをコンテキストとして Copilot Chat に添付することができました。コンテキストをより細かく制御するために、コードフラグメントを貼り付けてチャットのコンテキストとして添付できるようになりました。これにより、必要なファイル情報と対応する行番号が追加されます。現在のワークスペース内のファイルからのコードのみを貼り付けることができます。
 
-To try this out, copy some code and paste it in Inline Chat, Quick Chat, or the Chat view. Select the paste control that shows up and select `Pasted Code Attachment.` Alternatively, you can set the `setting(editor.pasteAs.preferences)` setting:
+これを試すには、いくつかのコードをコピーして、インラインチャット、クイックチャット、またはチャットビューに貼り付けます。表示されるペーストコントロールを選択し、`Pasted Code Attachment` を選択します。代わりに、`setting(editor.pasteAs.preferences)` 設定を使用することもできます：
 
 ```json
 "editor.pasteAs.preferences": [
@@ -632,210 +632,209 @@ To try this out, copy some code and paste it in Inline Chat, Quick Chat, or the 
 ]
 ```
 
-![Attaching code as context in Copilot Chat using the paste control.](https://code.visualstudio.com/assets/updates/1_96/paste-code-context.gif)
+![ペーストコントロールを使用して Copilot Chat にコードをコンテキストとして添付する](https://code.visualstudio.com/assets/updates/1_96/paste-code-context.gif)
 
-### Terminal completions for more shells
+### より多くのシェルのターミナル補完 {#terminal-completions-for-more-shells}
 
-We added experimental support for terminal completions in `pwsh` in prior iterations. This release, we have started working on expanding this to other shells. Specifically targeting `bash` and `zsh` for now, but since this new approach is powered by an extension host API, we plan on having general support for most shells.
+以前のイテレーションで `pwsh` のターミナル補完の実験的サポートを追加しました。このリリースでは、これを他のシェルに拡張する作業を開始しました。現在は `bash` および `zsh` を対象としていますが、この新しいアプローチは拡張ホスト API によってサポートされているため、ほとんどのシェルに対して一般的なサポートを提供する予定です。
 
-You can try out the current work in progress by setting `setting(terminal.integrated.suggest.enabled)` and
-`setting(terminal.integrated.suggest.enableExtensionCompletions)`. Currently only `cd`, `code`, and `code-insiders` arguments are supported.
+現在の作業を試すには、`setting(terminal.integrated.suggest.enabled)` および `setting(terminal.integrated.suggest.enableExtensionCompletions)` を設定します。現在は `cd`、`code`、および `code-insiders` の引数のみがサポートされています。
 
-![The command `code` is typed on the terminal, which shows suggestions. Then `--` is typed and options are provided, `--locale` is selected. Completions are requested with ctrl+space and all locales are shown. `e` is typed and the list is filtered to `en` and `es`.](https://code.visualstudio.com/assets/updates/1_96/terminal-completions.gif)
+![ターミナルで `code` コマンドを入力すると、補完が表示されます。次に `--` を入力するとオプションが表示され、`--locale` が選択されます。ctrl+space を押して補完を要求すると、すべてのロケールが表示されます。`e` を入力するとリストが `en` と `es` に絞り込まれます。](https://code.visualstudio.com/assets/updates/1_96/terminal-completions.gif)
 
-## Proposed APIs
+## 提案された API {#proposed-api}
 
-### Proposed Value Selection API on Quick Pick
+### Quick Pick の提案された値選択 API {#proposed-value-selection-api-for-quick-pick}
 
-For `InputBox` you have been able to set the "value selection", which enables you to programmatically select part or all of the input. This milestone, we added a proposed API for value selection in a QuickPick.
+`InputBox` では、プログラムで入力の一部または全体を選択できる "値選択" を設定できました。このマイルストーンでは、QuickPick での値選択の提案された API を追加しました。
 
-Here's an example of what that might look like:
+これがどのように見えるかの例を次に示します：
 
 ```ts
 const qp = vscode.window.createQuickPick();
 qp.value = '12345678';
 qp.valueSelection = [4, 6];
 qp.items = [
-	{ label: '12345678', description: 'desc 1' },
-	{ label: '12345678', description: 'desc 2' },
-	{ label: '12345678', description: 'desc 3' },
+    { label: '12345678', description: 'desc 1' },
+    { label: '12345678', description: 'desc 2' },
+    { label: '12345678', description: 'desc 3' },
 ];
 qp.show();
 ```
 
-![A couple of characters are selected in the quick pick's input box.](https://code.visualstudio.com/assets/updates/1_96/valueSelectionQuickPick.png)
+![Quick Pick の入力ボックスでいくつかの文字が選択されている](https://code.visualstudio.com/assets/updates/1_96/valueSelectionQuickPick.png)
 
-Try out the [valueSelectionInQuickPick proposal](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.valueSelectionInQuickPick.d.ts) and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/233274)!
+[valueSelectionInQuickPick 提案](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.valueSelectionInQuickPick.d.ts) を試してみて、[この GitHub issue](https://github.com/microsoft/vscode/issues/233274) でフィードバックをお寄せください！
 
-### Proposed Native Window Handle API
+### 提案されたネイティブウィンドウハンドル API {#proposed-native-window-handle-api}
 
-This milestone, we added a new proposed API to retrieve the native window handle of the focused window. The native window handle is an OS concept that essentially provides a pointer to a particular window. This is useful if you are interacting with native code and need to, for example, render a native dialog on top of a window.
+このマイルストーンでは、フォーカスされたウィンドウのネイティブウィンドウハンドルを取得するための新しい提案された API を追加しました。ネイティブウィンドウハンドルは、特定のウィンドウへのポインタを提供する OS の概念です。これは、ネイティブコードと対話し、たとえばウィンドウの上にネイティブダイアログをレンダリングする必要がある場合に役立ちます。
 
 ```ts
 declare module 'vscode' {
 
-	export namespace window {
-		/**
-		 * Retrieves the native window handle of the current active window.
-		 * This will be updated when the active window changes.
-		 */
-		export const nativeHandle: Uint8Array | undefined;
-	}
+    export namespace window {
+        /**
+         * 現在アクティブなウィンドウのネイティブウィンドウハンドルを取得します。
+         * これは、アクティブなウィンドウが変更されると更新されます。
+         */
+        export const nativeHandle: Uint8Array | undefined;
+    }
 }
 ```
 
-This was added specifically for Microsoft Authentication's [adoption of MSAL](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md#window-parenting), so that we could pass the native handle down to the OS so it could render an auth dialog overtop VS Code.
+これは、Microsoft Authentication の [MSAL の採用](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md#window-parenting) のために特に追加されました。これにより、ネイティブハンドルを OS に渡して、VS Code の上に認証ダイアログをレンダリングできます。
 
-If you have a use case or feedback for the [nativeWindowHandle proposal](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts), let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/233106)!
+[nativeWindowHandle 提案](https://github.com/microsoft/vscode/blob/008340a55c6391f9b333010951455ee71b338787/src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts) に対するユースケースやフィードバックがある場合は、[この GitHub issue](https://github.com/microsoft/vscode/issues/233106) でお知らせください！
 
-## Engineering
+## エンジニアリング {#engineering}
 
-### Optimized extension updates with vscode-unpkg service
+### vscode-unpkg サービスを使用した拡張機能の更新の最適化 {#optimizing-extension-updates-using-vscode-unpkg-service}
 
-To reduce the load on the Marketplace infrastructure, VS Code now uses the newly added endpoint from the `vscode-unpkg` service to check for extension updates. The service implements server-side caching with a 10-minute TTL, which significantly reduces the number direct requests to the Marketplace. The optimization is controlled via the `setting(extensions.gallery.useUnpkgResourceApi)` setting (enabled by default).
+マーケットプレイスインフラストラクチャへの負荷を軽減するために、VS Code は拡張機能の更新を確認するために `vscode-unpkg` サービスの新しいエンドポイントを使用するようになりました。このサービスは、10 分の TTL でサーバー側のキャッシュを実装しており、マーケットプレイスへの直接リクエストの数を大幅に削減します。この最適化は、`setting(extensions.gallery.useUnpkgResourceApi)` 設定 (デフォルトで有効) によって制御されます。
 
-If you notice issues with extension updates, you can disable this functionality with `setting(extensions.gallery.useUnpkgResourceApi:false)`, and revert back to direct Marketplace version checks.
+拡張機能の更新に問題がある場合は、`setting(extensions.gallery.useUnpkgResourceApi:false)` を使用してこの機能を無効にし、マーケットプレイスのバージョンチェックに直接戻すことができます。
 
-### Ground work for GPU acceleration in the editor
+### エディターでの GPU アクセラレーションの基盤作業 {#foundational-work-for-gpu-acceleration-in-editor}
 
-We are excited to announce that we have started work on enabling GPU acceleration in the editor, [similar to the terminal](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration). The goals of this effort are to improve the overall coding experience primarily by reducing input latency and improving scrolling performance.
+エディターでの GPU アクセラレーションを有効にする作業を開始したことをお知らせします。これは、[ターミナルと同様](https://code.visualstudio.com/docs/terminal/appearance#_gpu-acceleration) です。この取り組みの目標は、主に入力遅延を減らし、スクロールパフォーマンスを向上させることで、全体的なコーディングエクスペリエンスを向上させることです。
 
-This is still early and not ready to test out, but we wanted to share some details about the progress that has been made:
+これはまだ初期段階であり、テストする準備はできていませんが、進捗状況についていくつかの詳細を共有したいと思います：
 
-* The GPU renderer is using WebGPU behind the scenes.
-* We're focusing currently on feature parity and correctness over performance.
-* There's a fallback mechanism when GPU acceleration is enabled that allows lines to "fallback" to DOM rendering when it's not fully supported. This means that we can self-host early on and currently incompatible lines will show using the DOM approach instead. Some examples of lines that currently fallback lines over 200 characters, lines with certain monaco decorations (eg. fading unused variables), lines that wrap, and so on.
-* Monaco's inline decorations which allow styling the actual elements containing the characters posed a big challenge for this feature as they are styled using CSS. The approach we're using to support most inline decorations without breaking or changing API is to detect the CSS attached to these decorations and then support a subset of common CSS properties, falling back if not all styles are supported.
+* GPU レンダラーは、WebGPU を使用しています。
+* 現在は、パフォーマンスよりも機能のパリティと正確性に焦点を当てています。
+* GPU アクセラレーションが有効な場合のフォールバックメカニズムがあり、完全にサポートされていない場合は行が DOM レンダリングにフォールバックします。これにより、初期段階で自己ホストでき、現在互換性のない行は DOM アプローチを使用して表示されます。現在フォールバックする行の例としては、200 文字を超える行、特定のモナコデコレーション (例：未使用の変数のフェード) を持つ行、折り返し行などがあります。
+* モナコのインラインデコレーションは、実際の文字を含む要素をスタイル設定するために CSS を使用しているため、この機能にとって大きな課題でした。これらのデコレーションに添付された CSS を検出し、一般的な CSS プロパティのサブセットをサポートし、すべてのスタイルがサポートされていない場合はフォールバックするアプローチを使用して、ほとんどのインラインデコレーションをサポートすることにしました。
 
-Here's a screenshot of the feature in action, note the yellow line in the gutter tells us what lines are using fallback rendering. This particular case uses fallback rendering due to the `dontShow` parameter having an inline decoration as it's unused:
+この機能が動作しているスクリーンショットを次に示します。黄色の行はフォールバックレンダリングを使用していることを示しています。この特定のケースでは、`dontShow` パラメーターが未使用のためインラインデコレーションを持っているため、フォールバックレンダリングを使用しています：
 
-![GPU rendering looks mostly the same as DOM rendering currently, a yellow line appears for lines rendered via the DOM](https://code.visualstudio.com/assets/updates/1_96/editor-gpu.png)
+![GPU レンダリングは現在 DOM レンダリングとほぼ同じに見えますが、黄色の行は DOM を介してレンダリングされる行を示しています](https://code.visualstudio.com/assets/updates/1_96/editor-gpu.png)
 
-The issue tracking this work is [#221145](https://github.com/microsoft/vscode/issues/221145) which has frequent updates and more details on progress as it's made.
+この作業を追跡する問題は [#221145](https://github.com/microsoft/vscode/issues/221145) であり、進捗状況が頻繁に更新され、詳細が提供されます。
 
-### EOL warning for macOS 10.15
+### macOS 10.15 の EOL 警告 {#macos-10-15-eol-warning}
 
-VS Code desktop will be updating to [Electron 33](https://github.com/microsoft/vscode/issues/232993) in the next couple of milestones. With the Electron 33 update, VS Code desktop will no longer run on **macOS Catalina**. In this milestone, we have added deprecation notices for the users on this affected platform to prepare them for migration. If you are a user of the aforementioned OS version, please take a look at our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
+VS Code デスクトップは、次の数か月で [Electron 33](https://github.com/microsoft/vscode/issues/232993) に更新されます。Electron 33 の更新により、VS Code デスクトップは **macOS Catalina** では実行されなくなります。このマイルストーンでは、影響を受けるプラットフォームのユーザーに移行の準備を促すための非推奨通知を追加しました。上記の OS バージョンを使用している場合は、追加情報について [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) をご覧ください。
 
-## Notable fixes
+## 注目の修正 {#notable-fixes}
 
-* [233915](https://github.com/microsoft/vscode/issues/233915) Share an extension with others by using the **Copy Link** action in the context menu of an extension in the Extensions view.
-* [231542](https://github.com/microsoft/vscode/issues/231542) Frequently unable to save file or file data gets erased with error EBUSY
-* [233304](https://github.com/microsoft/vscode/issues/233304) `onDidChangeCheckboxState` broken in 1.95
-* [232263](https://github.com/microsoft/vscode/issues/232263) Optimize tree view such that cross process calls are batched
-* [156723](https://github.com/microsoft/vscode/issues/156723) Drag and drop support fixed when running with wayland
+* [233915](https://github.com/microsoft/vscode/issues/233915) 拡張機能ビューの拡張機能のコンテキストメニューで **Copy Link** アクションを使用して、他の人と拡張機能を共有します。
+* [231542](https://github.com/microsoft/vscode/issues/231542) ファイルを保存できないことが頻繁に発生するか、ファイルデータが消去されるエラー EBUSY
+* [233304](https://github.com/microsoft/vscode/issues/233304) `onDidChangeCheckboxState` が 1.95 で壊れている
+* [232263](https://github.com/microsoft/vscode/issues/232263) クロスプロセスコールがバッチ処理されるようにツリービューを最適化する
+* [156723](https://github.com/microsoft/vscode/issues/156723) wayland を使用しているときのドラッグアンドドロップサポートの修正
 
-## Thank you
+## ありがとう {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆さんに大きな _**ありがとう**_ を伝えたいと思います。
 
-### Issue tracking
+### 問題追跡 {#issue-tracking}
 
-Contributions to our issue tracking:
+問題追跡への貢献：
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@sahin52 (Sahin Kasap)](https://github.com/sahin52)
 
-### Pull requests
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献：
 
-* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Add support for a border between sidebar and panel titles and views [PR #157318](https://github.com/microsoft/vscode/pull/157318)
-* [@aravind-n (Aravind Nidadavolu)](https://github.com/aravind-n): Fix fish shell integration execution order [PR #226589](https://github.com/microsoft/vscode/pull/226589)
-* [@BABA983 (BABA)](https://github.com/BABA983): Correct ShellIntegrationDecorationsEnabled in markdownDescription [PR #233387](https://github.com/microsoft/vscode/pull/233387)
-* [@BenLocal (benshi)](https://github.com/BenLocal): Cli serve_web sets the path prefix to /<quality>-<commit>/, commit value parsing error [PR #233986](https://github.com/microsoft/vscode/pull/233986)
-* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): fix: cannot open vscode when use vscode-win32-x64 in Windows [PR #233285](https://github.com/microsoft/vscode/pull/233285)
-* [@BugGambit (Fredrik Anfinsen)](https://github.com/BugGambit): Add support for links 'foo, <line>' [PR #231775](https://github.com/microsoft/vscode/pull/231775)
-* [@cachandlerdev](https://github.com/cachandlerdev): Copy extension link [PR #234210](https://github.com/microsoft/vscode/pull/234210)
-* [@CrafterKolyan (Nikolai Korolev)](https://github.com/CrafterKolyan): Add interface for adding value selection in QuickPick for extension API [PR #233275](https://github.com/microsoft/vscode/pull/233275)
-* [@davidmartos96 (David Martos)](https://github.com/davidmartos96): Fix PATH prepending when using Fish [PR #232291](https://github.com/microsoft/vscode/pull/232291)
-* [@dibarbet (David Barbet)](https://github.com/dibarbet): Do not mark interpolation tokens as strings in C# [PR #232772](https://github.com/microsoft/vscode/pull/232772)
-* [@duncpro (Duncan)](https://github.com/duncpro): fix: clickability of create new file/folder button [PR #232130](https://github.com/microsoft/vscode/pull/232130)
-* [@elias-pap (Elias Papavasileiou)](https://github.com/elias-pap): feat: add icon for Vite [PR #234620](https://github.com/microsoft/vscode/pull/234620)
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): サイドバーとパネルのタイトルとビューの間に境界線を追加するサポートを追加 [PR #157318](https://github.com/microsoft/vscode/pull/157318)
+* [@aravind-n (Aravind Nidadavolu)](https://github.com/aravind-n): fish シェル統合の実行順序を修正 [PR #226589](https://github.com/microsoft/vscode/pull/226589)
+* [@BABA983 (BABA)](https://github.com/BABA983): ShellIntegrationDecorationsEnabled の markdownDescription の修正 [PR #233387](https://github.com/microsoft/vscode/pull/233387)
+* [@BenLocal (benshi)](https://github.com/BenLocal): Cli serve_web がパスプレフィックスを /<quality>-<commit>/ に設定し、コミット値の解析エラー [PR #233986](https://github.com/microsoft/vscode/pull/233986)
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): 修正：Windows で vscode-win32-x64 を使用すると VS Code を開けない [PR #233285](https://github.com/microsoft/vscode/pull/233285)
+* [@BugGambit (Fredrik Anfinsen)](https://github.com/BugGambit): 'foo, <line>' 形式のリンクを追加 [PR #231775](https://github.com/microsoft/vscode/pull/231775)
+* [@cachandlerdev](https://github.com/cachandlerdev): 拡張機能リンクのコピー [PR #234210](https://github.com/microsoft/vscode/pull/234210)
+* [@CrafterKolyan (Nikolai Korolev)](https://github.com/CrafterKolyan): 拡張機能 API の QuickPick に値選択を追加するインターフェースを追加 [PR #233275](https://github.com/microsoft/vscode/pull/233275)
+* [@davidmartos96 (David Martos)](https://github.com/davidmartos96): Fish の PATH 先頭追加の修正 [PR #232291](https://github.com/microsoft/vscode/pull/232291)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): C# の文字列としての補間トークンをマークしない [PR #232772](https://github.com/microsoft/vscode/pull/232772)
+* [@duncpro (Duncan)](https://github.com/duncpro): 修正：新しいファイル/フォルダ作成ボタンのクリック可能性 [PR #232130](https://github.com/microsoft/vscode/pull/232130)
+* [@elias-pap (Elias Papavasileiou)](https://github.com/elias-pap): feat: Vite のアイコンを追加 [PR #234620](https://github.com/microsoft/vscode/pull/234620)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
-  * Add `workbench.view.showQuietly` settings object to stop extensions revealing hidden Output view (fix #105270) [PR #205225](https://github.com/microsoft/vscode/pull/205225)
-  * Fix `Go to Current History Item` breakage (fix #235063) [PR #235067](https://github.com/microsoft/vscode/pull/235067)
-  * Enable `Go to Current History Item` correctly after reference picker change (fix #235132) [PR #235134](https://github.com/microsoft/vscode/pull/235134)
-* [@iisaduan (Isabel Duan)](https://github.com/iisaduan): fix typescript organizeImports settings [PR #232676](https://github.com/microsoft/vscode/pull/232676)
-* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): Fixes old extensionHost process is not killed immediately after reloading vscode web tab in the browser [PR #234944](https://github.com/microsoft/vscode/pull/234944)
-* [@Kannav02 (Kannav Sethi)](https://github.com/Kannav02): Change "Organize Imports" command label to "Optimize Imports" [PR #232869](https://github.com/microsoft/vscode/pull/232869)
-* [@LionelJouin (Lionel Jouin)](https://github.com/LionelJouin): Fix: go grammar update (#232142) [PR #232335](https://github.com/microsoft/vscode/pull/232335)
-* [@LitoMore (LitoMore)](https://github.com/LitoMore): Remove Microsoft-related logos [PR #215758](https://github.com/microsoft/vscode/pull/215758)
-* [@Logicer16 (Logicer)](https://github.com/Logicer16): Fix grammar in activeOnStart description [PR #197536](https://github.com/microsoft/vscode/pull/197536)
-* [@RedCMD (RedCMD)](https://github.com/RedCMD): Add `.winget` file extension to YAML [PR #232218](https://github.com/microsoft/vscode/pull/232218)
-* [@ribru17 (Riley Bruins)](https://github.com/ribru17): Render JSDoc examples as typescript code [PR #234143](https://github.com/microsoft/vscode/pull/234143)
-* [@sandersn (Nathan Shively-Sanders)](https://github.com/sandersn): Revert register copilotRelated with copilot [PR #233729](https://github.com/microsoft/vscode/pull/233729)
-* [@nickdiego (Nick Yamane)](https://github.com/nickdiego): Fix for drag and drop support when using wayland [Chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/6000277)
+  * 拡張機能が非表示の出力ビューを表示しないようにする `workbench.view.showQuietly` 設定オブジェクトを追加 (fix #105270) [PR #205225](https://github.com/microsoft/vscode/pull/205225)
+  * `Go to Current History Item` の破損を修正 (fix #235063) [PR #235067](https://github.com/microsoft/vscode/pull/235067)
+  * 参照ピッカーの変更後に `Go to Current History Item` を正しく有効にする (fix #235132) [PR #235134](https://github.com/microsoft/vscode/pull/235134)
+* [@iisaduan (Isabel Duan)](https://github.com/iisaduan): typescript organizeImports 設定の修正 [PR #232676](https://github.com/microsoft/vscode/pull/232676)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413): VS Code Web タブをブラウザでリロードした後に古い extensionHost プロセスがすぐに終了しない問題を修正 [PR #234944](https://github.com/microsoft/vscode/pull/234944)
+* [@Kannav02 (Kannav Sethi)](https://github.com/Kannav02): "Organize Imports" コマンドラベルを "Optimize Imports" に変更 [PR #232869](https://github.com/microsoft/vscode/pull/232869)
+* [@LionelJouin (Lionel Jouin)](https://github.com/LionelJouin): 修正：go 文法の更新 (#232142) [PR #232335](https://github.com/microsoft/vscode/pull/232335)
+* [@LitoMore (LitoMore)](https://github.com/LitoMore): Microsoft 関連のロゴを削除 [PR #215758](https://github.com/microsoft/vscode/pull/215758)
+* [@Logicer16 (Logicer)](https://github.com/Logicer16): activeOnStart 説明の文法を修正 [PR #197536](https://github.com/microsoft/vscode/pull/197536)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): `.winget` ファイル拡張子を YAML に追加 [PR #232218](https://github.com/microsoft/vscode/pull/232218)
+* [@ribru17 (Riley Bruins)](https://github.com/ribru17): JSDoc の例を typescript コードとしてレンダリング [PR #234143](https://github.com/microsoft/vscode/pull/234143)
+* [@sandersn (Nathan Shively-Sanders)](https://github.com/sandersn): copilotRelated を copilot で登録しないようにリバート [PR #233729](https://github.com/microsoft/vscode/pull/233729)
+* [@nickdiego (Nick Yamane)](https://github.com/nickdiego): wayland を使用しているときのドラッグアンドドロップサポートの修正 [Chromium CL](https://chromium-review.googlesource.com/c/chromium/src/+/6000277)
 
-Contributions to `vscode-emmet-helper`:
+`vscode-emmet-helper` への貢献：
 
-* [@onlurking (Diogo Felix)](https://github.com/onlurking): Add missing HTML tags to emmet [PR #90](https://github.com/microsoft/vscode-emmet-helper/pull/90)
+* [@onlurking (Diogo Felix)](https://github.com/onlurking): emmet に欠落している HTML タグを追加 [PR #90](https://github.com/microsoft/vscode-emmet-helper/pull/90)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献：
 
-* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Update contributing instructions [PR #1947](https://github.com/microsoft/vscode-eslint/pull/1947)
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): 貢献の手順を更新 [PR #1947](https://github.com/microsoft/vscode-eslint/pull/1947)
 
-Contributions to `vscode-extension-samples`:
+`vscode-extension-samples` への貢献：
 
-* [@olguzzar (Olivia Guzzardo)](https://github.com/olguzzar): Update Chat tutorial to use request.model [PR #1125](https://github.com/microsoft/vscode-extension-samples/pull/1125)
-* [@phil294 (Philip Waritschlager)](https://github.com/phil294): webview-codicons: Move codicons dependency from devDependencies into dependencies [PR #1005](https://github.com/microsoft/vscode-extension-samples/pull/1005)
-* [@witsaint (gaodingqiang)](https://github.com/witsaint): fix: `lsp-embedded-language-service` cleaninterval args type [PR #1126](https://github.com/microsoft/vscode-extension-samples/pull/1126)
+* [@olguzzar (Olivia Guzzardo)](https://github.com/olguzzar): Chat チュートリアルを request.model を使用するように更新 [PR #1125](https://github.com/microsoft/vscode-extension-samples/pull/1125)
+* [@phil294 (Philip Waritschlager)](https://github.com/phil294): webview-codicons: codicons 依存関係を devDependencies から dependencies に移動 [PR #1005](https://github.com/microsoft/vscode-extension-samples/pull/1005)
+* [@witsaint (gaodingqiang)](https://github.com/witsaint): 修正：`lsp-embedded-language-service` cleaninterval 引数の型 [PR #1126](https://github.com/microsoft/vscode-extension-samples/pull/1126)
 
-Contributions to `vscode-extension-telemetry`:
+`vscode-extension-telemetry` への貢献：
 
-* [@kmagiera (Krzysztof Magiera)](https://github.com/kmagiera): Propagate session ID metadata [PR #215](https://github.com/microsoft/vscode-extension-telemetry/pull/215)
+* [@kmagiera (Krzysztof Magiera)](https://github.com/kmagiera): セッション ID メタデータの伝播 [PR #215](https://github.com/microsoft/vscode-extension-telemetry/pull/215)
 
-Contributions to `vscode-hexeditor`:
+`vscode-hexeditor` への貢献：
 
-* [@Antecer (Antecer)](https://github.com/Antecer): We need a WYSIWYG copy method [PR #540](https://github.com/microsoft/vscode-hexeditor/pull/540)
-* [@Hexa3333 (Alp Yılmaz)](https://github.com/Hexa3333): Fix: DisplayContextSelection read violation (#547) [PR #548](https://github.com/microsoft/vscode-hexeditor/pull/548)
-* [@jogo-](https://github.com/jogo-): Update CHANGELOG.md [PR #549](https://github.com/microsoft/vscode-hexeditor/pull/549)
-* [@tomilho (Tomás Silva)](https://github.com/tomilho): fix: ctrl+f not working with caps lock active [PR #555](https://github.com/microsoft/vscode-hexeditor/pull/555)
+* [@Antecer (Antecer)](https://github.com/Antecer): WYSIWYG コピー方法が必要 [PR #540](https://github.com/microsoft/vscode-hexeditor/pull/540)
+* [@Hexa3333 (Alp Yılmaz)](https://github.com/Hexa3333): 修正：DisplayContextSelection 読み取り違反 (#547) [PR #548](https://github.com/microsoft/vscode-hexeditor/pull/548)
+* [@jogo-](https://github.com/jogo-): CHANGELOG.md の更新 [PR #549](https://github.com/microsoft/vscode-hexeditor/pull/549)
+* [@tomilho (Tomás Silva)](https://github.com/tomilho): 修正：caps lock がアクティブな場合の ctrl+f の動作 [PR #555](https://github.com/microsoft/vscode-hexeditor/pull/555)
 
-Contributions to `vscode-json-languageservice`:
+`vscode-json-languageservice` への貢献：
 
-* [@jeremyfiel (Jeremy Fiel)](https://github.com/jeremyfiel): fix: typo in `then` description [PR #251](https://github.com/microsoft/vscode-json-languageservice/pull/251)
-* [@Legend-Master (Tony)](https://github.com/Legend-Master): Fix slow large oneof validation [PR #247](https://github.com/microsoft/vscode-json-languageservice/pull/247)
-* [@sumimakito (Makito)](https://github.com/sumimakito): feat(completion): support detail from schema [PR #243](https://github.com/microsoft/vscode-json-languageservice/pull/243)
+* [@jeremyfiel (Jeremy Fiel)](https://github.com/jeremyfiel): 修正：`then` 説明のタイプミス [PR #251](https://github.com/microsoft/vscode-json-languageservice/pull/251)
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): 大規模な oneof 検証の遅延を修正 [PR #247](https://github.com/microsoft/vscode-json-languageservice/pull/247)
+* [@sumimakito (Makito)](https://github.com/sumimakito): feat(completion): スキーマからの詳細をサポート [PR #243](https://github.com/microsoft/vscode-json-languageservice/pull/243)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献：
 
-* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Add `connor4312.esbuild-problem-matchers` recommendation [PR #16195](https://github.com/microsoft/vscode-jupyter/pull/16195)
-* [@pwang347 (Paul)](https://github.com/pwang347): Add public API event for kernel post-initialization [PR #16214](https://github.com/microsoft/vscode-jupyter/pull/16214)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): `connor4312.esbuild-problem-matchers` 推奨を追加 [PR #16195](https://github.com/microsoft/vscode-jupyter/pull/16195)
+* [@pwang347 (Paul)](https://github.com/pwang347): カーネルの初期化後の公開 API イベントを追加 [PR #16214](https://github.com/microsoft/vscode-jupyter/pull/16214)
 
-Contributions to `vscode-mypy`:
+`vscode-mypy` への貢献：
 
-* [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): fix: address dev-dependency issues reported by `npm audit` [PR #327](https://github.com/microsoft/vscode-mypy/pull/327)
-* [@taesungh (Taesung Hwang)](https://github.com/taesungh): Use global settings for `ignorePatterns` default [PR #325](https://github.com/microsoft/vscode-mypy/pull/325)
+* [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): 修正：`npm audit` によって報告された dev-dependency の問題 [PR #327](https://github.com/microsoft/vscode-mypy/pull/327)
+* [@taesungh (Taesung Hwang)](https://github.com/taesungh): グローバル設定の `ignorePatterns` デフォルトを使用 [PR #325](https://github.com/microsoft/vscode-mypy/pull/325)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献：
 
 * [@rchiodo (Rich Chiodo)](https://github.com/rchiodo)
-  * Update debugpy_info for v1.8.8 [PR #500](https://github.com/microsoft/vscode-python-debugger/pull/500)
-  * Update debugpy version to 1.8.9 [PR #505](https://github.com/microsoft/vscode-python-debugger/pull/505)
+  * v1.8.8 用の debugpy_info を更新 [PR #500](https://github.com/microsoft/vscode-python-debugger/pull/500)
+  * debugpy バージョンを 1.8.9 に更新 [PR #505](https://github.com/microsoft/vscode-python-debugger/pull/505)
 
-Contributions to `vscode-python-tools-extension-template`:
+`vscode-python-tools-extension-template` への貢献：
 
 * [@oliversen (Oliver Olsen)](https://github.com/oliversen)
-  * Exclude `.dist-info` directories from extension package [PR #215](https://github.com/microsoft/vscode-python-tools-extension-template/pull/215)
-  * Fix glob pattern for `.pyc` files in `.vscodeignore` [PR #216](https://github.com/microsoft/vscode-python-tools-extension-template/pull/216)
-  * Remove duplicate code from `noxfile.py` [PR #217](https://github.com/microsoft/vscode-python-tools-extension-template/pull/217)
+  * 拡張機能パッケージから `.dist-info` ディレクトリを除外 [PR #215](https://github.com/microsoft/vscode-python-tools-extension-template/pull/215)
+  * `.vscodeignore` の `.pyc` ファイルの glob パターンを修正 [PR #216](https://github.com/microsoft/vscode-python-tools-extension-template/pull/216)
+  * `noxfile.py` から重複コードを削除 [PR #217](https://github.com/microsoft/vscode-python-tools-extension-template/pull/217)
 
-Contributions to `vscode-test-web`:
+`vscode-test-web` への貢献：
 
-* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): VS Code main has moved back to npm, we could catch it [PR #148](https://github.com/microsoft/vscode-test-web/pull/148)
+* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): VS Code main が npm に戻ったため、それをキャッチできる [PR #148](https://github.com/microsoft/vscode-test-web/pull/148)
 
-Contributions to `inno-updater`:
+`inno-updater` への貢献：
 
-* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): fix: dialog is show when silent is true [PR #29](https://github.com/microsoft/inno-updater/pull/29)
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): 修正：サイレントが true の場合にダイアログが表示される [PR #29](https://github.com/microsoft/inno-updater/pull/29)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献：
 
-* [@EwanDubashinski (Ivan Dubashinskii)](https://github.com/EwanDubashinski): Added link to the PL/SQL language server [PR #2057](https://github.com/microsoft/language-server-protocol/pull/2057)
-* [@gquerret (Gilles Querret)](https://github.com/gquerret): Add OpenEdge ABL in language servers list [PR #2056](https://github.com/microsoft/language-server-protocol/pull/2056)
-* [@orbitalquark](https://github.com/orbitalquark): Added link to client implementation for Textadept. [PR #2058](https://github.com/microsoft/language-server-protocol/pull/2058)
+* [@EwanDubashinski (Ivan Dubashinskii)](https://github.com/EwanDubashinski): PL/SQL 言語サーバーへのリンクを追加 [PR #2057](https://github.com/microsoft/language-server-protocol/pull/2057)
+* [@gquerret (Gilles Querret)](https://github.com/gquerret): OpenEdge ABL を言語サーバーリストに追加 [PR #2056](https://github.com/microsoft/language-server-protocol/pull/2056)
+* [@orbitalquark](https://github.com/orbitalquark): Textadept 用のクライアント実装へのリンクを追加 [PR #2058](https://github.com/microsoft/language-server-protocol/pull/2058)
 
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>


### PR DESCRIPTION
## Work notes

1. Replace:
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
2. Prompt:
   ```
   Translate markdown contents into Japanese and insert white space between English words or inline code blocks and Japanese.
   ```
3. Revision: https://github.com/microsoft/vscode-docs/commit/dc32849ca199843388fbc49c4a7e99aee16ca565