### PR TITLE
Translate January 2025 (version 1.97)

### DIFF
--- a/docs/release-notes/v1_97.md
+++ b/docs/release-notes/v1_97.md
@@ -1,0 +1,769 @@
+---
+Order: 106
+TOCTitle: January 2025
+PageTitle: Visual Studio Code January 2025
+MetaDescription: Learn what is new in the Visual Studio Code January 2025 Release (1.97)
+MetaSocialImage: 1_97/release-highlights.png
+Date: 2025-02-06
+DownloadVersion: 1.97.0
+---
+# January 2025 (version 1.97)
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the January 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* [Next Edit Suggestions (preview)](#copilot-next-edit-suggestions-preview) - Copilot predicts the next edit you are likely to make.
+* [Reposition Command Palette](#move-the-command-palette-and-quick-inputs) - Drag the Command Palette and Quick Inputs to a new position.
+* [Auto accept edits](#improved-editor-controls) - Automatically accept edits from Copilot after a configurable timeout.
+* [Extension publisher trust](#trusting-extension-publishers) - Keep your environment secure with extension publisher trust.
+* [Compound logs](#compound-logs) - Combine multiple logs into a single, aggregated log view.
+* [Filter output logs](#output-panel-filtering) - Filter the contents of the Output panel.
+* [Git blame information](#git-blame-information) - Rich git blame information and open on GitHub.
+* [Search values in debug variables](#filter-and-search-on-values) - Filter and search for specific values in debug variables.
+* [Notebook inline values](#inline-values-upon-cell-execution) - View inline values for code cell variables in notebooks.
+* [Python no-config debug](#no-config-debug) - Quickly debug a Python script or module without setup.
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## GitHub Copilot
+
+### Copilot Next Edit Suggestions (Preview)
+
+**Setting**: `setting(github.copilot.nextEditSuggestions.enabled)`
+
+GitHub Copilot code completions are great at autocomplete, but since most coding activity is editing existing code, it's a natural evolution of completions to also help with edits. So, we're excited to release a new preview feature, **Copilot Next Edit Suggestions** (Copilot NES).
+
+Based on the edits you're making, Copilot NES both predicts the location of the next edit you'll want to make and what that edit should be. NES suggests future changes relevant to your current work, and you can simply `kbstyle(Tab)` to quickly navigate and accept suggestions.
+
+Notice in the following example that changing a variable triggers an edit suggestion further down the file. Just use the `kbstyle(Tab)` key to navigate and accept the suggestion. The gutter indicator will guide you to your next edit suggestion.
+
+![Video showing Copilot NES suggesting code edits at another location. The gutter shows an arrow indicating the relative position of the edit.](./images/1_97/nes-arrow-directions.gif)
+
+Enable Copilot NES via the VS Code setting `setting(github.copilot.nextEditSuggestions.enabled)`.
+
+Based on the size and type of edit, the rendering of the suggestion might change dynamically from side-by-side to below the current line. Configure the `setting(editor.inlineSuggest.edits.renderSideBySide:never)` setting to always render suggestions below the current line.
+
+Copilot NES is rapidly evolving, and we can't wait to get your feedback via issues in [our repo](https://github.com/microsoft/vscode-copilot-release). You can read our full [Copilot NES docs](https://aka.ms/gh-copilot-nes-docs) for more information and scenarios as we expand the NES experience.
+
+> **Note**: If you are a Copilot Business or Enterprise user, an administrator of your organization [must opt in](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) to the use of previews of Copilot features, in addition to you setting `setting(github.copilot.nextEditSuggestions.enabled)` in your editor.
+
+### Copilot Edits
+
+#### Copilot Edits general availability
+
+In our VS Code October release, we announced the preview of Copilot Edits. Today, we're now announcing the general availability of Copilot Edits! Copilot Edits is optimized for code editing and enables you to make code changes across multiple files in your workspace, directly from chat.
+
+#### Improved editor controls
+
+Edits can now be accepted and discarded individually, giving you more control. Also new is that the editor controls for edits remain visible when switching to the side-by-side view. This is useful for understanding larger changes.
+
+![Screenshot that shows how to accept an individual change from Copilot Edits in the editor.](images/1_97/edits-accept-hunk.png)
+_Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
+
+Lastly, we have added a new setting for automatically accepting edit suggestions after a configurable timeout. The setting for that is `setting(chat.editing.autoAcceptDelay)`, which specifies the number of seconds after which changes are accepted. The countdown stops when you interact with the accept button or when you start to review changes. This should be familiar to anyone who binge-watches on the weekends.
+
+<video src="images/1_97/edits-auto-accept.mp4" title="Video showing a gradient on the Accept button for Copilot Edits, indicating the auto-accept progress." autoplay loop controls muted></video>
+_Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
+
+### Apply in editor
+
+In Copilot Chat, any code block can be applied to a file in the workspace by using the **Apply to Editor** action in the toolbar of the code block.
+We made several improvements to this experience:
+
+- The hover of the action now shows the file the code block was generated for.
+
+  ![Screenshot that shows the Apply Code Block hover text, indicating the target file name.](images/1_97/apply-code-block-hover.png)
+
+- If the code block is for a non-existent file, you are prompted where to create the file. This can be at a file path suggested by Copilot, in an untitled editor, or in the currently active editor.
+
+- When the changes are computed and applied, the same flow and UI as for Copilot Edits are used. You can review, improve, or discard each change individually.
+
+### Temporal context
+
+Temporal context helps when editing or generating code by informing the language model about files that you have recently interacted with. We are experimenting and measuring its effectiveness but it can also be enabled manually,  `setting(github.copilot.chat.editor.temporalContext.enabled)` for Inline Chat and `setting(github.copilot.chat.edits.temporalContext.enabled)` for Copilot Edits.
+
+### Workspace index status UI
+
+When you ask Copilot a question about the code in your project by using `@workspace` or `#codebase`, we use an index to quickly and accurately search your codebase for relevant code snippets to include as context. This index can either be a [remote index managed by GitHub](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index), [a locally stored index](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index), or [a basic index](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) used as a fallback for large projects that can't use a remote index.
+
+This iteration, we've added the new workspace index to the language status indicator in the Status Bar that shows the type of index being used by Copilot and related information, such as the number of files being reindexed. To see this, just select the `{}` icon in the VS Code Status Bar.
+
+![Screenshot that shows the status of the Copilot workspace indexing in the Status Bar.](images/1_97/copilot-workspace-status.png)
+
+Check out the [Copilot workspace docs](https://code.visualstudio.com/docs/copilot/workspace-context#_managing-the-workspace-index) for more info about the types of workspace indexes and how you can switch between them.
+
+### Build a remote workspace index
+
+[Remote workspace indexes](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index) are managed by GitHub. A remote index can provide high-quality results quickly, even for large projects. They also only have to be built once per GitHub project, instead of once per user.
+
+Given all these advantages, we have added several new ways to upgrade a project to a remote index:
+
+- Run the new **GitHub Copilot: Build Remote Index** command.
+
+- Select the Build Index button in the [workspace index status UI](#workspace-index-status-ui). This only shows up if your project is eligible for remote indexing.
+
+- Select the Build Index button in the first `@workspace` response you see. This only shows up if your project is eligible and also only shows once per workspace.
+
+Keep in mind that only projects with a GitHub remote can currently use a remote index. It may also take some time to build up the remote index, especially if your project is large. Check the [Workspace index status UI](#workspace-index-status-ui) to see if remote indexing has completed.
+
+### Workspace search improvements
+
+We've also continued optimizing code search for `@workspace` and `#codebase`. Highlights include:
+
+- Improved tracking and handling of locally changed files when using a [remote index](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index).
+
+- Added background updating of changed files in the [local index](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index), so that `@workspace` questions don't have to wait for them to be updated.
+
+- Optimized the [basic index](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) for large projects.
+
+### Git changes context variable
+
+When writing queries for Chat or Edits, you can now reference files that were modified in Git source control by using the `#changes` context variable. For example, you could prompt for `summarize the #changes in my workspace`.
+
+![Screenshot of a Copilot chat response, which lists the modified files and changes when prompting for '#changes'.](images/1_97/copilot-chat-git-changes.png)
+
+### Model availability
+
+You now have even more models to choose from when using Copilot. The following models are now available in the model picker in Visual Studio Code and github.com chat:
+
+- **OpenAI’s o3-mini**: OpenAI’s newest reasoning model to your coding workflow, is rolling out gradually and will be available to GitHub Copilot Pro, Business, and Enterprise users. Learn more about the o3-mini model availability in the [GitHub blog post](https://github.blog/changelog/2025-01-31-openai-o3-mini-now-available-in-github-copilot-and-github-models-public-preview/).
+
+- **Gemini 2.0 Flash**: Google’s latest model shows high capabilities for code suggestions, documentation, and explaining code. This model is now available to all GitHub Copilot customers, including Copilot Free. Learn more about the Gemini 2.0 Flash model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-05-google-gemini-2-0-flash-is-now-available-to-all-copilot-users-in-public-preview/).
+
+## Accessibility
+
+### Enhanced accessibility sounds
+
+We've refined several accessibility sounds based on user feedback to improve clarity and distinction. The following sounds have been updated:
+
+- `setting(accessibility.signals.save)`
+- `setting(accessibility.signals.lineHasFoldedArea)`
+- `setting(accessibility.signals.terminalQuickFix)`
+- `setting(accessibility.signals.lineHasInlineSuggestion)`
+
+You can preview these updates by running the command **Help: List Signal Sounds** from the Command Palette.
+
+### Copilot Edits Accessibility Help dialog
+
+Screen reader users can now access guidance on interacting with Copilot Edits by invoking:
+`kb(editor.action.accessibilityHelp)` within the input box.
+
+Additionally, when an editor contains pending Copilot edits, this status is now indicated in the editor help dialog. We've also introduced keyboard shortcuts for navigating next `kb(chatEditor.action.navigateNext)` / previous `kb(chatEditor.action.navigatePrevious)`, accepting `kb(chatEditor.action.acceptHunk)`, discarding `kb(chatEditor.action.undoHunk)`, and toggling the diff view `kb(chatEditor.action.diffHunk)`.
+
+### Source Control Accessibility Help dialog
+
+If you invoke the **Show Accessibility Help** command while the Source Control view is focused, it opens the Source Control Accessibility Help dialog to provide important information for screen reader users. The dialog contains the summary of the current source control state and general information about the views and how to navigate them.
+
+### Improved screen reader notifications
+
+When a screen reader is detected, related notifications now include a link to learn more, providing additional context and resources.
+
+### Ignore code blocks in text to speech
+
+Previously, when you used text-to-speech to read out a Copilot response, code blocks were also read out loud. You can ignore code blocks from text-to-speech sessions by using the `setting(accessibility.voice.ignoreCodeBlocks)` setting.
+
+## Workbench
+
+### Move the Command Palette and Quick Inputs
+
+You can now move the Command Palette and other Quick Inputs to a new position, instead of having it fixed at the top of the window.
+
+Features:
+
+* Drag and drop the Command Palette or any other Quick Input with snapping to center and top
+* Persisted position across reloads, allowing you to set a new permanent position for Quick Inputs
+* Preset positions are available in the Customize Layout picker
+
+<video src="images/1_97/quick-pick-move.mp4" title="Video showing moving the Command Palette around the screen and watching it snap into different places. Then opening Customize Layout to play with the presets: top & center." autoplay loop controls muted></video>
+
+### Trusting extension publishers
+
+When you install an extension from a publisher for the first time you will now see a dialog to help you assess the trustworthiness of the extension publisher. This feature helps ensure that you only install extensions from trusted sources, enhancing the security of your development environment.
+
+![Screenshot that shows the Trust Publisher dialog that is shown when a user installs an extension.](images/1_97/trust-publisher-dialog.png)
+
+If you install an extension pack or an extension with dependencies, trusting the publisher will also implicitly trust the publishers of the extensions that get installed along with it.
+
+When you update to the VS Code 1.97 release, the publishers of currently installed extensions are automatically trusted. You can manage the trusted extension publishers with the **Extensions: Manage Trusted Extensions Publishers** command. This command allows you to reset or revoke trust for publishers you have previously trusted.
+
+![Screenshot that shows the Quick Pick list of trusted publishers, enabling unchecking publishers to make them untrusted.](images/1_97/manage-trusted-publishers.png)
+
+**Note**: When no VS Code window is open and you install an extension from the CLI (`code-insiders --install-extension pub.name`), the extension is installed, but the publisher is not added to the trusted list.
+
+For more information, you can visit the [learn more](https://aka.ms/vscode-extension-security) link.
+
+### Output panel filtering
+
+You can now filter the contents of the Output panel, which can greatly improve managing and analyzing logs, especially when you have to deal with large volumes of log data.
+
+![Screenshot of the Output panel, highlighting the filtering dropdown.](images/1_97/output-view-filtering.png)
+
+- **Filter by Log Level:** Filter logs based on their severity level (for example, Error, Warning, Info). This helps you focus on the most critical issues first.
+- **Filter by Category:** Narrow down logs by specific categories, allowing you to isolate logs from particular sources or components. The categories are picked up automatically from the log data.
+- **Filter by Text:** Search for specific text within the logs to quickly locate relevant entries.
+
+### Compound logs
+
+Sometimes you find that information is spread across multiple logs, and you need to view them together to get a complete picture. You can now view multiple logs in a single compound log view. Combine this with the new [filtering](#output-panel-filtering) functionality and analyzing logs has just become much better!
+
+To create a custom compound log, use the **Create Compound Log...** action in the overflow menu of the Output panel.
+
+<video src="images/1_97/compound-log.mp4" title="Video showing how to create a compound log that combines the log messages from two other logs." autoplay loop controls muted></video>
+
+You can also open compound logs in an editor or a new VS Code window for flexible monitoring and analysis. This feature improves your ability to diagnose issues by providing a consolidated view of related logs.
+
+> **Note:** Compound log views are currently not persisted across VS Code restarts.
+
+### Export and import logs
+
+You can now export and import logs using the actions in the overflow menu of the Output view. This feature enhances collaboration and log management by making it easy to share and review logs.
+
+Select the corresponding **Export Logs** or **Import Log** action in the overflow menu of the Output panel to export or import logs.
+
+### Settings editor search fixes
+
+This iteration, we fixed a regression where search queries with missing letters were not showing expected results. For example, the Settings editor was not finding the `setting(editor.formatOnPaste)` setting when you searched for "editor formonpast".
+
+We also fixed an issue where the Settings editor would reveal the table of contents during a search even when it was in a narrow editor group.
+
+![Screenshot of a narrow-width Settings editor, with a search for 'edtor cursstyle' that shows the 'editor.cursorStyle' setting and does not reveal the settings table of contents.](images/1_97/settings-editor-search.png)
+
+### Extension filter enhancements
+
+To help you keep track of extensions that have updates available and to find extensions that were recently updated, you now have two new filter options in the Extensions view: `@outdated` and `@recentlyUpdated`.
+
+![Screenshot of the filtering options in the Extension view, highlighting the 'outdated' and 'recentlyUpdated' options.](images/1_97/extension-filters.png)
+
+### SVG image preview support
+
+The built-in image preview now has basic support for previewing SVG files.
+
+![Screenshot that shows the default preview of an SVG image in VS Code.](images/1_97/image-svg-preview.png)
+
+Check out the [Visual Studio Marketplace](https://marketplace.visualstudio.com/) for more advanced SVG preview extensions.
+
+### Remove a root folder from a workspace from the CLI
+
+Previously, you could already add a root folder to a [multi-root workspace](https://code.visualstudio.com/docs/editor/workspaces/multi-root-workspaces) by using the `--add` [command-line](https://code.visualstudio.com/docs/editor/command-line#_advanced-cli-options) option.
+
+We've now also added the ability to remove a root folder from a multi-root workspace with the new `--remove` command-line option.
+
+```bash
+code --remove /path/to/rootfolder
+```
+
+## Editor
+
+### Persist find and replace history
+
+Last milestone, we introduced history persistence to the editor find control. In this milestone, we are extending that further to the replace input control, so that you can maintain both separately across multiple sessions. The replace history is stored per workspace and can be disabled via the `setting(editor.find.replaceHistory)` setting.
+
+<video src="images/1_97/replace-history.mp4" title="Video showing the persistence of editor replace history across VS Code reloads." autoplay loop controls muted></video>
+
+### Comments
+
+#### Confirmation when closing an un-submitted comment
+
+A confirmation dialog will show when you `esc` or otherwise close a comment control that has un-submitted comments. You can disable this confirmation with the setting `setting(comments.thread.confirmOnCollapse)`.
+
+#### Quick actions in the comment editor
+
+Quick actions can be used from the comments editor.
+
+![Screenshot that shows Quick actions in the Comments editor.](images/1_97/quick-actions-in-comment.gif)
+
+## Source Control
+
+### Git blame information
+
+This milestone, we continued to polish the feature to display git blame information in the editor and in the Status Bar. We have also improved the information that is shown when you hover over the editor decoration or the Status Bar item.
+
+![Screenshot that shows Git blame information when hovering over the git blame item in the Status Bar.](images/1_97/scm-git-blame.png)
+
+The git blame Status Bar item is now enabled by default, and you can disable it by using the `setting(git.blame.statusBarItem.enabled:false)` setting. Enable the git blame editor decoration with the `setting(git.blame.editorDecoration.enabled:true)` setting.
+
+We have also added commands to easily toggle the git blame information by using the Command Palette or by using keybindings: **Git: Toggle Git Blame Editor Decoration** and **Git: Toggle Git Blame Status Bar Item**.
+
+### GitHub repositories
+
+For repositories that are hosted on GitHub, we have added a new command, **Open on GitHub**, to the timeline context menu and hover, the Source Control Graph context menu and hover, and the git blame editor decoration and Status Bar item hover.
+
+![Screenshot of the Source Control history item hover, highlighting the Open on GitHub link.](images/1_97/scm-graph-hover.png)
+
+GitHub issue and pull request references are rendered as links in the timeline, Source Control Graph, and git blame editor decoration and Status Bar item hovers, so that they can be easily opened in a browser.
+
+Last but not least, we also added the GitHub avatar in the timeline, Source Control Graph, and git blame editor decoration and Status Bar item hovers. Disable the rendering of the GitHub avatar by using the `setting(github.showAvatar:false)` setting.
+
+### Source Control Graph actions
+
+We have expanded the functionality of the Source Control Graph view by adding actions scoped to a history item reference (for example, branch tag) to the context menu. The first actions that we added are **Checkout**, **Delete Branch**, and **DeleteTag** that allow you to easily check out a branch/tag, delete a branch, and delete a tag directly from the Source Control Graph view.
+
+We are planning to add more actions in the upcoming milestones.
+
+## Notebooks
+
+### Inline values upon cell execution
+
+The notebook editor now supports showing inline values after cell execution with the setting `setting(notebook.inlineValues)`. When enabled, after a successful cell execution, inline values are displayed according to the results of a registered `InlineValueProvider`.
+
+If there's no provider, the fallback approach matches values found in the kernel against the cell document via simple regex matching. It's recommended to use a provider from a language extension to ensure more accurate results.
+
+![Screenshot that shows inline values after cell execution in the notebook editor.](images/1_97/nb-inline-values.png)
+
+### Custom font family for Markdown cells
+
+The notebook editor now supports setting a custom font family for rendered Markdown cells. This can be controlled with the `setting(notebook.markup.fontFamily)` setting. When left blank, the default workbench font family is used.
+
+![Screenshot that shows a custom font for rendered Markdown cells.](images/1_97/markdown-cell-font-family.png)
+
+## Terminal
+
+### Ligature support
+
+This feature is now considered stable. Here is a summary of the changes since the last version:
+
+- The enablement setting changed from `terminal.integrated.fontLigatures` to `setting(terminal.integrated.fontLigatures.enabled)`.
+- Ligatures are now temporarily disabled while the cursor or the selection is within the ligature.
+- Use `setting(terminal.integrated.fontLigatures.featureSettings)` to set ligature sets and variants. This is passed on to the [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) CSS property behind the scenes.
+- Use `setting(terminal.integrated.fontLigatures.fallbackLigatures)` to set ligature sequences manually when the library that we use to parse ligatures is not supported.
+
+### Support for ConEmu's progress escape sequences
+
+The `ESC ] 9 ; 4` escape sequence pioneered by ConEmu that reports progress in the terminal is now supported. This is used by some CLI tools such as `winget` to report progress. To view the progress in terminal tabs, add `${progress}` to either `setting(terminal.integrated.tabs.title)` or `setting(terminal.integrated.tabs.description)`. This typically shows as a progress spinner or as a percentage.
+
+<video src="images/1_97/terminal-progress.mp4" title="Video showing a progress indicator in the terminal title while running a 'winget' command." autoplay loop controls muted></video>
+
+### Sticky Scroll for truncated commands
+
+Sticky Scroll in the terminal (`setting(terminal.integrated.stickyScroll.enabled)`) now shows when a command is truncated with an ellipsis at the end:
+
+![Screenshot that shows an ellipsis at the end of a command in Sticky Scroll when it is truncated.](images/1_97/terminal-sticky-scroll-ellipsis.png)
+
+### Configure the behavior when the last terminal closes
+
+The new `setting(terminal.integrated.hideOnLastClosed)` setting allows configuring whether the panel will be closed when the last terminal has been closed. Along with this, the experience when there is no terminal open has been improved.
+
+## Tasks
+
+### Column number variable
+
+The new `${columnNumber}` variable can be used in [`tasks.json`](https://code.visualstudio.com/docs/editor/tasks) and [`launch.json`](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) to refer to the column number of the cursor position. See the full list of [variables](https://code.visualstudio.com/docs/editor/variables-reference) in the VS Code documentation.
+
+## Debug
+
+### Filter and search on values
+
+You can now search within a view (`kb(list.find)`) in the Variables and Watch views to filter on variable and expression values, rather than just names.
+
+![Screenshot that shows the search control in the Variables view when debugging.](images/1_97/debug-search-values.png)
+
+### Select in the Debug Console
+
+The Debug Console now supports longer and more reliable content selection, allowing easier copy and paste.
+
+### JavaScript debugger
+
+Scripts can now be _pretty printed_ by using the **Debug: Pretty print for debugging** command from the command palette or editor actions, even when they are not the source the debugger is currently paused in.
+
+## Languages
+
+### TypeScript 5.7.3
+
+This release includes the [TypeScript 5.7.3](https://github.com/microsoft/typescript/issues?q=is%3Aissue%20state%3Aclosed%20%20milestone%3A%22TypeScript%205.7.3%22) recovery release. This minor update fixes a few import bugs and regressions.
+
+### Right click to open images from the Markdown preview
+
+You can now right click on a workspace image in the Markdown preview and select **Open Image** to open it in a new editor.
+
+![Screenshot that shows the context menu option to open an image in the Markdown preview.](images/1_97/md-preview-open-image.png)
+
+This is supported for any images that are part of the current workspace.
+
+### Markdown link validation status item
+
+VS Code's built-in Markdown features support automatically [validating local links to files and images](https://code.visualstudio.com/docs/languages/markdown#_link-validation). This is a great way to catch common mistakes, such as linking to a header that was renamed or to a file that no longer exists on disk.
+
+To help you discover this feature, we've added a new language status item for link validation:
+
+![Screenshot that shows the Markdown link validation language status item.](images/1_97/md-link-status-item.png)
+
+With a Markdown file open, select the `{}` in the Status Bar to view the link validation status. You can also use the status item to quickly toggle link validation off and on.
+
+### New Ruby syntax highlighting grammar
+
+We've moved away from the old, unmaintained, Ruby grammar from `textmate/ruby.tmbundle` and now get our Ruby grammar from `Shopify/ruby-lsp`.
+
+## Remote Development
+
+The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+
+Highlights include:
+
+- Migration path for connecting to Linux legacy servers
+- SSH Chat participant improvements
+- SSH configuration improvements
+- Default remote extensions for SSH
+
+You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md).
+
+## Contributions to extensions
+
+### Microsoft Account
+
+#### Microsoft Account now uses MSAL (with WAM support on Windows)
+
+> NOTE: Last month's rollout of an MSAL-based authentication for Microsoft needed to be rolled back due to a critical bug. This bug has been squashed and we are proceeding with the rollout.
+
+In order to ensure a strong security baseline for Microsoft authentication, we've adopted the [Microsoft Authentication Library](https://github.com/AzureAD/microsoft-authentication-library-for-js) in the Microsoft Account extension.
+
+One of the stand out features of this work is WAM (Web Account Manager... also known as [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) integration. Put simply, rather than going to the browser for Microsoft authentication flows, we now talk to the OS directly, which is the recommended way of acquiring a Microsoft authentication session. Additionally, it's faster since we're able to leverage the accounts that you're already logged into on the OS.
+
+![Screenshot that shows an authentication popup that the OS shows over VS Code.](images/1_97/showingBrokerOSDialog.png)
+
+Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
+
+### Python
+
+#### Launch native REPL from the terminal
+
+You are now able to launch a VS Code Native REPL from your REPL in the terminal. Setting `setting(python.terminal.shellIntegration.enabled)` to `true` should display a clickable link in the Python REPL in the terminal, allowing you to directly open the VS Code Native REPL from the terminal.
+
+<video src="images/1_97/native-repl-link.mp4" title="Video showing the Native REPL entry point link in terminal REPL." autoplay loop controls muted></video>
+
+#### No config debug
+
+You are now able to debug a Python script or module without setup, right from the terminal as part of the new no-config debug feature! Check out the [wiki page](https://github.com/microsoft/vscode-python-debugger/wiki/No%E2%80%90Config-Debugging) on the feature for all the details and troubleshooting tips.
+
+<video src="images/1_97/no-config-debug.mp4" title="Video showing the no-config debug feature for Python." autoplay loop controls muted></video>
+
+#### Test discovery cancellation
+
+When triggering test discovery from the Test Explorer UI, you can now cancel an ongoing test discovery call. Use the Cancel button, which appears in replacement of the Refresh button during discovery.
+
+![Screenshot that shows the Test Explorer, highlighting the Cancel button to cancel the test discovery.](./images/1_97/test-discovery-cancelation.png)
+
+#### Go to Implementation
+
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now has support for **Go to Implementation**, which allows you to more quickly navigate to the implementation of a function or method directly from its usage. This is a particularly helpful feature when working with inherited classes.
+
+![Screenshot that shows the Go to Implementation displayed via the context menu](./images/1_97/pylance-go-to-implementation.png)
+
+#### AI Code Action: Generate Symbol (Experimental)
+
+There's a new experimental AI Code Action for generating symbols with Pylance and Copilot. To try it out, you can enable the following setting:
+
+```
+"python.analysis.aiCodeActions": {"generateSymbol": true}
+```
+
+Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let Copilot handle the implementation! If you want, you can then leverage Pylance's **Move Symbol** Code Actions to move it to a different file.
+
+<video src="images/1_97/pylance-create-symbol-with-copilot.mp4" title="Video showing invoking a new class that doesn't exist and then selecting the 'Create Class With Copilot' code action to implement a new class." autoplay loop controls muted></video>
+
+### GitHub Pull Requests and Issues
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+
+* Global pull request queries, with a variable to specify a time range relative to today (`${today-7d}`).
+* `:<emoji-name>:` style emojis are now supported in comments.
+* All non-outdated comments will show in the Comments panel when you open the description of an un-checked out pull request.
+
+Review the [changelog for the 0.104.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01040) release of the extension to learn about the other highlights.
+
+## Preview Features
+
+### Agent mode (Experimental)
+
+We've been working on a new _agent mode_ for Copilot Edits. When in agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
+
+![Screenshot that shows agent mode in the Copilot Edits view.](images/1_97/agent-mode.png)
+
+You can switch between the current edit mode that we've had for a few months and agent mode with the dropdown in the Copilot Edits view. To see the dropdown, enable the `setting(chat.agent.enabled)` setting. You can start using agent mode in [VS Code Insiders](https://code.visualstudio.com/insiders/) today. We will gradually be rolling it out to VS Code Stable users. If the setting doesn't show up for you in Stable, then it isn't enabled for you yet.
+
+![Screenshot of the agent mode setting in the Settings editor.](images/1_97/agent-setting.png)
+
+In agent mode, Copilot runs autonomously, but it can only edit files within your current workspace. When it wants to run a terminal command, it shows you the command and waits for you to review it and select Continue before proceeding.
+
+> **Note**: Copilot Edits may use many chat requests in agent mode, so it will periodically pause and ask you whether to continue. You can customize this with `setting(chat.agent.maxRequests)`. This defaults to 15 for Copilot paid users, and 5 for Copilot Free users.
+
+Learn more about [agent mode in Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-agent-mode-preview) in the VS Code documentation.
+
+### Agentic codebase search (Preview)
+
+You can add `#codebase` to your query and Copilot Edits will discover relevant files for your task. We've added experimental support for discovering relevant files using additional tools like file and text search, Git repository state, and directory reads. Previously, `#codebase` only performed semantic search.
+
+You can enable it with `setting(github.copilot.chat.edits.codesearch.enabled)`, and please [share any feedback](https://github.com/microsoft/vscode-copilot-release) with us.
+
+### Copilot Vision in VS Code Insiders (Preview)
+
+We're introducing end-to-end vision support in the pre-release version of GitHub Copilot Chat in [VS Code Insiders](https://code.visualstudio.com/insiders/). This lets you attach images and interact with images in Copilot Chat prompts. For example, if you're encountering an error while debugging, quickly attach a screenshot of VS Code and ask Copilot to help you resolve the issue.
+
+![Screenshot that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](images/1_97/image-attachments.gif)
+
+You can now attach images using several methods:
+
+- Drag and drop images from your OS or from the Explorer view
+- Paste an image from the clipboard
+- Attach a screenshot of the VS Code window (select Attach > Screenshot Window)
+
+A warning is shown if the selected model currently does not have the capability to handle images. The only supported model at the moment will be `GPT 4o`. Currently, the supported image types are `JPEG/JPG`, `PNG`, `GIF`, and `WEBP`.
+
+### Reusable prompts (Experimental)
+
+This feature lets you build, store, and share reusable prompts. A prompt file is a `.prompt.md` Markdown file that follows the same format used for writing prompts in Copilot Chat, and it can link to other files or even other prompts. You can attach prompt files for task-specific guidance, aid with code generation, or keep complete prompts for later use.
+
+To enable prompt files, set `setting(chat.promptFiles)` to `true`, or use the `{ "/path/to/folder": boolean }` notation to specify a different path. The `.github/prompts` folder is used by default to locate prompt files (`*.prompt.md`), if no other path is specified.
+
+Learn more about [prompt files](https://aka.ms/vscode-ghcp-prompt-snippets) in the VS Code documentation.
+
+### Custom title bar on Linux (Experimental)
+
+This milestone, we are starting an experiment to enable the custom title bar for a subset of Linux users.
+
+![Screenshot that shows the custom VS Code title bar on Linux.](images/1_97/custom-title.png)
+
+If you are not part of the experiment, you can manually configure `setting(window.titleBarStyle)` as `custom` to try it out.
+
+You can always revert back to the native title decorations, either from the custom title context menu or by configuring `setting(window.titleBarStyle)` to `native`.
+
+![Screenshot that shows the content menu option to disable the custom title bar on Linux.](images/1_97/restore-title.png)
+
+### TypeScript 5.8 beta support
+
+This release includes support for the TypeScript 5.8 beta release. Check out the [TypeScript 5.8 blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/) for details on what's in store for this release.
+
+To start using preview builds of TypeScript 5.8, install the [TypeScript Nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next). Share your feedback and let us know if you run into any bugs with TypeScript 5.8.
+
+### Terminal completions for more shells
+
+We have iterated on the general terminal completions that [were introduced in the last version](https://code.visualstudio.com/updates/v1_96#_terminal-completions-for-more-shells) that are build on our new proposed API. Once enabled with `setting(terminal.integrated.suggest.enabled)`, the new completions now replace the previous built-in provider for PowerShell but can now be customized with `setting(terminal.integrated.suggest.providers)`.
+
+Here are the key updates this release:
+
+- Enhanced widget styling and configuration to align with the editor's suggest widget.
+- A configurable status bar (`setting(terminal.integrated.suggest.showStatusBar)`) provides contextual actions and information.
+- Improved argument awareness for commands, including: `code`, `code-insiders`, `cd`, `ls`, `rm`, `echo`, `mkdir`, `rmdir`, `touch`.
+- Displays command or resource paths as additional details.
+- Added support for directory navigation shortcuts like `.`, `..`, and `../../`.
+- Enabled screen reader usage.
+- Entries pulled from the `$PATH` will now only show when they are executable files. Since Windows does not have the concept of an executable bit in file metadata, the list of extensions can be configured with `setting(terminal.integrated.suggest.windowsExecutableExtensions)`. These now also use the actual shell environment when available using an upcoming proposed API.
+- Enhanced keyboard support to toggle details, `kb(workbench.action.terminal.suggestToggleDetails)` and toggle suggest details focus `kb(workbench.action.terminal.suggestToggleDetailsFocus)`.
+- Suggestions will now always be on every type, aligning closer to how quick suggestions work in the editor.
+- PowerShell-specific global completions such as `Get-ChildItem`, `Write-Host`, etc. will now be suggested.
+
+### Tree-Sitter based syntax highlighting for typescript
+
+Since many of our Textmate grammars are no longer maintained, we've been investigating using Tree-Sitter for syntax highlighting. We've started with TypeScript so the team can selfhost it and provide feedback. You can try out an early preview it out with the `setting(editor.experimental.preferTreeSitter)` setting.
+
+## Extension Authoring
+
+### Document paste API
+
+The document paste API allows extensions to hook into copy/paste operations in text documents. Using this API, your extension can:
+
+- On copy, write data to the clipboard. This includes writing metadata that the can be picked up on paste.
+
+- On paste, generate a custom edit that applies the paste. This can change the text content being pasted or make more complex workspace edits, such as creating new files.
+
+- Provide multiple ways that content can be pasted. Users can select how content should be pasted using the paste control or with the `editor.pasteAs.preferences` setting.
+
+VS Code uses the document paste API to implement features such as [updating imports on paste for JavaScript and TypeScript](https://code.visualstudio.com/updates/v1_95#_update-imports-on-paste-for-javascript-and-typescript) and [automatically creating Markdown links when pasting URLs](https://code.visualstudio.com/updates/v1_81#_markdown-paste-urls-as-formatted-links).
+
+To get started with the document paste API, check out the [document paste extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/document-paste). For a more complex example, check out how the built-in Markdown extension [implements pasting of image files](https://github.com/microsoft/vscode/blob/8237317c2ff4d0a3dadfaeb67cd35630cf1a6b75/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts#L31) to insert images into Markdown documents.
+
+### File `openLabel` shows in the simple file picker
+
+The `openLabel` property in the `OpenDialogOptions` is now supported in the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (in addition to the system file picker, where it was previously exclusively supported). This allows you to provide a custom label for the button in the file picker.
+
+### File-level comments API
+
+The comments API supports making and showing file-level comments. File-level comments show at the top of the file, before the first line. They are not attached to a specific line or range in the file. To show a file-level comment, set the `range` of the comment to `undefined`. To support leaving file-level comments from your commenting range provider, set the `enableFileComments` property on your `CommentingRangeProvider` to `true`.
+
+## Proposed APIs
+
+### Terminal completion provider
+
+You can now [register a terminal completion provider](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts#L79-L87) and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/226562).
+
+An example of this can be found in our terminal suggest extension, which provides completions when enabled via `setting(terminal.integrated.suggest.enabled)`.
+
+### Terminal shell type
+
+Extensions will be able to [access currently active shell type information](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalShellType.d.ts).
+The `shellType` field will be part of `TerminalState`.
+
+Use this shell type information to perform shell-specific operations that you need.
+
+## Engineering
+
+### Housekeeping
+
+As part of our annual housekeeping efforts in December, we focused on cleaning up our GitHub issues and pull requests across all repositories. This year, we achieved a net reduction of 3,821 issues and pull requests, ensuring that our backlog remains relevant and manageable.
+
+By following our issue cleanup guide, we reviewed and triaged outdated, duplicated, and no longer relevant issues. This helps us maintain an efficient development workflow and focus on improving Visual Studio Code for our users.
+
+We appreciate the community’s continued engagement and feedback — your contributions make VS Code better every day! 🚀
+
+![Chart that shows the trend of the number of open issues over the last years. The chart shows a steep decline each year during December, the housekeeping month.](images/1_97/housekeeping.png)
+
+### Resource optimization for file watching in TypeScript workspaces
+
+A couple of optimizations have been made to reduce the overhead that file watching has in large TypeScript workspaces (thousands of TypeScript files or projects). Specifically, when opening such a workspace and initializing the watcher, you should no longer see CPU spikes or CPU usage should settle quickly.
+
+See this [VS Code issue](https://github.com/microsoft/vscode/issues/237351) for more details.
+
+## Notable fixes
+
+* [160325](https://github.com/microsoft/vscode/issues/160325) Suppress terminal launch failure after ctrl+D is pressed
+* [230438](https://github.com/microsoft/vscode/issues/230438) Support for code page `1125` aka `cp866u`
+* [238577](https://github.com/microsoft/vscode/issues/238577) Increase default window size
+* [197377](https://github.com/microsoft/vscode/issues/197377) workspaceFolder variable substitution in launch.json or tasks.json should use URI for virtual filesystems
+* [229857](https://github.com/microsoft/vscode/issues/229857) a11y view is blank after running `focus comment on line`
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@starball5 (starball)](https://github.com/starball5)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@Abrifq (Arda Aydın)](https://github.com/Abrifq): Change `Create New Terminal` to focus accordingly to the terminal location [PR #237404](https://github.com/microsoft/vscode/pull/237404)
+* [@adrianstephens](https://github.com/adrianstephens): custom editor preview [PR #235533](https://github.com/microsoft/vscode/pull/235533)
+* [@andrewsuzuki (Andrew Suzuki)](https://github.com/andrewsuzuki): Fix 'new Color' string typo for editorBracketHighlight.unexpectedBracket.foreground [PR #237236](https://github.com/microsoft/vscode/pull/237236)
+* [@aslezar (Shivam Garg)](https://github.com/aslezar)
+  * Fix incorrect GLIBC version parsing [PR #236082](https://github.com/microsoft/vscode/pull/236082)
+  * feat: support custom js switch-case indentation [PR #237069](https://github.com/microsoft/vscode/pull/237069)
+* [@atreids (Aaron Donaldson)](https://github.com/atreids): chore: fix typo in VSIX progress notification [PR #238845](https://github.com/microsoft/vscode/pull/238845)
+* [@BABA983 (BABA)](https://github.com/BABA983): Resolve custom editor with canonical resource [PR #226614](https://github.com/microsoft/vscode/pull/226614)
+* [@congyuandong (scott)](https://github.com/congyuandong): fix: remove duplicate `!**/*.mk` entry in dependenciesSrc [PR #236683](https://github.com/microsoft/vscode/pull/236683)
+* [@DetachHead](https://github.com/DetachHead): remove `javascript.inlayHints.enumMemberValues.enabled` because javascript does not have enums [PR #236297](https://github.com/microsoft/vscode/pull/236297)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): Use Electron fetch or Node fetch for github-authentication to support proxies [PR #238149](https://github.com/microsoft/vscode/pull/238149)
+* [@dmitrysonder (Dmitry Sonder)](https://github.com/dmitrysonder): refactor: use EventType constants for events [PR #236941](https://github.com/microsoft/vscode/pull/236941)
+* [@fa0311 (ふぁ)](https://github.com/fa0311): Fix ${unixTime} Placeholder to Use Full Millisecond Timestamp in markdown.copyFiles.destination [PR #239061](https://github.com/microsoft/vscode/pull/239061)
+* [@g122622](https://github.com/g122622): Scrollbar for File menu is displaying over Open Recent [PR #236998](https://github.com/microsoft/vscode/pull/236998)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Add a Configure option to overflow menu of Open Editors view [PR #237678](https://github.com/microsoft/vscode/pull/237678)
+* [@goodmind (andretshurotshka)](https://github.com/goodmind): Fixes #44237: Add column number in tasks [PR #65264](https://github.com/microsoft/vscode/pull/65264)
+* [@HD787 (Henry)](https://github.com/HD787)
+  * Add ${unixTime} Placeholder for markdown.copyFiles.destination Option [PR #238027](https://github.com/microsoft/vscode/pull/238027)
+  * enable typescript commands when only config files are open [PR #238630](https://github.com/microsoft/vscode/pull/238630)
+* [@iamdereky (Derek Yang)](https://github.com/iamdereky): Fix CSS errors when using HTML escaped quotes [PR #235367](https://github.com/microsoft/vscode/pull/235367)
+* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): Remove paths from tsconfig.base.json [PR #238475](https://github.com/microsoft/vscode/pull/238475)
+* [@janajar (Jawad Najar)](https://github.com/janajar): Fix: When no results in search editor it throws an error [PR #235031](https://github.com/microsoft/vscode/pull/235031)
+* [@jaymroy](https://github.com/jaymroy): Issue: #214481 Add Option to Ignore Code Blocks in Text-to-Speech [PR #235697](https://github.com/microsoft/vscode/pull/235697)
+* [@jogibear9988 (Jochen Kühner)](https://github.com/jogibear9988): support svg's in image preview [PR #237217](https://github.com/microsoft/vscode/pull/237217)
+* [@Jules-Bertholet (Jules Bertholet)](https://github.com/Jules-Bertholet): Support back and forward keys in default shortcuts [PR #237701](https://github.com/microsoft/vscode/pull/237701)
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): Reland fix custom task shell doesn't work without manually passing in "run command" arg/flag [PR #236058](https://github.com/microsoft/vscode/pull/236058)
+* [@LemmusLemmus](https://github.com/LemmusLemmus): Add $ to surrounding pairs in markdown [PR #233981](https://github.com/microsoft/vscode/pull/233981)
+* [@leopardracer (leopardracer)](https://github.com/leopardracer): fix: typos in documentation files [PR #235968](https://github.com/microsoft/vscode/pull/235968)
+* [@misode (Misode)](https://github.com/misode): Fix missing uri to file path conversion when loading json schema [PR #237275](https://github.com/microsoft/vscode/pull/237275)
+* [@mohankumarelec (mohanram)](https://github.com/mohankumarelec): Fixes #236973 [PR #236974](https://github.com/microsoft/vscode/pull/236974)
+* [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango): Add 'open image' context in markdown preview [PR #234649](https://github.com/microsoft/vscode/pull/234649)
+* [@numbermaniac](https://github.com/numbermaniac): Fix typo in InlayHintKind docs [PR #238032](https://github.com/microsoft/vscode/pull/238032)
+* [@oltolm (oltolm)](https://github.com/oltolm): debug: ignore error when stopping a process [PR #236009](https://github.com/microsoft/vscode/pull/236009)
+* [@oxcened (Alen Ajam)](https://github.com/oxcened)
+  * fix: set _lastFocusedWidget as undefined on widget blur [PR #234610](https://github.com/microsoft/vscode/pull/234610)
+  * fix: check whether lastFocusedList is valid when assigned [PR #238765](https://github.com/microsoft/vscode/pull/238765)
+* [@pankajk07 (Pankaj Khandelwal)](https://github.com/pankajk07): fix: synchronous script loading from web workers of extensions [PR #233175](https://github.com/microsoft/vscode/pull/233175)
+* [@Parasaran-Python (Parasaran)](https://github.com/Parasaran-Python)
+  * fix 227150: Added a recursive git clone button [PR #232497](https://github.com/microsoft/vscode/pull/232497)
+  * fix 235221: Sanitizing the html content by closing the unclosed tags [PR #236145](https://github.com/microsoft/vscode/pull/236145)
+* [@r3m0t (Tomer Chachamu)](https://github.com/r3m0t): Fix revealing a notebook cell from the debugger stopping and revealing active statement (Fixes #225290) [PR #225292](https://github.com/microsoft/vscode/pull/225292)
+* [@rcjsuen (Remy Suen)](https://github.com/rcjsuen): Fix typo in the help text of the icon extension point [PR #238393](https://github.com/microsoft/vscode/pull/238393)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+  * Fix extension preview codeblock language getter [PR #235880](https://github.com/microsoft/vscode/pull/235880)
+  * Add `outdated` and `recentlyUpdated` suggestions to extension filter [PR #235884](https://github.com/microsoft/vscode/pull/235884)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
+  * Mark bun.lock as jsonc [PR #235917](https://github.com/microsoft/vscode/pull/235917)
+  * Allow the .ndjson extension for the jsonl language [PR #235921](https://github.com/microsoft/vscode/pull/235921)
+* [@RiskyMH (Michael H)](https://github.com/RiskyMH): `bun.lock` as package manager lockfile [PR #236012](https://github.com/microsoft/vscode/pull/236012)
+* [@sunnylost (sunnylost)](https://github.com/sunnylost): fix(settings-editor): ensure the width of the key name does not shrink [PR #229919](https://github.com/microsoft/vscode/pull/229919)
+* [@tcostew](https://github.com/tcostew): Allow Github Copilot chat to appear in QuickAccess [PR #210805](https://github.com/microsoft/vscode/pull/210805)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1)
+  * build: update to include more tsc boilerplate [PR #238422](https://github.com/microsoft/vscode/pull/238422)
+  * build: switch `build/tsconfig.json` to `module: nodenext` [PR #238426](https://github.com/microsoft/vscode/pull/238426)
+* [@tobil4sk](https://github.com/tobil4sk): Merge diverging findExecutable functions [PR #228373](https://github.com/microsoft/vscode/pull/228373)
+* [@zWingz (zWing)](https://github.com/zWingz): fix(git-ext): fix limitWarning block the git status progress [PR #226577](https://github.com/microsoft/vscode/pull/226577)
+
+Contributions to `vscode-eslint`:
+
+* [@ShahinSorkh (Shahin Sorkh)](https://github.com/ShahinSorkh): clarify where to set `eslint.runtime` and `eslint.execArgv` options [PR #1973](https://github.com/microsoft/vscode-eslint/pull/1973)
+
+Contributions to `vscode-extension-samples`:
+
+* [@IsBenben](https://github.com/IsBenben): Fixes cannot find module 'semver' [PR #1129](https://github.com/microsoft/vscode-extension-samples/pull/1129)
+
+Contributions to `vscode-js-debug`:
+
+* [@mdh1418 (Mitchell Hwang)](https://github.com/mdh1418): Update BlazorDebugger telemetry report event [PR #2158](https://github.com/microsoft/vscode-js-debug/pull/2158)
+
+Contributions to `vscode-jupyter`:
+
+* [@gy-mate (Máté Gyöngyösi)](https://github.com/gy-mate): Capitalize 'URL' [PR #16340](https://github.com/microsoft/vscode-jupyter/pull/16340)
+* [@pwang347 (Paul)](https://github.com/pwang347): Add `waitUntil` for `onDidStart` event [PR #16375](https://github.com/microsoft/vscode-jupyter/pull/16375)
+
+Contributions to `vscode-loc`:
+
+* [@NicoWeio (Nicolai Weitkemper)](https://github.com/NicoWeio): improve grammar in README [PR #1367](https://github.com/microsoft/vscode-loc/pull/1367)
+
+Contributions to `vscode-prompt-tsx`:
+
+* [@atxtechbro (Morgan Joyce)](https://github.com/atxtechbro)
+  * docs: fix typo in Passing Priority description [PR #140](https://github.com/microsoft/vscode-prompt-tsx/pull/140)
+  * docs: fix grammar in budget allocation description [PR #141](https://github.com/microsoft/vscode-prompt-tsx/pull/141)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@mikeseese (Mike Seese)](https://github.com/mikeseese): Add opt-in to always prompt for repo for issue creation and add comment to issue file specifying the repo [PR #6115](https://github.com/microsoft/vscode-pull-request-github/pull/6115)
+* [@NellyWhads (Nelly Whads)](https://github.com/NellyWhads): Remove the python language user mention exception [PR #6525](https://github.com/microsoft/vscode-pull-request-github/pull/6525)
+* [@Ronny-zzl (Zhang)](https://github.com/Ronny-zzl): Don't show hover cards for @-mentioned users in JSDocs in jsx and tsx files [PR #6531](https://github.com/microsoft/vscode-pull-request-github/pull/6531)
+
+Contributions to `vscode-pylint`:
+
+* [@DetachHead](https://github.com/DetachHead): workaround for memory leak caused by pylint bug [PR #585](https://github.com/microsoft/vscode-pylint/pull/585)
+
+Contributions to `vscode-python-debugger`:
+
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo)
+  * Update to 1.8.11 [PR #536](https://github.com/microsoft/vscode-python-debugger/pull/536)
+  * Support the clientOS property in VS code [PR #550](https://github.com/microsoft/vscode-python-debugger/pull/550)
+  * Update `debugpy` to 1.8.12 [PR #558](https://github.com/microsoft/vscode-python-debugger/pull/558)
+
+Contributions to `vscode-ripgrep`:
+
+* [@fiji-flo (Florian Dieminger)](https://github.com/fiji-flo): fix long download [PR #62](https://github.com/microsoft/vscode-ripgrep/pull/62)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Fix for arm64 windows [PR #63](https://github.com/microsoft/vscode-ripgrep/pull/63)
+
+Contributions to `vscode-test`:
+
+* [@kamaal111 (Kamaal Farah)](https://github.com/kamaal111): docs: update Github Actions link to point to sample [PR #297](https://github.com/microsoft/vscode-test/pull/297)
+
+Contributions to `language-server-protocol`:
+
+* [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721): cython-lsp [PR #2064](https://github.com/microsoft/language-server-protocol/pull/2064)
+* [@catwell (Pierre Chapuis)](https://github.com/catwell): Add Teal LSP [PR #2078](https://github.com/microsoft/language-server-protocol/pull/2078)
+* [@Enaium (Enaium)](https://github.com/Enaium)
+  * Add Jimmer DTO [PR #2070](https://github.com/microsoft/language-server-protocol/pull/2070)
+  * Change Maintainer [PR #2071](https://github.com/microsoft/language-server-protocol/pull/2071)
+* [@g-plane (Pig Fang)](https://github.com/g-plane): New language server: wasm-language-tools [PR #2065](https://github.com/microsoft/language-server-protocol/pull/2065)
+* [@jcs090218 (Jen-Chieh Shen)](https://github.com/jcs090218): chore(_implementors/servers.md): Update Ellsp link [PR #2073](https://github.com/microsoft/language-server-protocol/pull/2073)
+* [@kbwo (Kodai Kabasawa)](https://github.com/kbwo): Add testing-language-server in servers.md [PR #2076](https://github.com/microsoft/language-server-protocol/pull/2076)
+* [@kylebonnici (Kyle Micallef Bonnici)](https://github.com/kylebonnici): Add Devicetree LSP to list [PR #2085](https://github.com/microsoft/language-server-protocol/pull/2085)
+* [@ribru17 (Riley Bruins)](https://github.com/ribru17): Add ts_query_ls (Tree-sitter query language server) [PR #2068](https://github.com/microsoft/language-server-protocol/pull/2068)
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_97.md
+++ b/docs/release-notes/v1_97.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_97/release-highlights.png
 Date: 2025-02-06
 DownloadVersion: 1.97.0
 ---
-# January 2025 (version 1.97)
+# January 2025 (version 1.97) {#january-2025}
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
@@ -29,9 +29,9 @@ Welcome to the January 2025 release of Visual Studio Code. There are many update
 >If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 **Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
 
-## GitHub Copilot
+## GitHub Copilot {#github-copilot}
 
-### Copilot Next Edit Suggestions (Preview)
+### Copilot Next Edit Suggestions (Preview) {#copilot-next-edit-suggestions-preview}
 
 **Setting**: `setting(github.copilot.nextEditSuggestions.enabled)`
 
@@ -51,13 +51,13 @@ Copilot NES is rapidly evolving, and we can't wait to get your feedback via issu
 
 > **Note**: If you are a Copilot Business or Enterprise user, an administrator of your organization [must opt in](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) to the use of previews of Copilot features, in addition to you setting `setting(github.copilot.nextEditSuggestions.enabled)` in your editor.
 
-### Copilot Edits
+### Copilot Edits {#copilot-edits}
 
-#### Copilot Edits general availability
+#### Copilot Edits general availability {#copilot-edits-general-availability}
 
 In our VS Code October release, we announced the preview of Copilot Edits. Today, we're now announcing the general availability of Copilot Edits! Copilot Edits is optimized for code editing and enables you to make code changes across multiple files in your workspace, directly from chat.
 
-#### Improved editor controls
+#### Improved editor controls {#improved-editor-controls}
 
 Edits can now be accepted and discarded individually, giving you more control. Also new is that the editor controls for edits remain visible when switching to the side-by-side view. This is useful for understanding larger changes.
 
@@ -69,7 +69,7 @@ Lastly, we have added a new setting for automatically accepting edit suggestions
 <video src="images/1_97/edits-auto-accept.mp4" title="Video showing a gradient on the Accept button for Copilot Edits, indicating the auto-accept progress." autoplay loop controls muted></video>
 _Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
 
-### Apply in editor
+### Apply in editor {#apply-in-editor}
 
 In Copilot Chat, any code block can be applied to a file in the workspace by using the **Apply to Editor** action in the toolbar of the code block.
 We made several improvements to this experience:
@@ -82,11 +82,11 @@ We made several improvements to this experience:
 
 - When the changes are computed and applied, the same flow and UI as for Copilot Edits are used. You can review, improve, or discard each change individually.
 
-### Temporal context
+### Temporal context {#temporal-context}
 
 Temporal context helps when editing or generating code by informing the language model about files that you have recently interacted with. We are experimenting and measuring its effectiveness but it can also be enabled manually,  `setting(github.copilot.chat.editor.temporalContext.enabled)` for Inline Chat and `setting(github.copilot.chat.edits.temporalContext.enabled)` for Copilot Edits.
 
-### Workspace index status UI
+### Workspace index status UI {#workspace-index-status-ui}
 
 When you ask Copilot a question about the code in your project by using `@workspace` or `#codebase`, we use an index to quickly and accurately search your codebase for relevant code snippets to include as context. This index can either be a [remote index managed by GitHub](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index), [a locally stored index](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index), or [a basic index](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) used as a fallback for large projects that can't use a remote index.
 
@@ -96,7 +96,7 @@ This iteration, we've added the new workspace index to the language status indic
 
 Check out the [Copilot workspace docs](https://code.visualstudio.com/docs/copilot/workspace-context#_managing-the-workspace-index) for more info about the types of workspace indexes and how you can switch between them.
 
-### Build a remote workspace index
+### Build a remote workspace index {#build-a-remote-workspace-index}
 
 [Remote workspace indexes](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index) are managed by GitHub. A remote index can provide high-quality results quickly, even for large projects. They also only have to be built once per GitHub project, instead of once per user.
 
@@ -110,7 +110,7 @@ Given all these advantages, we have added several new ways to upgrade a project 
 
 Keep in mind that only projects with a GitHub remote can currently use a remote index. It may also take some time to build up the remote index, especially if your project is large. Check the [Workspace index status UI](#workspace-index-status-ui) to see if remote indexing has completed.
 
-### Workspace search improvements
+### Workspace search improvements {#workspace-search-improvements}
 
 We've also continued optimizing code search for `@workspace` and `#codebase`. Highlights include:
 
@@ -120,13 +120,13 @@ We've also continued optimizing code search for `@workspace` and `#codebase`. Hi
 
 - Optimized the [basic index](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) for large projects.
 
-### Git changes context variable
+### Git changes context variable {#git-changes-context-variable}
 
 When writing queries for Chat or Edits, you can now reference files that were modified in Git source control by using the `#changes` context variable. For example, you could prompt for `summarize the #changes in my workspace`.
 
 ![Screenshot of a Copilot chat response, which lists the modified files and changes when prompting for '#changes'.](images/1_97/copilot-chat-git-changes.png)
 
-### Model availability
+### Model availability {#model-availability}
 
 You now have even more models to choose from when using Copilot. The following models are now available in the model picker in Visual Studio Code and github.com chat:
 
@@ -134,9 +134,9 @@ You now have even more models to choose from when using Copilot. The following m
 
 - **Gemini 2.0 Flash**: Google’s latest model shows high capabilities for code suggestions, documentation, and explaining code. This model is now available to all GitHub Copilot customers, including Copilot Free. Learn more about the Gemini 2.0 Flash model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-05-google-gemini-2-0-flash-is-now-available-to-all-copilot-users-in-public-preview/).
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Enhanced accessibility sounds
+### Enhanced accessibility sounds {#enhanced-accessibility-sounds}
 
 We've refined several accessibility sounds based on user feedback to improve clarity and distinction. The following sounds have been updated:
 
@@ -147,28 +147,28 @@ We've refined several accessibility sounds based on user feedback to improve cla
 
 You can preview these updates by running the command **Help: List Signal Sounds** from the Command Palette.
 
-### Copilot Edits Accessibility Help dialog
+### Copilot Edits Accessibility Help dialog {#copilot-edits-accessibility-help-dialog}
 
 Screen reader users can now access guidance on interacting with Copilot Edits by invoking:
 `kb(editor.action.accessibilityHelp)` within the input box.
 
 Additionally, when an editor contains pending Copilot edits, this status is now indicated in the editor help dialog. We've also introduced keyboard shortcuts for navigating next `kb(chatEditor.action.navigateNext)` / previous `kb(chatEditor.action.navigatePrevious)`, accepting `kb(chatEditor.action.acceptHunk)`, discarding `kb(chatEditor.action.undoHunk)`, and toggling the diff view `kb(chatEditor.action.diffHunk)`.
 
-### Source Control Accessibility Help dialog
+### Source Control Accessibility Help dialog {#source-control-accessibility-help-dialog}
 
 If you invoke the **Show Accessibility Help** command while the Source Control view is focused, it opens the Source Control Accessibility Help dialog to provide important information for screen reader users. The dialog contains the summary of the current source control state and general information about the views and how to navigate them.
 
-### Improved screen reader notifications
+### Improved screen reader notifications {#improved-screen-reader-notifications}
 
 When a screen reader is detected, related notifications now include a link to learn more, providing additional context and resources.
 
-### Ignore code blocks in text to speech
+### Ignore code blocks in text to speech {#ignore-code-blocks-in-text-to-speech}
 
 Previously, when you used text-to-speech to read out a Copilot response, code blocks were also read out loud. You can ignore code blocks from text-to-speech sessions by using the `setting(accessibility.voice.ignoreCodeBlocks)` setting.
 
-## Workbench
+## Workbench {#workbench}
 
-### Move the Command Palette and Quick Inputs
+### Move the Command Palette and Quick Inputs {#move-the-command-palette-and-quick-inputs}
 
 You can now move the Command Palette and other Quick Inputs to a new position, instead of having it fixed at the top of the window.
 
@@ -180,7 +180,7 @@ Features:
 
 <video src="images/1_97/quick-pick-move.mp4" title="Video showing moving the Command Palette around the screen and watching it snap into different places. Then opening Customize Layout to play with the presets: top & center." autoplay loop controls muted></video>
 
-### Trusting extension publishers
+### Trusting extension publishers {#trusting-extension-publishers}
 
 When you install an extension from a publisher for the first time you will now see a dialog to help you assess the trustworthiness of the extension publisher. This feature helps ensure that you only install extensions from trusted sources, enhancing the security of your development environment.
 
@@ -196,7 +196,7 @@ When you update to the VS Code 1.97 release, the publishers of currently install
 
 For more information, you can visit the [learn more](https://aka.ms/vscode-extension-security) link.
 
-### Output panel filtering
+### Output panel filtering {#output-panel-filtering}
 
 You can now filter the contents of the Output panel, which can greatly improve managing and analyzing logs, especially when you have to deal with large volumes of log data.
 
@@ -206,7 +206,7 @@ You can now filter the contents of the Output panel, which can greatly improve m
 - **Filter by Category:** Narrow down logs by specific categories, allowing you to isolate logs from particular sources or components. The categories are picked up automatically from the log data.
 - **Filter by Text:** Search for specific text within the logs to quickly locate relevant entries.
 
-### Compound logs
+### Compound logs {#compound-logs}
 
 Sometimes you find that information is spread across multiple logs, and you need to view them together to get a complete picture. You can now view multiple logs in a single compound log view. Combine this with the new [filtering](#output-panel-filtering) functionality and analyzing logs has just become much better!
 
@@ -218,13 +218,13 @@ You can also open compound logs in an editor or a new VS Code window for flexibl
 
 > **Note:** Compound log views are currently not persisted across VS Code restarts.
 
-### Export and import logs
+### Export and import logs {#export-and-import-logs}
 
 You can now export and import logs using the actions in the overflow menu of the Output view. This feature enhances collaboration and log management by making it easy to share and review logs.
 
 Select the corresponding **Export Logs** or **Import Log** action in the overflow menu of the Output panel to export or import logs.
 
-### Settings editor search fixes
+### Settings editor search fixes {#settings-editor-search-fixes}
 
 This iteration, we fixed a regression where search queries with missing letters were not showing expected results. For example, the Settings editor was not finding the `setting(editor.formatOnPaste)` setting when you searched for "editor formonpast".
 
@@ -232,13 +232,13 @@ We also fixed an issue where the Settings editor would reveal the table of conte
 
 ![Screenshot of a narrow-width Settings editor, with a search for 'edtor cursstyle' that shows the 'editor.cursorStyle' setting and does not reveal the settings table of contents.](images/1_97/settings-editor-search.png)
 
-### Extension filter enhancements
+### Extension filter enhancements {#extension-filter-enhancements}
 
 To help you keep track of extensions that have updates available and to find extensions that were recently updated, you now have two new filter options in the Extensions view: `@outdated` and `@recentlyUpdated`.
 
 ![Screenshot of the filtering options in the Extension view, highlighting the 'outdated' and 'recentlyUpdated' options.](images/1_97/extension-filters.png)
 
-### SVG image preview support
+### SVG image preview support {#svg-image-preview-support}
 
 The built-in image preview now has basic support for previewing SVG files.
 
@@ -246,7 +246,7 @@ The built-in image preview now has basic support for previewing SVG files.
 
 Check out the [Visual Studio Marketplace](https://marketplace.visualstudio.com/) for more advanced SVG preview extensions.
 
-### Remove a root folder from a workspace from the CLI
+### Remove a root folder from a workspace from the CLI {#remove-a-root-folder-from-a-workspace-from-the-cli}
 
 Previously, you could already add a root folder to a [multi-root workspace](https://code.visualstudio.com/docs/editor/workspaces/multi-root-workspaces) by using the `--add` [command-line](https://code.visualstudio.com/docs/editor/command-line#_advanced-cli-options) option.
 
@@ -256,29 +256,29 @@ We've now also added the ability to remove a root folder from a multi-root works
 code --remove /path/to/rootfolder
 ```
 
-## Editor
+## Editor {#editor}
 
-### Persist find and replace history
+### Persist find and replace history {#persist-find-and-replace-history}
 
 Last milestone, we introduced history persistence to the editor find control. In this milestone, we are extending that further to the replace input control, so that you can maintain both separately across multiple sessions. The replace history is stored per workspace and can be disabled via the `setting(editor.find.replaceHistory)` setting.
 
 <video src="images/1_97/replace-history.mp4" title="Video showing the persistence of editor replace history across VS Code reloads." autoplay loop controls muted></video>
 
-### Comments
+### Comments {#comments}
 
-#### Confirmation when closing an un-submitted comment
+#### Confirmation when closing an un-submitted comment {#confirmation-when-closing-an-unsubmitted-comment}
 
 A confirmation dialog will show when you `esc` or otherwise close a comment control that has un-submitted comments. You can disable this confirmation with the setting `setting(comments.thread.confirmOnCollapse)`.
 
-#### Quick actions in the comment editor
+#### Quick actions in the comment editor {#quick-actions-in-the-comment-editor}
 
 Quick actions can be used from the comments editor.
 
 ![Screenshot that shows Quick actions in the Comments editor.](images/1_97/quick-actions-in-comment.gif)
 
-## Source Control
+## Source Control {#source-control}
 
-### Git blame information
+### Git blame information {#git-blame-information}
 
 This milestone, we continued to polish the feature to display git blame information in the editor and in the Status Bar. We have also improved the information that is shown when you hover over the editor decoration or the Status Bar item.
 
@@ -288,7 +288,7 @@ The git blame Status Bar item is now enabled by default, and you can disable it 
 
 We have also added commands to easily toggle the git blame information by using the Command Palette or by using keybindings: **Git: Toggle Git Blame Editor Decoration** and **Git: Toggle Git Blame Status Bar Item**.
 
-### GitHub repositories
+### GitHub repositories {#github-repositories}
 
 For repositories that are hosted on GitHub, we have added a new command, **Open on GitHub**, to the timeline context menu and hover, the Source Control Graph context menu and hover, and the git blame editor decoration and Status Bar item hover.
 
@@ -298,15 +298,15 @@ GitHub issue and pull request references are rendered as links in the timeline, 
 
 Last but not least, we also added the GitHub avatar in the timeline, Source Control Graph, and git blame editor decoration and Status Bar item hovers. Disable the rendering of the GitHub avatar by using the `setting(github.showAvatar:false)` setting.
 
-### Source Control Graph actions
+### Source Control Graph actions {#source-control-graph-actions}
 
 We have expanded the functionality of the Source Control Graph view by adding actions scoped to a history item reference (for example, branch tag) to the context menu. The first actions that we added are **Checkout**, **Delete Branch**, and **DeleteTag** that allow you to easily check out a branch/tag, delete a branch, and delete a tag directly from the Source Control Graph view.
 
 We are planning to add more actions in the upcoming milestones.
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Inline values upon cell execution
+### Inline values upon cell execution {#inline-values-upon-cell-execution}
 
 The notebook editor now supports showing inline values after cell execution with the setting `setting(notebook.inlineValues)`. When enabled, after a successful cell execution, inline values are displayed according to the results of a registered `InlineValueProvider`.
 
@@ -314,15 +314,15 @@ If there's no provider, the fallback approach matches values found in the kernel
 
 ![Screenshot that shows inline values after cell execution in the notebook editor.](images/1_97/nb-inline-values.png)
 
-### Custom font family for Markdown cells
+### Custom font family for Markdown cells {#custom-font-family-for-markdown-cells}
 
 The notebook editor now supports setting a custom font family for rendered Markdown cells. This can be controlled with the `setting(notebook.markup.fontFamily)` setting. When left blank, the default workbench font family is used.
 
 ![Screenshot that shows a custom font for rendered Markdown cells.](images/1_97/markdown-cell-font-family.png)
 
-## Terminal
+## Terminal {#terminal}
 
-### Ligature support
+### Ligature support {#ligature-support}
 
 This feature is now considered stable. Here is a summary of the changes since the last version:
 
@@ -331,51 +331,51 @@ This feature is now considered stable. Here is a summary of the changes since th
 - Use `setting(terminal.integrated.fontLigatures.featureSettings)` to set ligature sets and variants. This is passed on to the [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) CSS property behind the scenes.
 - Use `setting(terminal.integrated.fontLigatures.fallbackLigatures)` to set ligature sequences manually when the library that we use to parse ligatures is not supported.
 
-### Support for ConEmu's progress escape sequences
+### Support for ConEmu's progress escape sequences {#support-for-conemus-progress-escape-sequences}
 
 The `ESC ] 9 ; 4` escape sequence pioneered by ConEmu that reports progress in the terminal is now supported. This is used by some CLI tools such as `winget` to report progress. To view the progress in terminal tabs, add `${progress}` to either `setting(terminal.integrated.tabs.title)` or `setting(terminal.integrated.tabs.description)`. This typically shows as a progress spinner or as a percentage.
 
 <video src="images/1_97/terminal-progress.mp4" title="Video showing a progress indicator in the terminal title while running a 'winget' command." autoplay loop controls muted></video>
 
-### Sticky Scroll for truncated commands
+### Sticky Scroll for truncated commands {#sticky-scroll-for-truncated-commands}
 
 Sticky Scroll in the terminal (`setting(terminal.integrated.stickyScroll.enabled)`) now shows when a command is truncated with an ellipsis at the end:
 
 ![Screenshot that shows an ellipsis at the end of a command in Sticky Scroll when it is truncated.](images/1_97/terminal-sticky-scroll-ellipsis.png)
 
-### Configure the behavior when the last terminal closes
+### Configure the behavior when the last terminal closes {#configure-the-behavior-when-the-last-terminal-closes}
 
 The new `setting(terminal.integrated.hideOnLastClosed)` setting allows configuring whether the panel will be closed when the last terminal has been closed. Along with this, the experience when there is no terminal open has been improved.
 
-## Tasks
+## Tasks {#tasks}
 
-### Column number variable
+### Column number variable {#column-number-variable}
 
 The new `${columnNumber}` variable can be used in [`tasks.json`](https://code.visualstudio.com/docs/editor/tasks) and [`launch.json`](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) to refer to the column number of the cursor position. See the full list of [variables](https://code.visualstudio.com/docs/editor/variables-reference) in the VS Code documentation.
 
-## Debug
+## Debug {#debug}
 
-### Filter and search on values
+### Filter and search on values {#filter-and-search-on-values}
 
 You can now search within a view (`kb(list.find)`) in the Variables and Watch views to filter on variable and expression values, rather than just names.
 
 ![Screenshot that shows the search control in the Variables view when debugging.](images/1_97/debug-search-values.png)
 
-### Select in the Debug Console
+### Select in the Debug Console {#select-in-the-debug-console}
 
 The Debug Console now supports longer and more reliable content selection, allowing easier copy and paste.
 
-### JavaScript debugger
+### JavaScript debugger {#javascript-debugger}
 
 Scripts can now be _pretty printed_ by using the **Debug: Pretty print for debugging** command from the command palette or editor actions, even when they are not the source the debugger is currently paused in.
 
-## Languages
+## Languages {#languages}
 
-### TypeScript 5.7.3
+### TypeScript 5.7.3 {#typescript-573}
 
 This release includes the [TypeScript 5.7.3](https://github.com/microsoft/typescript/issues?q=is%3Aissue%20state%3Aclosed%20%20milestone%3A%22TypeScript%205.7.3%22) recovery release. This minor update fixes a few import bugs and regressions.
 
-### Right click to open images from the Markdown preview
+### Right click to open images from the Markdown preview {#right-click-to-open-images-from-the-markdown-preview}
 
 You can now right click on a workspace image in the Markdown preview and select **Open Image** to open it in a new editor.
 
@@ -383,7 +383,7 @@ You can now right click on a workspace image in the Markdown preview and select 
 
 This is supported for any images that are part of the current workspace.
 
-### Markdown link validation status item
+### Markdown link validation status item {#markdown-link-validation-status-item}
 
 VS Code's built-in Markdown features support automatically [validating local links to files and images](https://code.visualstudio.com/docs/languages/markdown#_link-validation). This is a great way to catch common mistakes, such as linking to a header that was renamed or to a file that no longer exists on disk.
 
@@ -393,11 +393,11 @@ To help you discover this feature, we've added a new language status item for li
 
 With a Markdown file open, select the `{}` in the Status Bar to view the link validation status. You can also use the status item to quickly toggle link validation off and on.
 
-### New Ruby syntax highlighting grammar
+### New Ruby syntax highlighting grammar {#new-ruby-syntax-highlighting-grammar}
 
 We've moved away from the old, unmaintained, Ruby grammar from `textmate/ruby.tmbundle` and now get our Ruby grammar from `Shopify/ruby-lsp`.
 
-## Remote Development
+## Remote Development {#remote-development}
 
 The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
 
@@ -410,11 +410,11 @@ Highlights include:
 
 You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md).
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### Microsoft Account
+### Microsoft Account {#microsoft-account}
 
-#### Microsoft Account now uses MSAL (with WAM support on Windows)
+#### Microsoft Account now uses MSAL (with WAM support on Windows) {#microsoft-account-now-uses-msal-with-wam-support-on-windows}
 
 > NOTE: Last month's rollout of an MSAL-based authentication for Microsoft needed to be rolled back due to a critical bug. This bug has been squashed and we are proceeding with the rollout.
 
@@ -426,33 +426,33 @@ One of the stand out features of this work is WAM (Web Account Manager... also k
 
 Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
 
-### Python
+### Python {#python}
 
-#### Launch native REPL from the terminal
+#### Launch native REPL from the terminal {#launch-native-repl-from-the-terminal}
 
 You are now able to launch a VS Code Native REPL from your REPL in the terminal. Setting `setting(python.terminal.shellIntegration.enabled)` to `true` should display a clickable link in the Python REPL in the terminal, allowing you to directly open the VS Code Native REPL from the terminal.
 
 <video src="images/1_97/native-repl-link.mp4" title="Video showing the Native REPL entry point link in terminal REPL." autoplay loop controls muted></video>
 
-#### No config debug
+#### No config debug {#no-config-debug}
 
 You are now able to debug a Python script or module without setup, right from the terminal as part of the new no-config debug feature! Check out the [wiki page](https://github.com/microsoft/vscode-python-debugger/wiki/No%E2%80%90Config-Debugging) on the feature for all the details and troubleshooting tips.
 
 <video src="images/1_97/no-config-debug.mp4" title="Video showing the no-config debug feature for Python." autoplay loop controls muted></video>
 
-#### Test discovery cancellation
+#### Test discovery cancellation {#test-discovery-cancellation}
 
 When triggering test discovery from the Test Explorer UI, you can now cancel an ongoing test discovery call. Use the Cancel button, which appears in replacement of the Refresh button during discovery.
 
 ![Screenshot that shows the Test Explorer, highlighting the Cancel button to cancel the test discovery.](./images/1_97/test-discovery-cancelation.png)
 
-#### Go to Implementation
+#### Go to Implementation {#go-to-implementation}
 
 [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now has support for **Go to Implementation**, which allows you to more quickly navigate to the implementation of a function or method directly from its usage. This is a particularly helpful feature when working with inherited classes.
 
 ![Screenshot that shows the Go to Implementation displayed via the context menu](./images/1_97/pylance-go-to-implementation.png)
 
-#### AI Code Action: Generate Symbol (Experimental)
+#### AI Code Action: Generate Symbol (Experimental) {#ai-code-action-generate-symbol-experimental}
 
 There's a new experimental AI Code Action for generating symbols with Pylance and Copilot. To try it out, you can enable the following setting:
 
@@ -464,7 +464,7 @@ Then once you define a new symbol, for example, a class or a function, you can s
 
 <video src="images/1_97/pylance-create-symbol-with-copilot.mp4" title="Video showing invoking a new class that doesn't exist and then selecting the 'Create Class With Copilot' code action to implement a new class." autoplay loop controls muted></video>
 
-### GitHub Pull Requests and Issues
+### GitHub Pull Requests and Issues {#github-pull-requests-and-issues}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
 
@@ -474,9 +474,9 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 Review the [changelog for the 0.104.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01040) release of the extension to learn about the other highlights.
 
-## Preview Features
+## Preview Features {#preview-features}
 
-### Agent mode (Experimental)
+### Agent mode (Experimental) {#agent-mode-experimental}
 
 We've been working on a new _agent mode_ for Copilot Edits. When in agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
 
@@ -492,13 +492,13 @@ In agent mode, Copilot runs autonomously, but it can only edit files within your
 
 Learn more about [agent mode in Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-agent-mode-preview) in the VS Code documentation.
 
-### Agentic codebase search (Preview)
+### Agentic codebase search (Preview) {#agentic-codebase-search-preview}
 
 You can add `#codebase` to your query and Copilot Edits will discover relevant files for your task. We've added experimental support for discovering relevant files using additional tools like file and text search, Git repository state, and directory reads. Previously, `#codebase` only performed semantic search.
 
 You can enable it with `setting(github.copilot.chat.edits.codesearch.enabled)`, and please [share any feedback](https://github.com/microsoft/vscode-copilot-release) with us.
 
-### Copilot Vision in VS Code Insiders (Preview)
+### Copilot Vision in VS Code Insiders (Preview) {#copilot-vision-in-vs-code-insiders-preview}
 
 We're introducing end-to-end vision support in the pre-release version of GitHub Copilot Chat in [VS Code Insiders](https://code.visualstudio.com/insiders/). This lets you attach images and interact with images in Copilot Chat prompts. For example, if you're encountering an error while debugging, quickly attach a screenshot of VS Code and ask Copilot to help you resolve the issue.
 
@@ -512,7 +512,7 @@ You can now attach images using several methods:
 
 A warning is shown if the selected model currently does not have the capability to handle images. The only supported model at the moment will be `GPT 4o`. Currently, the supported image types are `JPEG/JPG`, `PNG`, `GIF`, and `WEBP`.
 
-### Reusable prompts (Experimental)
+### Reusable prompts (Experimental) {#reusable-prompts-experimental}
 
 This feature lets you build, store, and share reusable prompts. A prompt file is a `.prompt.md` Markdown file that follows the same format used for writing prompts in Copilot Chat, and it can link to other files or even other prompts. You can attach prompt files for task-specific guidance, aid with code generation, or keep complete prompts for later use.
 
@@ -520,7 +520,7 @@ To enable prompt files, set `setting(chat.promptFiles)` to `true`, or use the `{
 
 Learn more about [prompt files](https://aka.ms/vscode-ghcp-prompt-snippets) in the VS Code documentation.
 
-### Custom title bar on Linux (Experimental)
+### Custom title bar on Linux (Experimental) {#custom-title-bar-on-linux-experimental}
 
 This milestone, we are starting an experiment to enable the custom title bar for a subset of Linux users.
 
@@ -532,13 +532,13 @@ You can always revert back to the native title decorations, either from the cust
 
 ![Screenshot that shows the content menu option to disable the custom title bar on Linux.](images/1_97/restore-title.png)
 
-### TypeScript 5.8 beta support
+### TypeScript 5.8 beta support {#typescript-58-beta-support}
 
 This release includes support for the TypeScript 5.8 beta release. Check out the [TypeScript 5.8 blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/) for details on what's in store for this release.
 
 To start using preview builds of TypeScript 5.8, install the [TypeScript Nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next). Share your feedback and let us know if you run into any bugs with TypeScript 5.8.
 
-### Terminal completions for more shells
+### Terminal completions for more shells {#terminal-completions-for-more-shells}
 
 We have iterated on the general terminal completions that [were introduced in the last version](https://code.visualstudio.com/updates/v1_96#_terminal-completions-for-more-shells) that are build on our new proposed API. Once enabled with `setting(terminal.integrated.suggest.enabled)`, the new completions now replace the previous built-in provider for PowerShell but can now be customized with `setting(terminal.integrated.suggest.providers)`.
 
@@ -555,13 +555,13 @@ Here are the key updates this release:
 - Suggestions will now always be on every type, aligning closer to how quick suggestions work in the editor.
 - PowerShell-specific global completions such as `Get-ChildItem`, `Write-Host`, etc. will now be suggested.
 
-### Tree-Sitter based syntax highlighting for typescript
+### Tree-Sitter based syntax highlighting for typescript {#tree-sitter-based-syntax-highlighting-for-typescript}
 
 Since many of our Textmate grammars are no longer maintained, we've been investigating using Tree-Sitter for syntax highlighting. We've started with TypeScript so the team can selfhost it and provide feedback. You can try out an early preview it out with the `setting(editor.experimental.preferTreeSitter)` setting.
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### Document paste API
+### Document paste API {#document-paste-api}
 
 The document paste API allows extensions to hook into copy/paste operations in text documents. Using this API, your extension can:
 
@@ -575,32 +575,32 @@ VS Code uses the document paste API to implement features such as [updating impo
 
 To get started with the document paste API, check out the [document paste extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/document-paste). For a more complex example, check out how the built-in Markdown extension [implements pasting of image files](https://github.com/microsoft/vscode/blob/8237317c2ff4d0a3dadfaeb67cd35630cf1a6b75/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts#L31) to insert images into Markdown documents.
 
-### File `openLabel` shows in the simple file picker
+### File `openLabel` shows in the simple file picker {#file-openlabel-shows-in-the-simple-file-picker}
 
 The `openLabel` property in the `OpenDialogOptions` is now supported in the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (in addition to the system file picker, where it was previously exclusively supported). This allows you to provide a custom label for the button in the file picker.
 
-### File-level comments API
+### File-level comments API {#file-level-comments-api}
 
 The comments API supports making and showing file-level comments. File-level comments show at the top of the file, before the first line. They are not attached to a specific line or range in the file. To show a file-level comment, set the `range` of the comment to `undefined`. To support leaving file-level comments from your commenting range provider, set the `enableFileComments` property on your `CommentingRangeProvider` to `true`.
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Terminal completion provider
+### Terminal completion provider {#terminal-completion-provider}
 
 You can now [register a terminal completion provider](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts#L79-L87) and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/226562).
 
 An example of this can be found in our terminal suggest extension, which provides completions when enabled via `setting(terminal.integrated.suggest.enabled)`.
 
-### Terminal shell type
+### Terminal shell type {#terminal-shell-type}
 
 Extensions will be able to [access currently active shell type information](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalShellType.d.ts).
 The `shellType` field will be part of `TerminalState`.
 
 Use this shell type information to perform shell-specific operations that you need.
 
-## Engineering
+## Engineering {#engineering}
 
-### Housekeeping
+### Housekeeping {#housekeeping}
 
 As part of our annual housekeeping efforts in December, we focused on cleaning up our GitHub issues and pull requests across all repositories. This year, we achieved a net reduction of 3,821 issues and pull requests, ensuring that our backlog remains relevant and manageable.
 
@@ -610,13 +610,13 @@ We appreciate the community’s continued engagement and feedback — your contr
 
 ![Chart that shows the trend of the number of open issues over the last years. The chart shows a steep decline each year during December, the housekeeping month.](images/1_97/housekeeping.png)
 
-### Resource optimization for file watching in TypeScript workspaces
+### Resource optimization for file watching in TypeScript workspaces {#resource-optimization-for-file-watching-in-typescript-workspaces}
 
 A couple of optimizations have been made to reduce the overhead that file watching has in large TypeScript workspaces (thousands of TypeScript files or projects). Specifically, when opening such a workspace and initializing the watcher, you should no longer see CPU spikes or CPU usage should settle quickly.
 
 See this [VS Code issue](https://github.com/microsoft/vscode/issues/237351) for more details.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [160325](https://github.com/microsoft/vscode/issues/160325) Suppress terminal launch failure after ctrl+D is pressed
 * [230438](https://github.com/microsoft/vscode/issues/230438) Support for code page `1125` aka `cp866u`
@@ -624,11 +624,11 @@ See this [VS Code issue](https://github.com/microsoft/vscode/issues/237351) for 
 * [197377](https://github.com/microsoft/vscode/issues/197377) workspaceFolder variable substitution in launch.json or tasks.json should use URI for virtual filesystems
 * [229857](https://github.com/microsoft/vscode/issues/229857) a11y view is blank after running `focus comment on line`
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -638,7 +638,7 @@ Contributions to our issue tracking:
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@starball5 (starball)](https://github.com/starball5)
 
-### Pull requests
+### Pull requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_97.md
+++ b/docs/release-notes/v1_97.md
@@ -41,7 +41,7 @@ Based on the edits you're making, Copilot NES both predicts the location of the 
 
 Notice in the following example that changing a variable triggers an edit suggestion further down the file. Just use the `kbstyle(Tab)` key to navigate and accept the suggestion. The gutter indicator will guide you to your next edit suggestion.
 
-![Video showing Copilot NES suggesting code edits at another location. The gutter shows an arrow indicating the relative position of the edit.](./images/1_97/nes-arrow-directions.gif)
+![Video showing Copilot NES suggesting code edits at another location. The gutter shows an arrow indicating the relative position of the edit.](https://code.visualstudio.com/assets/updates/1_97/nes-arrow-directions.gif)
 
 Enable Copilot NES via the VS Code setting `setting(github.copilot.nextEditSuggestions.enabled)`.
 
@@ -61,12 +61,12 @@ In our VS Code October release, we announced the preview of Copilot Edits. Today
 
 Edits can now be accepted and discarded individually, giving you more control. Also new is that the editor controls for edits remain visible when switching to the side-by-side view. This is useful for understanding larger changes.
 
-![Screenshot that shows how to accept an individual change from Copilot Edits in the editor.](images/1_97/edits-accept-hunk.png)
+![Screenshot that shows how to accept an individual change from Copilot Edits in the editor.](https://code.visualstudio.com/assets/updates/1_97/edits-accept-hunk.png)
 _Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
 
 Lastly, we have added a new setting for automatically accepting edit suggestions after a configurable timeout. The setting for that is `setting(chat.editing.autoAcceptDelay)`, which specifies the number of seconds after which changes are accepted. The countdown stops when you interact with the accept button or when you start to review changes. This should be familiar to anyone who binge-watches on the weekends.
 
-<video src="images/1_97/edits-auto-accept.mp4" title="Video showing a gradient on the Accept button for Copilot Edits, indicating the auto-accept progress." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/edits-auto-accept.mp4" title="Video showing a gradient on the Accept button for Copilot Edits, indicating the auto-accept progress." autoplay loop controls muted></video>
 _Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
 
 ### Apply in editor {#apply-in-editor}
@@ -76,7 +76,7 @@ We made several improvements to this experience:
 
 - The hover of the action now shows the file the code block was generated for.
 
-  ![Screenshot that shows the Apply Code Block hover text, indicating the target file name.](images/1_97/apply-code-block-hover.png)
+  ![Screenshot that shows the Apply Code Block hover text, indicating the target file name.](https://code.visualstudio.com/assets/updates/1_97/apply-code-block-hover.png)
 
 - If the code block is for a non-existent file, you are prompted where to create the file. This can be at a file path suggested by Copilot, in an untitled editor, or in the currently active editor.
 
@@ -92,7 +92,7 @@ When you ask Copilot a question about the code in your project by using `@worksp
 
 This iteration, we've added the new workspace index to the language status indicator in the Status Bar that shows the type of index being used by Copilot and related information, such as the number of files being reindexed. To see this, just select the `{}` icon in the VS Code Status Bar.
 
-![Screenshot that shows the status of the Copilot workspace indexing in the Status Bar.](images/1_97/copilot-workspace-status.png)
+![Screenshot that shows the status of the Copilot workspace indexing in the Status Bar.](https://code.visualstudio.com/assets/updates/1_97/copilot-workspace-status.png)
 
 Check out the [Copilot workspace docs](https://code.visualstudio.com/docs/copilot/workspace-context#_managing-the-workspace-index) for more info about the types of workspace indexes and how you can switch between them.
 
@@ -124,7 +124,7 @@ We've also continued optimizing code search for `@workspace` and `#codebase`. Hi
 
 When writing queries for Chat or Edits, you can now reference files that were modified in Git source control by using the `#changes` context variable. For example, you could prompt for `summarize the #changes in my workspace`.
 
-![Screenshot of a Copilot chat response, which lists the modified files and changes when prompting for '#changes'.](images/1_97/copilot-chat-git-changes.png)
+![Screenshot of a Copilot chat response, which lists the modified files and changes when prompting for '#changes'.](https://code.visualstudio.com/assets/updates/1_97/copilot-chat-git-changes.png)
 
 ### Model availability {#model-availability}
 
@@ -178,19 +178,19 @@ Features:
 * Persisted position across reloads, allowing you to set a new permanent position for Quick Inputs
 * Preset positions are available in the Customize Layout picker
 
-<video src="images/1_97/quick-pick-move.mp4" title="Video showing moving the Command Palette around the screen and watching it snap into different places. Then opening Customize Layout to play with the presets: top & center." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/quick-pick-move.mp4" title="Video showing moving the Command Palette around the screen and watching it snap into different places. Then opening Customize Layout to play with the presets: top & center." autoplay loop controls muted></video>
 
 ### Trusting extension publishers {#trusting-extension-publishers}
 
 When you install an extension from a publisher for the first time you will now see a dialog to help you assess the trustworthiness of the extension publisher. This feature helps ensure that you only install extensions from trusted sources, enhancing the security of your development environment.
 
-![Screenshot that shows the Trust Publisher dialog that is shown when a user installs an extension.](images/1_97/trust-publisher-dialog.png)
+![Screenshot that shows the Trust Publisher dialog that is shown when a user installs an extension.](https://code.visualstudio.com/assets/updates/1_97/trust-publisher-dialog.png)
 
 If you install an extension pack or an extension with dependencies, trusting the publisher will also implicitly trust the publishers of the extensions that get installed along with it.
 
 When you update to the VS Code 1.97 release, the publishers of currently installed extensions are automatically trusted. You can manage the trusted extension publishers with the **Extensions: Manage Trusted Extensions Publishers** command. This command allows you to reset or revoke trust for publishers you have previously trusted.
 
-![Screenshot that shows the Quick Pick list of trusted publishers, enabling unchecking publishers to make them untrusted.](images/1_97/manage-trusted-publishers.png)
+![Screenshot that shows the Quick Pick list of trusted publishers, enabling unchecking publishers to make them untrusted.](https://code.visualstudio.com/assets/updates/1_97/manage-trusted-publishers.png)
 
 **Note**: When no VS Code window is open and you install an extension from the CLI (`code-insiders --install-extension pub.name`), the extension is installed, but the publisher is not added to the trusted list.
 
@@ -200,7 +200,7 @@ For more information, you can visit the [learn more](https://aka.ms/vscode-exten
 
 You can now filter the contents of the Output panel, which can greatly improve managing and analyzing logs, especially when you have to deal with large volumes of log data.
 
-![Screenshot of the Output panel, highlighting the filtering dropdown.](images/1_97/output-view-filtering.png)
+![Screenshot of the Output panel, highlighting the filtering dropdown.](https://code.visualstudio.com/assets/updates/1_97/output-view-filtering.png)
 
 - **Filter by Log Level:** Filter logs based on their severity level (for example, Error, Warning, Info). This helps you focus on the most critical issues first.
 - **Filter by Category:** Narrow down logs by specific categories, allowing you to isolate logs from particular sources or components. The categories are picked up automatically from the log data.
@@ -212,7 +212,7 @@ Sometimes you find that information is spread across multiple logs, and you need
 
 To create a custom compound log, use the **Create Compound Log...** action in the overflow menu of the Output panel.
 
-<video src="images/1_97/compound-log.mp4" title="Video showing how to create a compound log that combines the log messages from two other logs." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/compound-log.mp4" title="Video showing how to create a compound log that combines the log messages from two other logs." autoplay loop controls muted></video>
 
 You can also open compound logs in an editor or a new VS Code window for flexible monitoring and analysis. This feature improves your ability to diagnose issues by providing a consolidated view of related logs.
 
@@ -230,19 +230,19 @@ This iteration, we fixed a regression where search queries with missing letters 
 
 We also fixed an issue where the Settings editor would reveal the table of contents during a search even when it was in a narrow editor group.
 
-![Screenshot of a narrow-width Settings editor, with a search for 'edtor cursstyle' that shows the 'editor.cursorStyle' setting and does not reveal the settings table of contents.](images/1_97/settings-editor-search.png)
+![Screenshot of a narrow-width Settings editor, with a search for 'edtor cursstyle' that shows the 'editor.cursorStyle' setting and does not reveal the settings table of contents.](https://code.visualstudio.com/assets/updates/1_97/settings-editor-search.png)
 
 ### Extension filter enhancements {#extension-filter-enhancements}
 
 To help you keep track of extensions that have updates available and to find extensions that were recently updated, you now have two new filter options in the Extensions view: `@outdated` and `@recentlyUpdated`.
 
-![Screenshot of the filtering options in the Extension view, highlighting the 'outdated' and 'recentlyUpdated' options.](images/1_97/extension-filters.png)
+![Screenshot of the filtering options in the Extension view, highlighting the 'outdated' and 'recentlyUpdated' options.](https://code.visualstudio.com/assets/updates/1_97/extension-filters.png)
 
 ### SVG image preview support {#svg-image-preview-support}
 
 The built-in image preview now has basic support for previewing SVG files.
 
-![Screenshot that shows the default preview of an SVG image in VS Code.](images/1_97/image-svg-preview.png)
+![Screenshot that shows the default preview of an SVG image in VS Code.](https://code.visualstudio.com/assets/updates/1_97/image-svg-preview.png)
 
 Check out the [Visual Studio Marketplace](https://marketplace.visualstudio.com/) for more advanced SVG preview extensions.
 
@@ -262,7 +262,7 @@ code --remove /path/to/rootfolder
 
 Last milestone, we introduced history persistence to the editor find control. In this milestone, we are extending that further to the replace input control, so that you can maintain both separately across multiple sessions. The replace history is stored per workspace and can be disabled via the `setting(editor.find.replaceHistory)` setting.
 
-<video src="images/1_97/replace-history.mp4" title="Video showing the persistence of editor replace history across VS Code reloads." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/replace-history.mp4" title="Video showing the persistence of editor replace history across VS Code reloads." autoplay loop controls muted></video>
 
 ### Comments {#comments}
 
@@ -274,7 +274,7 @@ A confirmation dialog will show when you `esc` or otherwise close a comment cont
 
 Quick actions can be used from the comments editor.
 
-![Screenshot that shows Quick actions in the Comments editor.](images/1_97/quick-actions-in-comment.gif)
+![Screenshot that shows Quick actions in the Comments editor.](https://code.visualstudio.com/assets/updates/1_97/quick-actions-in-comment.gif)
 
 ## Source Control {#source-control}
 
@@ -282,7 +282,7 @@ Quick actions can be used from the comments editor.
 
 This milestone, we continued to polish the feature to display git blame information in the editor and in the Status Bar. We have also improved the information that is shown when you hover over the editor decoration or the Status Bar item.
 
-![Screenshot that shows Git blame information when hovering over the git blame item in the Status Bar.](images/1_97/scm-git-blame.png)
+![Screenshot that shows Git blame information when hovering over the git blame item in the Status Bar.](https://code.visualstudio.com/assets/updates/1_97/scm-git-blame.png)
 
 The git blame Status Bar item is now enabled by default, and you can disable it by using the `setting(git.blame.statusBarItem.enabled:false)` setting. Enable the git blame editor decoration with the `setting(git.blame.editorDecoration.enabled:true)` setting.
 
@@ -292,7 +292,7 @@ We have also added commands to easily toggle the git blame information by using 
 
 For repositories that are hosted on GitHub, we have added a new command, **Open on GitHub**, to the timeline context menu and hover, the Source Control Graph context menu and hover, and the git blame editor decoration and Status Bar item hover.
 
-![Screenshot of the Source Control history item hover, highlighting the Open on GitHub link.](images/1_97/scm-graph-hover.png)
+![Screenshot of the Source Control history item hover, highlighting the Open on GitHub link.](https://code.visualstudio.com/assets/updates/1_97/scm-graph-hover.png)
 
 GitHub issue and pull request references are rendered as links in the timeline, Source Control Graph, and git blame editor decoration and Status Bar item hovers, so that they can be easily opened in a browser.
 
@@ -312,13 +312,13 @@ The notebook editor now supports showing inline values after cell execution with
 
 If there's no provider, the fallback approach matches values found in the kernel against the cell document via simple regex matching. It's recommended to use a provider from a language extension to ensure more accurate results.
 
-![Screenshot that shows inline values after cell execution in the notebook editor.](images/1_97/nb-inline-values.png)
+![Screenshot that shows inline values after cell execution in the notebook editor.](https://code.visualstudio.com/assets/updates/1_97/nb-inline-values.png)
 
 ### Custom font family for Markdown cells {#custom-font-family-for-markdown-cells}
 
 The notebook editor now supports setting a custom font family for rendered Markdown cells. This can be controlled with the `setting(notebook.markup.fontFamily)` setting. When left blank, the default workbench font family is used.
 
-![Screenshot that shows a custom font for rendered Markdown cells.](images/1_97/markdown-cell-font-family.png)
+![Screenshot that shows a custom font for rendered Markdown cells.](https://code.visualstudio.com/assets/updates/1_97/markdown-cell-font-family.png)
 
 ## Terminal {#terminal}
 
@@ -335,13 +335,13 @@ This feature is now considered stable. Here is a summary of the changes since th
 
 The `ESC ] 9 ; 4` escape sequence pioneered by ConEmu that reports progress in the terminal is now supported. This is used by some CLI tools such as `winget` to report progress. To view the progress in terminal tabs, add `${progress}` to either `setting(terminal.integrated.tabs.title)` or `setting(terminal.integrated.tabs.description)`. This typically shows as a progress spinner or as a percentage.
 
-<video src="images/1_97/terminal-progress.mp4" title="Video showing a progress indicator in the terminal title while running a 'winget' command." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/terminal-progress.mp4" title="Video showing a progress indicator in the terminal title while running a 'winget' command." autoplay loop controls muted></video>
 
 ### Sticky Scroll for truncated commands {#sticky-scroll-for-truncated-commands}
 
 Sticky Scroll in the terminal (`setting(terminal.integrated.stickyScroll.enabled)`) now shows when a command is truncated with an ellipsis at the end:
 
-![Screenshot that shows an ellipsis at the end of a command in Sticky Scroll when it is truncated.](images/1_97/terminal-sticky-scroll-ellipsis.png)
+![Screenshot that shows an ellipsis at the end of a command in Sticky Scroll when it is truncated.](https://code.visualstudio.com/assets/updates/1_97/terminal-sticky-scroll-ellipsis.png)
 
 ### Configure the behavior when the last terminal closes {#configure-the-behavior-when-the-last-terminal-closes}
 
@@ -359,7 +359,7 @@ The new `${columnNumber}` variable can be used in [`tasks.json`](https://code.vi
 
 You can now search within a view (`kb(list.find)`) in the Variables and Watch views to filter on variable and expression values, rather than just names.
 
-![Screenshot that shows the search control in the Variables view when debugging.](images/1_97/debug-search-values.png)
+![Screenshot that shows the search control in the Variables view when debugging.](https://code.visualstudio.com/assets/updates/1_97/debug-search-values.png)
 
 ### Select in the Debug Console {#select-in-the-debug-console}
 
@@ -379,7 +379,7 @@ This release includes the [TypeScript 5.7.3](https://github.com/microsoft/typesc
 
 You can now right click on a workspace image in the Markdown preview and select **Open Image** to open it in a new editor.
 
-![Screenshot that shows the context menu option to open an image in the Markdown preview.](images/1_97/md-preview-open-image.png)
+![Screenshot that shows the context menu option to open an image in the Markdown preview.](https://code.visualstudio.com/assets/updates/1_97/md-preview-open-image.png)
 
 This is supported for any images that are part of the current workspace.
 
@@ -389,7 +389,7 @@ VS Code's built-in Markdown features support automatically [validating local lin
 
 To help you discover this feature, we've added a new language status item for link validation:
 
-![Screenshot that shows the Markdown link validation language status item.](images/1_97/md-link-status-item.png)
+![Screenshot that shows the Markdown link validation language status item.](https://code.visualstudio.com/assets/updates/1_97/md-link-status-item.png)
 
 With a Markdown file open, select the `{}` in the Status Bar to view the link validation status. You can also use the status item to quickly toggle link validation off and on.
 
@@ -422,7 +422,7 @@ In order to ensure a strong security baseline for Microsoft authentication, we'v
 
 One of the stand out features of this work is WAM (Web Account Manager... also known as [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) integration. Put simply, rather than going to the browser for Microsoft authentication flows, we now talk to the OS directly, which is the recommended way of acquiring a Microsoft authentication session. Additionally, it's faster since we're able to leverage the accounts that you're already logged into on the OS.
 
-![Screenshot that shows an authentication popup that the OS shows over VS Code.](images/1_97/showingBrokerOSDialog.png)
+![Screenshot that shows an authentication popup that the OS shows over VS Code.](https://code.visualstudio.com/assets/updates/1_97/showingBrokerOSDialog.png)
 
 Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
 
@@ -432,25 +432,25 @@ Let us know if you see any issues with this new flow. If you do see a major issu
 
 You are now able to launch a VS Code Native REPL from your REPL in the terminal. Setting `setting(python.terminal.shellIntegration.enabled)` to `true` should display a clickable link in the Python REPL in the terminal, allowing you to directly open the VS Code Native REPL from the terminal.
 
-<video src="images/1_97/native-repl-link.mp4" title="Video showing the Native REPL entry point link in terminal REPL." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/native-repl-link.mp4" title="Video showing the Native REPL entry point link in terminal REPL." autoplay loop controls muted></video>
 
 #### No config debug {#no-config-debug}
 
 You are now able to debug a Python script or module without setup, right from the terminal as part of the new no-config debug feature! Check out the [wiki page](https://github.com/microsoft/vscode-python-debugger/wiki/No%E2%80%90Config-Debugging) on the feature for all the details and troubleshooting tips.
 
-<video src="images/1_97/no-config-debug.mp4" title="Video showing the no-config debug feature for Python." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/no-config-debug.mp4" title="Video showing the no-config debug feature for Python." autoplay loop controls muted></video>
 
 #### Test discovery cancellation {#test-discovery-cancellation}
 
 When triggering test discovery from the Test Explorer UI, you can now cancel an ongoing test discovery call. Use the Cancel button, which appears in replacement of the Refresh button during discovery.
 
-![Screenshot that shows the Test Explorer, highlighting the Cancel button to cancel the test discovery.](./images/1_97/test-discovery-cancelation.png)
+![Screenshot that shows the Test Explorer, highlighting the Cancel button to cancel the test discovery.](https://code.visualstudio.com/assets/updates/1_97/test-discovery-cancelation.png)
 
 #### Go to Implementation {#go-to-implementation}
 
 [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now has support for **Go to Implementation**, which allows you to more quickly navigate to the implementation of a function or method directly from its usage. This is a particularly helpful feature when working with inherited classes.
 
-![Screenshot that shows the Go to Implementation displayed via the context menu](./images/1_97/pylance-go-to-implementation.png)
+![Screenshot that shows the Go to Implementation displayed via the context menu](https://code.visualstudio.com/assets/updates/1_97/pylance-go-to-implementation.png)
 
 #### AI Code Action: Generate Symbol (Experimental) {#ai-code-action-generate-symbol-experimental}
 
@@ -462,7 +462,7 @@ There's a new experimental AI Code Action for generating symbols with Pylance an
 
 Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let Copilot handle the implementation! If you want, you can then leverage Pylance's **Move Symbol** Code Actions to move it to a different file.
 
-<video src="images/1_97/pylance-create-symbol-with-copilot.mp4" title="Video showing invoking a new class that doesn't exist and then selecting the 'Create Class With Copilot' code action to implement a new class." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/pylance-create-symbol-with-copilot.mp4" title="Video showing invoking a new class that doesn't exist and then selecting the 'Create Class With Copilot' code action to implement a new class." autoplay loop controls muted></video>
 
 ### GitHub Pull Requests and Issues {#github-pull-requests-and-issues}
 
@@ -480,11 +480,11 @@ Review the [changelog for the 0.104.0](https://github.com/microsoft/vscode-pull-
 
 We've been working on a new _agent mode_ for Copilot Edits. When in agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
 
-![Screenshot that shows agent mode in the Copilot Edits view.](images/1_97/agent-mode.png)
+![Screenshot that shows agent mode in the Copilot Edits view.](https://code.visualstudio.com/assets/updates/1_97/agent-mode.png)
 
 You can switch between the current edit mode that we've had for a few months and agent mode with the dropdown in the Copilot Edits view. To see the dropdown, enable the `setting(chat.agent.enabled)` setting. You can start using agent mode in [VS Code Insiders](https://code.visualstudio.com/insiders/) today. We will gradually be rolling it out to VS Code Stable users. If the setting doesn't show up for you in Stable, then it isn't enabled for you yet.
 
-![Screenshot of the agent mode setting in the Settings editor.](images/1_97/agent-setting.png)
+![Screenshot of the agent mode setting in the Settings editor.](https://code.visualstudio.com/assets/updates/1_97/agent-setting.png)
 
 In agent mode, Copilot runs autonomously, but it can only edit files within your current workspace. When it wants to run a terminal command, it shows you the command and waits for you to review it and select Continue before proceeding.
 
@@ -502,7 +502,7 @@ You can enable it with `setting(github.copilot.chat.edits.codesearch.enabled)`, 
 
 We're introducing end-to-end vision support in the pre-release version of GitHub Copilot Chat in [VS Code Insiders](https://code.visualstudio.com/insiders/). This lets you attach images and interact with images in Copilot Chat prompts. For example, if you're encountering an error while debugging, quickly attach a screenshot of VS Code and ask Copilot to help you resolve the issue.
 
-![Screenshot that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](images/1_97/image-attachments.gif)
+![Screenshot that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](https://code.visualstudio.com/assets/updates/1_97/image-attachments.gif)
 
 You can now attach images using several methods:
 
@@ -524,13 +524,13 @@ Learn more about [prompt files](https://aka.ms/vscode-ghcp-prompt-snippets) in t
 
 This milestone, we are starting an experiment to enable the custom title bar for a subset of Linux users.
 
-![Screenshot that shows the custom VS Code title bar on Linux.](images/1_97/custom-title.png)
+![Screenshot that shows the custom VS Code title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/custom-title.png)
 
 If you are not part of the experiment, you can manually configure `setting(window.titleBarStyle)` as `custom` to try it out.
 
 You can always revert back to the native title decorations, either from the custom title context menu or by configuring `setting(window.titleBarStyle)` to `native`.
 
-![Screenshot that shows the content menu option to disable the custom title bar on Linux.](images/1_97/restore-title.png)
+![Screenshot that shows the content menu option to disable the custom title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/restore-title.png)
 
 ### TypeScript 5.8 beta support {#typescript-58-beta-support}
 
@@ -608,7 +608,7 @@ By following our issue cleanup guide, we reviewed and triaged outdated, duplicat
 
 We appreciate the community’s continued engagement and feedback — your contributions make VS Code better every day! 🚀
 
-![Chart that shows the trend of the number of open issues over the last years. The chart shows a steep decline each year during December, the housekeeping month.](images/1_97/housekeeping.png)
+![Chart that shows the trend of the number of open issues over the last years. The chart shows a steep decline each year during December, the housekeeping month.](https://code.visualstudio.com/assets/updates/1_97/housekeeping.png)
 
 ### Resource optimization for file watching in TypeScript workspaces {#resource-optimization-for-file-watching-in-typescript-workspaces}
 

--- a/docs/release-notes/v1_97.md
+++ b/docs/release-notes/v1_97.md
@@ -7,630 +7,630 @@ MetaSocialImage: 1_97/release-highlights.png
 Date: 2025-02-06
 DownloadVersion: 1.97.0
 ---
-# January 2025 (version 1.97) {#january-2025}
+# 2025 年 1 月 (バージョン 1.97) {#january-2025}
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the January 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の2025 年1 月リリースへようこそ。このバージョンには多くのアップデートが含まれており、きっと気に入っていただけると思います。主なハイライトは次のとおりです。
 
-* [Next Edit Suggestions (preview)](#copilot-next-edit-suggestions-preview) - Copilot predicts the next edit you are likely to make.
-* [Reposition Command Palette](#move-the-command-palette-and-quick-inputs) - Drag the Command Palette and Quick Inputs to a new position.
-* [Auto accept edits](#improved-editor-controls) - Automatically accept edits from Copilot after a configurable timeout.
-* [Extension publisher trust](#trusting-extension-publishers) - Keep your environment secure with extension publisher trust.
-* [Compound logs](#compound-logs) - Combine multiple logs into a single, aggregated log view.
-* [Filter output logs](#output-panel-filtering) - Filter the contents of the Output panel.
-* [Git blame information](#git-blame-information) - Rich git blame information and open on GitHub.
-* [Search values in debug variables](#filter-and-search-on-values) - Filter and search for specific values in debug variables.
-* [Notebook inline values](#inline-values-upon-cell-execution) - View inline values for code cell variables in notebooks.
-* [Python no-config debug](#no-config-debug) - Quickly debug a Python script or module without setup.
+* [次の編集候補 (プレビュー)](#copilot-next-edit-suggestions-preview) - Copilot が、次に行う可能性のある編集を予測します。
+* [コマンドパレットの再配置](#move-the-command-palette-and-quick-inputs) - コマンドパレットとクイック入力を新しい位置にドラッグします。
+* [編集の自動承認](#improved-editor-controls) - 設定可能なタイムアウト後、Copilot からの編集を自動的に承認します。
+* [拡張機能の発行者の信頼](#trusting-extension-publishers) - 拡張機能の発行者の信頼で、環境を安全に保ちます。
+* [複合ログ](#compound-logs) - 複数のログを単一の集約されたログビューに結合します。
+* [出力ログのフィルタリング](#output-panel-filtering) - 出力パネルの内容をフィルタリングします。
+* [Git blame 情報](#git-blame-information) - 豊富な Git blame 情報と GitHub でのオープン。
+* [デバッグ変数の値を検索](#filter-and-search-on-values) - デバッグ変数内の特定の値でフィルタリングおよび検索します。
+* [ノートブックのインライン値](#inline-values-upon-cell-execution) - ノートブックのコードセルの変数のインライン値を表示します。
+* [Python の設定不要デバッグ](#no-config-debug) - 設定なしで Python スクリプトまたはモジュールをすばやくデバッグします。
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+> これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** 新機能をいち早く試したいですか？ nightly [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新のアップデートをすぐに試すことができます。
 
 ## GitHub Copilot {#github-copilot}
 
-### Copilot Next Edit Suggestions (Preview) {#copilot-next-edit-suggestions-preview}
+### Copilot の次の編集候補 (プレビュー) {#copilot-next-edit-suggestions-preview}
 
-**Setting**: `setting(github.copilot.nextEditSuggestions.enabled)`
+**設定:** `setting(github.copilot.nextEditSuggestions.enabled)`
 
-GitHub Copilot code completions are great at autocomplete, but since most coding activity is editing existing code, it's a natural evolution of completions to also help with edits. So, we're excited to release a new preview feature, **Copilot Next Edit Suggestions** (Copilot NES).
+GitHub Copilot のコード補完はオートコンプリートに優れていますが、ほとんどのコーディングアクティビティは既存のコードの編集であるため、補完の自然な進化として、編集も支援することが考えられます。そこで、新しいプレビュー機能である **Copilot の次の編集候補**(Copilot NES) をリリースすることになりました。
 
-Based on the edits you're making, Copilot NES both predicts the location of the next edit you'll want to make and what that edit should be. NES suggests future changes relevant to your current work, and you can simply `kbstyle(Tab)` to quickly navigate and accept suggestions.
+Copilot NES は、行っている編集に基づいて、次に行いたい編集の場所と、その編集内容を予測します。NES は現在の作業に関連する将来の変更を提案し、`kbstyle(Tab)` を使用してすばやく移動し、提案を受け入れることができます。
 
-Notice in the following example that changing a variable triggers an edit suggestion further down the file. Just use the `kbstyle(Tab)` key to navigate and accept the suggestion. The gutter indicator will guide you to your next edit suggestion.
+次の例では、変数を変更すると、ファイルのさらに下にある編集候補がトリガーされることに注目してください。`kbstyle(Tab)` キーを使用して、候補を移動して受け入れるだけです。gutter インジケーターは、次の編集候補に案内します。
 
-![Video showing Copilot NES suggesting code edits at another location. The gutter shows an arrow indicating the relative position of the edit.](https://code.visualstudio.com/assets/updates/1_97/nes-arrow-directions.gif)
+![Copilot NES が別の場所でコード編集を提案するビデオ。gutter には、編集の相対的な位置を示す矢印が表示されます。](https://code.visualstudio.com/assets/updates/1_97/nes-arrow-directions.gif)
 
-Enable Copilot NES via the VS Code setting `setting(github.copilot.nextEditSuggestions.enabled)`.
+VS Code の設定 `setting(github.copilot.nextEditSuggestions.enabled)` を使用して Copilot NES を有効にします。
 
-Based on the size and type of edit, the rendering of the suggestion might change dynamically from side-by-side to below the current line. Configure the `setting(editor.inlineSuggest.edits.renderSideBySide:never)` setting to always render suggestions below the current line.
+編集のサイズと種類に基づいて、候補のレンダリングは、サイドバイサイドから現在の行の下に動的に変更される場合があります。`setting(editor.inlineSuggest.edits.renderSideBySide:never)` 設定を構成して、常に現在の行の下に候補をレンダリングします。
 
-Copilot NES is rapidly evolving, and we can't wait to get your feedback via issues in [our repo](https://github.com/microsoft/vscode-copilot-release). You can read our full [Copilot NES docs](https://aka.ms/gh-copilot-nes-docs) for more information and scenarios as we expand the NES experience.
+Copilot NES は急速に進化しており、[リポジトリ](https://github.com/microsoft/vscode-copilot-release) の issue でフィードバックをお待ちしています。NES エクスペリエンスの拡張に伴い、詳細とシナリオについては、[Copilot NES のドキュメント](https://aka.ms/gh-copilot-nes-docs) をお読みください。
 
-> **Note**: If you are a Copilot Business or Enterprise user, an administrator of your organization [must opt in](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) to the use of previews of Copilot features, in addition to you setting `setting(github.copilot.nextEditSuggestions.enabled)` in your editor.
+> **注:** Copilot Business または Enterprise ユーザーの場合、組織の管理者は、エディターで `setting(github.copilot.nextEditSuggestions.enabled)` を設定することに加えて、Copilot 機能のプレビューの使用を [オプトイン](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) する必要があります。
 
 ### Copilot Edits {#copilot-edits}
 
-#### Copilot Edits general availability {#copilot-edits-general-availability}
+#### Copilot Edits の一般提供開始 {#copilot-edits-general-availability}
 
-In our VS Code October release, we announced the preview of Copilot Edits. Today, we're now announcing the general availability of Copilot Edits! Copilot Edits is optimized for code editing and enables you to make code changes across multiple files in your workspace, directly from chat.
+VS Code の10 月のリリースで、Copilot Edits のプレビューを発表しました。本日、Copilot Edits の一般提供開始を発表します! Copilot Edits はコード編集用に最適化されており、チャットから直接、ワークスペース内の複数のファイルにわたってコードを変更できます。
 
-#### Improved editor controls {#improved-editor-controls}
+#### エディターコントロールの改善 {#improved-editor-controls}
 
-Edits can now be accepted and discarded individually, giving you more control. Also new is that the editor controls for edits remain visible when switching to the side-by-side view. This is useful for understanding larger changes.
+編集を個別に承認および破棄できるようになり、より詳細な制御が可能になりました。また、サイドバイサイドビューに切り替えても、編集用のエディターコントロールが表示されたままになるようになりました。これは、より大きな変更を理解するのに役立ちます。
 
-![Screenshot that shows how to accept an individual change from Copilot Edits in the editor.](https://code.visualstudio.com/assets/updates/1_97/edits-accept-hunk.png)
-_Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
+![エディターで Copilot Edits から個々の変更を受け入れる方法を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/edits-accept-hunk.png)
+_テーマ: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) ([vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)) でプレビュー)_
 
-Lastly, we have added a new setting for automatically accepting edit suggestions after a configurable timeout. The setting for that is `setting(chat.editing.autoAcceptDelay)`, which specifies the number of seconds after which changes are accepted. The countdown stops when you interact with the accept button or when you start to review changes. This should be familiar to anyone who binge-watches on the weekends.
+最後に、設定可能なタイムアウト後に編集候補を自動的に受け入れるための新しい設定を追加しました。その設定は `setting(chat.editing.autoAcceptDelay)` で、変更が受け入れられるまでの秒数を指定します。承認ボタンを操作するか、変更の確認を開始すると、カウントダウンが停止します。これは、週末に一気見する人にはおなじみのはずです。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/edits-auto-accept.mp4" title="Video showing a gradient on the Accept button for Copilot Edits, indicating the auto-accept progress." autoplay loop controls muted></video>
-_Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
+<video src="https://code.visualstudio.com/assets/updates/1_97/edits-auto-accept.mp4" title="Copilot Edits の [承認] ボタンのグラデーションを示すビデオ。自動承認の進行状況を示します。" autoplay loop controls muted></video>
+_テーマ: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) ([vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)) でプレビュー)_
 
-### Apply in editor {#apply-in-editor}
+### エディターで適用 {#apply-in-editor}
 
-In Copilot Chat, any code block can be applied to a file in the workspace by using the **Apply to Editor** action in the toolbar of the code block.
-We made several improvements to this experience:
+Copilot Chat では、コードブロックのツールバーにある **エディターに適用** アクションを使用すると、ワークスペース内のファイルにコードブロックを適用できます。
+このエクスペリエンスには、いくつかの改善が加えられました。
 
-- The hover of the action now shows the file the code block was generated for.
+- アクションのホバーで、コードブロックが生成されたファイルが表示されるようになりました。
 
-  ![Screenshot that shows the Apply Code Block hover text, indicating the target file name.](https://code.visualstudio.com/assets/updates/1_97/apply-code-block-hover.png)
+  ![ターゲットファイル名を示す [コードブロックの適用] ホバーテキストを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/apply-code-block-hover.png)
 
-- If the code block is for a non-existent file, you are prompted where to create the file. This can be at a file path suggested by Copilot, in an untitled editor, or in the currently active editor.
+- コードブロックが存在しないファイルの場合、ファイルの作成場所を尋ねられます。これは、Copilot が提案したファイルパス、名前のないエディター、または現在アクティブなエディターにすることができます。
 
-- When the changes are computed and applied, the same flow and UI as for Copilot Edits are used. You can review, improve, or discard each change individually.
+- 変更が計算されて適用されると、Copilot Edits と同じフローと UI が使用されます。各変更を個別に確認、改善、または破棄できます。
 
-### Temporal context {#temporal-context}
+### テンポラルコンテキスト {#temporal-context}
 
-Temporal context helps when editing or generating code by informing the language model about files that you have recently interacted with. We are experimenting and measuring its effectiveness but it can also be enabled manually,  `setting(github.copilot.chat.editor.temporalContext.enabled)` for Inline Chat and `setting(github.copilot.chat.edits.temporalContext.enabled)` for Copilot Edits.
+テンポラルコンテキストは、最近操作したファイルに関する言語モデルに通知することで、コードの編集または生成時に役立ちます。効果を実験および測定していますが、インラインチャットの場合は `setting(github.copilot.chat.editor.temporalContext.enabled)`、Copilot Edits の場合は `setting(github.copilot.chat.edits.temporalContext.enabled)` を手動で有効にすることもできます。
 
-### Workspace index status UI {#workspace-index-status-ui}
+### ワークスペースインデックスのステータス UI {#workspace-index-status-ui}
 
-When you ask Copilot a question about the code in your project by using `@workspace` or `#codebase`, we use an index to quickly and accurately search your codebase for relevant code snippets to include as context. This index can either be a [remote index managed by GitHub](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index), [a locally stored index](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index), or [a basic index](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) used as a fallback for large projects that can't use a remote index.
+`@workspace` または `#codebase` を使用して、プロジェクト内のコードに関する質問を Copilot に行うと、インデックスを使用して、関連するコードスニペットをすばやく正確に検索し、コンテキストとして含めます。このインデックスは、[GitHub によって管理されるリモートインデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index)、[ローカルに保存されたインデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index)、またはリモートインデックスを使用できない大規模なプロジェクトのフォールバックとして使用される [基本インデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) のいずれかになります。
 
-This iteration, we've added the new workspace index to the language status indicator in the Status Bar that shows the type of index being used by Copilot and related information, such as the number of files being reindexed. To see this, just select the `{}` icon in the VS Code Status Bar.
+今回のイテレーションでは、Copilot が使用しているインデックスの種類や、再インデックスされているファイルの数などの関連情報を示す、ステータスバーの言語ステータスインジケーターに、新しいワークスペースインデックスを追加しました。これを確認するには、VS Code のステータスバーにある `{}` アイコンを選択するだけです。
 
-![Screenshot that shows the status of the Copilot workspace indexing in the Status Bar.](https://code.visualstudio.com/assets/updates/1_97/copilot-workspace-status.png)
+![ステータスバーでの Copilot ワークスペースインデックスのステータスを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/copilot-workspace-status.png)
 
-Check out the [Copilot workspace docs](https://code.visualstudio.com/docs/copilot/workspace-context#_managing-the-workspace-index) for more info about the types of workspace indexes and how you can switch between them.
+ワークスペースインデックスの種類と、それらを切り替える方法の詳細については、[Copilot ワークスペースドキュメント](https://code.visualstudio.com/docs/copilot/workspace-context#_managing-the-workspace-index) を参照してください。
 
-### Build a remote workspace index {#build-a-remote-workspace-index}
+### リモートワークスペースインデックスの構築 {#build-a-remote-workspace-index}
 
-[Remote workspace indexes](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index) are managed by GitHub. A remote index can provide high-quality results quickly, even for large projects. They also only have to be built once per GitHub project, instead of once per user.
+[リモートワークスペースインデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index) は、GitHub によって管理されます。リモートインデックスは、大規模なプロジェクトでも、高品質の結果をすばやく提供できます。また、ユーザーごとに1 回ではなく、GitHub プロジェクトごとに1 回構築するだけで済みます。
 
-Given all these advantages, we have added several new ways to upgrade a project to a remote index:
+これらの利点を考慮して、プロジェクトをリモートインデックスにアップグレードするためのいくつかの新しい方法を追加しました。
 
-- Run the new **GitHub Copilot: Build Remote Index** command.
+- 新しい **GitHub Copilot: リモートインデックスの構築** コマンドを実行します。
 
-- Select the Build Index button in the [workspace index status UI](#workspace-index-status-ui). This only shows up if your project is eligible for remote indexing.
+- [ワークスペースインデックスのステータス UI](#workspace-index-status-ui) で [インデックスの構築] ボタンを選択します。これは、プロジェクトがリモートインデックス作成の対象となる場合にのみ表示されます。
 
-- Select the Build Index button in the first `@workspace` response you see. This only shows up if your project is eligible and also only shows once per workspace.
+- 最初に表示される `@workspace` 応答で [インデックスの構築] ボタンを選択します。これは、プロジェクトが対象となる場合にのみ表示され、ワークスペースごとに1 回のみ表示されます。
 
-Keep in mind that only projects with a GitHub remote can currently use a remote index. It may also take some time to build up the remote index, especially if your project is large. Check the [Workspace index status UI](#workspace-index-status-ui) to see if remote indexing has completed.
+現在、GitHub リモートを持つプロジェクトのみがリモートインデックスを使用できることに注意してください。また、特にプロジェクトが大きい場合は、リモートインデックスの構築に時間がかかる場合があります。[ワークスペースインデックスのステータス UI](#workspace-index-status-ui) を確認して、リモートインデックス作成が完了したかどうかを確認します。
 
-### Workspace search improvements {#workspace-search-improvements}
+### ワークスペース検索の改善 {#workspace-search-improvements}
 
-We've also continued optimizing code search for `@workspace` and `#codebase`. Highlights include:
+`@workspace` および `#codebase` のコード検索の最適化も継続しています。ハイライトは次のとおりです。
 
-- Improved tracking and handling of locally changed files when using a [remote index](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index).
+- [リモートインデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_remote-index) を使用する場合の、ローカルで変更されたファイルの追跡と処理の改善。
 
-- Added background updating of changed files in the [local index](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index), so that `@workspace` questions don't have to wait for them to be updated.
+- `@workspace` の質問が更新を待つ必要がないように、[ローカルインデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_local-index) で変更されたファイルのバックグラウンド更新を追加しました。
 
-- Optimized the [basic index](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) for large projects.
+- 大規模なプロジェクト向けに [基本インデックス](https://code.visualstudio.com/docs/copilot/workspace-context#_basic-index) を最適化しました。
 
-### Git changes context variable {#git-changes-context-variable}
+### Git の変更コンテキスト変数 {#git-changes-context-variable}
 
-When writing queries for Chat or Edits, you can now reference files that were modified in Git source control by using the `#changes` context variable. For example, you could prompt for `summarize the #changes in my workspace`.
+チャットまたは Edits のクエリを作成するときに、`#changes` コンテキスト変数を使用して、Git ソース管理で変更されたファイルを参照できるようになりました。たとえば、`ワークスペース内の #changes を要約する` ように求めることができます。
 
-![Screenshot of a Copilot chat response, which lists the modified files and changes when prompting for '#changes'.](https://code.visualstudio.com/assets/updates/1_97/copilot-chat-git-changes.png)
+![Copilot チャットの応答のスクリーンショット。'#changes' を要求すると、変更されたファイルと変更が一覧表示されます。](https://code.visualstudio.com/assets/updates/1_97/copilot-chat-git-changes.png)
 
-### Model availability {#model-availability}
+### モデルの可用性 {#model-availability}
 
-You now have even more models to choose from when using Copilot. The following models are now available in the model picker in Visual Studio Code and github.com chat:
+Copilot を使用する際に選択できるモデルがさらに増えました。次のモデルが、Visual Studio Code および github.com チャットのモデルピッカーで利用できるようになりました。
 
-- **OpenAI’s o3-mini**: OpenAI’s newest reasoning model to your coding workflow, is rolling out gradually and will be available to GitHub Copilot Pro, Business, and Enterprise users. Learn more about the o3-mini model availability in the [GitHub blog post](https://github.blog/changelog/2025-01-31-openai-o3-mini-now-available-in-github-copilot-and-github-models-public-preview/).
+- **OpenAI の o3-mini**: OpenAI の最新の推論モデルをコーディングワークフローに追加し、段階的に展開され、GitHub Copilot Pro、Business、および Enterprise ユーザーが利用できるようになります。o3-mini モデルの可用性の詳細については、[GitHub ブログ投稿](https://github.blog/changelog/2025-01-31-openai-o3-mini-now-available-in-github-copilot-and-github-models-public-preview/) を参照してください。
 
-- **Gemini 2.0 Flash**: Google’s latest model shows high capabilities for code suggestions, documentation, and explaining code. This model is now available to all GitHub Copilot customers, including Copilot Free. Learn more about the Gemini 2.0 Flash model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-05-google-gemini-2-0-flash-is-now-available-to-all-copilot-users-in-public-preview/).
+- **Gemini 2.0 Flash**: Google の最新モデルは、コードの提案、ドキュメント、およびコードの説明において高い能力を発揮します。このモデルは、Copilot Free を含むすべての GitHub Copilot 顧客が利用できるようになりました。Gemini 2.0 Flash モデルの可用性の詳細については、[GitHub ブログ投稿](https://github.blog/changelog/2025-02-05-google-gemini-2-0-flash-is-now-available-to-all-copilot-users-in-public-preview/) を参照してください。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Enhanced accessibility sounds {#enhanced-accessibility-sounds}
+### アクセシビリティサウンドの強化 {#enhanced-accessibility-sounds}
 
-We've refined several accessibility sounds based on user feedback to improve clarity and distinction. The following sounds have been updated:
+ユーザーからのフィードバックに基づいて、いくつかのアクセシビリティサウンドを改良し、明瞭さと区別を向上させました。次のサウンドが更新されました。
 
 - `setting(accessibility.signals.save)`
 - `setting(accessibility.signals.lineHasFoldedArea)`
 - `setting(accessibility.signals.terminalQuickFix)`
 - `setting(accessibility.signals.lineHasInlineSuggestion)`
 
-You can preview these updates by running the command **Help: List Signal Sounds** from the Command Palette.
+コマンドパレットから **ヘルプ: シグナルサウンドの一覧表示** コマンドを実行して、これらの更新をプレビューできます。
 
-### Copilot Edits Accessibility Help dialog {#copilot-edits-accessibility-help-dialog}
+### Copilot Edits アクセシビリティヘルプダイアログ {#copilot-edits-accessibility-help-dialog}
 
-Screen reader users can now access guidance on interacting with Copilot Edits by invoking:
-`kb(editor.action.accessibilityHelp)` within the input box.
+スクリーンリーダーのユーザーは、以下を呼び出すことで、Copilot Edits との対話に関するガイダンスにアクセスできるようになりました:
+入力ボックス内の `kb(editor.action.accessibilityHelp)`
 
-Additionally, when an editor contains pending Copilot edits, this status is now indicated in the editor help dialog. We've also introduced keyboard shortcuts for navigating next `kb(chatEditor.action.navigateNext)` / previous `kb(chatEditor.action.navigatePrevious)`, accepting `kb(chatEditor.action.acceptHunk)`, discarding `kb(chatEditor.action.undoHunk)`, and toggling the diff view `kb(chatEditor.action.diffHunk)`.
+さらに、エディターに保留中の Copilot 編集が含まれている場合、このステータスがエディターヘルプダイアログに表示されるようになりました。また、次の移動 `kb(chatEditor.action.navigateNext)`/前の移動 `kb(chatEditor.action.navigatePrevious)`、承認 `kb(chatEditor.action.acceptHunk)`、破棄 `kb(chatEditor.action.undoHunk)`、および差分ビューの切り替え `kb(chatEditor.action.diffHunk)` のキーボードショートカットも導入しました。
 
-### Source Control Accessibility Help dialog {#source-control-accessibility-help-dialog}
+### ソース管理アクセシビリティヘルプダイアログ {#source-control-accessibility-help-dialog}
 
-If you invoke the **Show Accessibility Help** command while the Source Control view is focused, it opens the Source Control Accessibility Help dialog to provide important information for screen reader users. The dialog contains the summary of the current source control state and general information about the views and how to navigate them.
+ソース管理ビューにフォーカスがあるときに **アクセシビリティヘルプの表示** コマンドを呼び出すと、ソース管理アクセシビリティヘルプダイアログが開き、スクリーンリーダーのユーザーに重要な情報が提供されます。ダイアログには、現在のソース管理状態の概要と、ビューに関する一般的な情報、およびそれらをナビゲートする方法が含まれています。
 
-### Improved screen reader notifications {#improved-screen-reader-notifications}
+### スクリーンリーダーの通知の改善 {#improved-screen-reader-notifications}
 
-When a screen reader is detected, related notifications now include a link to learn more, providing additional context and resources.
+スクリーンリーダーが検出されると、関連する通知に詳細情報へのリンクが含まれるようになり、追加のコンテキストとリソースが提供されます。
 
-### Ignore code blocks in text to speech {#ignore-code-blocks-in-text-to-speech}
+### テキスト読み上げでコードブロックを無視する {#ignore-code-blocks-in-text-to-speech}
 
-Previously, when you used text-to-speech to read out a Copilot response, code blocks were also read out loud. You can ignore code blocks from text-to-speech sessions by using the `setting(accessibility.voice.ignoreCodeBlocks)` setting.
+以前は、テキスト読み上げを使用して Copilot の応答を読み上げると、コードブロックも読み上げられていました。`setting(accessibility.voice.ignoreCodeBlocks)` 設定を使用すると、テキスト読み上げセッションからコードブロックを無視できます。
 
-## Workbench {#workbench}
+## ワークベンチ {#workbench}
 
-### Move the Command Palette and Quick Inputs {#move-the-command-palette-and-quick-inputs}
+### コマンドパレットとクイック入力を移動する {#move-the-command-palette-and-quick-inputs}
 
-You can now move the Command Palette and other Quick Inputs to a new position, instead of having it fixed at the top of the window.
+コマンドパレットやその他のクイック入力を、ウィンドウの上部に固定するのではなく、新しい位置に移動できるようになりました。
 
-Features:
+機能:
 
-* Drag and drop the Command Palette or any other Quick Input with snapping to center and top
-* Persisted position across reloads, allowing you to set a new permanent position for Quick Inputs
-* Preset positions are available in the Customize Layout picker
+* コマンドパレットまたはその他のクイック入力をドラッグアンドドロップして、中央と上部にスナップします。
+* リロード間で位置が保持されるため、クイック入力の新しい永続的な位置を設定できます。
+* プリセット位置は、[レイアウトのカスタマイズ] ピッカーで利用できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/quick-pick-move.mp4" title="Video showing moving the Command Palette around the screen and watching it snap into different places. Then opening Customize Layout to play with the presets: top & center." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/quick-pick-move.mp4" title="画面上でコマンドパレットを移動し、さまざまな場所にスナップするのを見るビデオ。次に、[レイアウトのカスタマイズ] を開いて、プリセット (上部と中央) を操作します。" autoplay loop controls muted></video>
 
-### Trusting extension publishers {#trusting-extension-publishers}
+### 拡張機能の発行者を信頼する {#trusting-extension-publishers}
 
-When you install an extension from a publisher for the first time you will now see a dialog to help you assess the trustworthiness of the extension publisher. This feature helps ensure that you only install extensions from trusted sources, enhancing the security of your development environment.
+発行者から拡張機能を初めてインストールすると、拡張機能の発行者の信頼性を評価するのに役立つダイアログが表示されるようになりました。この機能は、信頼できるソースからの拡張機能のみをインストールするようにし、開発環境のセキュリティを強化するのに役立ちます。
 
-![Screenshot that shows the Trust Publisher dialog that is shown when a user installs an extension.](https://code.visualstudio.com/assets/updates/1_97/trust-publisher-dialog.png)
+![ユーザーが拡張機能をインストールするときに表示される [発行者の信頼] ダイアログを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/trust-publisher-dialog.png)
 
-If you install an extension pack or an extension with dependencies, trusting the publisher will also implicitly trust the publishers of the extensions that get installed along with it.
+拡張機能パックまたは依存関係のある拡張機能をインストールする場合、発行者を信頼すると、一緒にインストールされる拡張機能の発行者も暗黙的に信頼されます。
 
-When you update to the VS Code 1.97 release, the publishers of currently installed extensions are automatically trusted. You can manage the trusted extension publishers with the **Extensions: Manage Trusted Extensions Publishers** command. This command allows you to reset or revoke trust for publishers you have previously trusted.
+VS Code 1.97 リリースに更新すると、現在インストールされている拡張機能の発行者は自動的に信頼されます。**拡張機能: 信頼できる拡張機能の発行者の管理** コマンドを使用して、信頼できる拡張機能の発行者を管理できます。このコマンドを使用すると、以前に信頼した発行者の信頼をリセットまたは取り消すことができます。
 
-![Screenshot that shows the Quick Pick list of trusted publishers, enabling unchecking publishers to make them untrusted.](https://code.visualstudio.com/assets/updates/1_97/manage-trusted-publishers.png)
+![信頼できる発行者のクイックピッキングリストを示すスクリーンショット。発行者のチェックを外して信頼できないようにすることができます。](https://code.visualstudio.com/assets/updates/1_97/manage-trusted-publishers.png)
 
-**Note**: When no VS Code window is open and you install an extension from the CLI (`code-insiders --install-extension pub.name`), the extension is installed, but the publisher is not added to the trusted list.
+**注:** VS Code ウィンドウが開いていないときに、CLI から拡張機能をインストールする場合 (`code-insiders --install-extension pub.name`)、拡張機能はインストールされますが、発行者は信頼できるリストに追加されません。
 
-For more information, you can visit the [learn more](https://aka.ms/vscode-extension-security) link.
+詳細については、[詳細はこちら](https://aka.ms/vscode-extension-security) リンクにアクセスしてください。
 
-### Output panel filtering {#output-panel-filtering}
+### 出力パネルのフィルタリング {#output-panel-filtering}
 
-You can now filter the contents of the Output panel, which can greatly improve managing and analyzing logs, especially when you have to deal with large volumes of log data.
+出力パネルの内容をフィルタリングできるようになりました。これにより、特に大量のログデータを処理する必要がある場合に、ログの管理と分析が大幅に改善されます。
 
-![Screenshot of the Output panel, highlighting the filtering dropdown.](https://code.visualstudio.com/assets/updates/1_97/output-view-filtering.png)
+![出力パネルのスクリーンショット。フィルタリングドロップダウンが強調表示されています。](https://code.visualstudio.com/assets/updates/1_97/output-view-filtering.png)
 
-- **Filter by Log Level:** Filter logs based on their severity level (for example, Error, Warning, Info). This helps you focus on the most critical issues first.
-- **Filter by Category:** Narrow down logs by specific categories, allowing you to isolate logs from particular sources or components. The categories are picked up automatically from the log data.
-- **Filter by Text:** Search for specific text within the logs to quickly locate relevant entries.
+- **ログレベルでフィルタリング:** 重大度レベル (エラー、警告、情報など) に基づいてログをフィルタリングします。これにより、最も重要な問題に最初に焦点を当てることができます。
+- **カテゴリでフィルタリング:** 特定のカテゴリでログを絞り込み、特定のソースまたはコンポーネントからのログを分離できます。カテゴリは、ログデータから自動的に取得されます。
+- **テキストでフィルタリング:** ログ内の特定のテキストを検索して、関連するエントリをすばやく見つけます。
 
-### Compound logs {#compound-logs}
+### 複合ログ {#compound-logs}
 
-Sometimes you find that information is spread across multiple logs, and you need to view them together to get a complete picture. You can now view multiple logs in a single compound log view. Combine this with the new [filtering](#output-panel-filtering) functionality and analyzing logs has just become much better!
+情報が複数のログに分散しており、全体像を把握するためにそれらをまとめて表示する必要がある場合があります。複数のログを単一の複合ログビューで表示できるようになりました。これを新しい [フィルタリング](#output-panel-filtering) 機能と組み合わせると、ログの分析がはるかに簡単になります。
 
-To create a custom compound log, use the **Create Compound Log...** action in the overflow menu of the Output panel.
+カスタム複合ログを作成するには、出力パネルのオーバーフローメニューにある **複合ログの作成...** アクションを使用します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/compound-log.mp4" title="Video showing how to create a compound log that combines the log messages from two other logs." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/compound-log.mp4" title="2 つの他のログからのログメッセージを結合する複合ログを作成する方法を示すビデオ。" autoplay loop controls muted></video>
 
-You can also open compound logs in an editor or a new VS Code window for flexible monitoring and analysis. This feature improves your ability to diagnose issues by providing a consolidated view of related logs.
+また、柔軟な監視と分析のために、複合ログをエディターまたは新しい VS Code ウィンドウで開くこともできます。この機能は、関連するログの統合ビューを提供することで、問題を診断する機能を向上させます。
 
-> **Note:** Compound log views are currently not persisted across VS Code restarts.
+> **注:** 複合ログビューは、現在 VS Code の再起動後も保持されません。
 
-### Export and import logs {#export-and-import-logs}
+### ログのエクスポートとインポート {#export-and-import-logs}
 
-You can now export and import logs using the actions in the overflow menu of the Output view. This feature enhances collaboration and log management by making it easy to share and review logs.
+出力ビューのオーバーフローメニューにあるアクションを使用して、ログをエクスポートおよびインポートできるようになりました。この機能は、ログの共有とレビューを容易にすることで、コラボレーションとログ管理を強化します。
 
-Select the corresponding **Export Logs** or **Import Log** action in the overflow menu of the Output panel to export or import logs.
+出力パネルのオーバーフローメニューで対応する **ログのエクスポート** または **ログのインポート** アクションを選択して、ログをエクスポートまたはインポートします。
 
-### Settings editor search fixes {#settings-editor-search-fixes}
+### 設定エディターの検索の修正 {#settings-editor-search-fixes}
 
-This iteration, we fixed a regression where search queries with missing letters were not showing expected results. For example, the Settings editor was not finding the `setting(editor.formatOnPaste)` setting when you searched for "editor formonpast".
+今回のイテレーションでは、文字が欠落している検索クエリで予期される結果が表示されないという回帰を修正しました。たとえば、"editor formonpast" を検索しても、設定エディターで `setting(editor.formatOnPaste)` 設定が見つかりませんでした。
 
-We also fixed an issue where the Settings editor would reveal the table of contents during a search even when it was in a narrow editor group.
+また、設定エディターが狭いエディターグループにある場合でも、検索中に目次が表示される問題を修正しました。
 
-![Screenshot of a narrow-width Settings editor, with a search for 'edtor cursstyle' that shows the 'editor.cursorStyle' setting and does not reveal the settings table of contents.](https://code.visualstudio.com/assets/updates/1_97/settings-editor-search.png)
+![幅の狭い設定エディターのスクリーンショット。"edtor cursstyle" の検索では、"editor.cursorStyle" 設定が表示され、設定の目次は表示されません。](https://code.visualstudio.com/assets/updates/1_97/settings-editor-search.png)
 
-### Extension filter enhancements {#extension-filter-enhancements}
+### 拡張機能フィルターの機能強化 {#extension-filter-enhancements}
 
-To help you keep track of extensions that have updates available and to find extensions that were recently updated, you now have two new filter options in the Extensions view: `@outdated` and `@recentlyUpdated`.
+更新プログラムが利用可能な拡張機能を追跡したり、最近更新された拡張機能を見つけたりするのに役立つように、拡張機能ビューに2 つの新しいフィルターオプション `@outdated` と `@recentlyUpdated` が追加されました。
 
-![Screenshot of the filtering options in the Extension view, highlighting the 'outdated' and 'recentlyUpdated' options.](https://code.visualstudio.com/assets/updates/1_97/extension-filters.png)
+![拡張機能ビューのフィルタリングオプションのスクリーンショット。"outdated" および "recentlyUpdated" オプションが強調表示されています。](https://code.visualstudio.com/assets/updates/1_97/extension-filters.png)
 
-### SVG image preview support {#svg-image-preview-support}
+### SVG 画像プレビューのサポート {#svg-image-preview-support}
 
-The built-in image preview now has basic support for previewing SVG files.
+組み込みの画像プレビューで、SVG ファイルのプレビューの基本的なサポートが追加されました。
 
-![Screenshot that shows the default preview of an SVG image in VS Code.](https://code.visualstudio.com/assets/updates/1_97/image-svg-preview.png)
+![VS Code での SVG 画像のデフォルトプレビューを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/image-svg-preview.png)
 
-Check out the [Visual Studio Marketplace](https://marketplace.visualstudio.com/) for more advanced SVG preview extensions.
+より高度な SVG プレビュー拡張機能については、[Visual Studio Marketplace](https://marketplace.visualstudio.com/) を参照してください。
 
-### Remove a root folder from a workspace from the CLI {#remove-a-root-folder-from-a-workspace-from-the-cli}
+### CLI からワークスペースからルートフォルダーを削除する {#remove-a-root-folder-from-a-workspace-from-the-cli}
 
-Previously, you could already add a root folder to a [multi-root workspace](https://code.visualstudio.com/docs/editor/workspaces/multi-root-workspaces) by using the `--add` [command-line](https://code.visualstudio.com/docs/editor/command-line#_advanced-cli-options) option.
+以前は、`--add` [コマンドライン](https://code.visualstudio.com/docs/editor/command-line#_advanced-cli-options) オプションを使用して、[マルチルートワークスペース](https://code.visualstudio.com/docs/editor/workspaces/multi-root-workspaces) にルートフォルダーを追加できました。
 
-We've now also added the ability to remove a root folder from a multi-root workspace with the new `--remove` command-line option.
+新しい `--remove` コマンドラインオプションを使用して、マルチルートワークスペースからルートフォルダーを削除する機能も追加しました。
 
 ```bash
 code --remove /path/to/rootfolder
 ```
 
-## Editor {#editor}
+## エディター {#editor}
 
-### Persist find and replace history {#persist-find-and-replace-history}
+### 検索と置換履歴の保持 {#persist-find-and-replace-history}
 
-Last milestone, we introduced history persistence to the editor find control. In this milestone, we are extending that further to the replace input control, so that you can maintain both separately across multiple sessions. The replace history is stored per workspace and can be disabled via the `setting(editor.find.replaceHistory)` setting.
+前回のマイルストーンでは、エディターの検索コントロールに履歴の保持を導入しました。今回のマイルストーンでは、置換入力コントロールにも拡張し、複数のセッションにわたってそれらを個別に保持できるようにしました。置換履歴はワークスペースごとに保存され、`setting(editor.find.replaceHistory)` 設定で無効にできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/replace-history.mp4" title="Video showing the persistence of editor replace history across VS Code reloads." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/replace-history.mp4" title="VS Code のリロード間でエディターの置換履歴の保持を示すビデオ。" autoplay loop controls muted></video>
 
-### Comments {#comments}
+### コメント {#comments}
 
-#### Confirmation when closing an un-submitted comment {#confirmation-when-closing-an-unsubmitted-comment}
+#### 未送信コメントを閉じるときの確認 {#confirmation-when-closing-an-unsubmitted-comment}
 
-A confirmation dialog will show when you `esc` or otherwise close a comment control that has un-submitted comments. You can disable this confirmation with the setting `setting(comments.thread.confirmOnCollapse)`.
+未送信のコメントがあるコメントコントロールを `esc` キーで閉じると、確認ダイアログが表示されます。この確認は、`setting(comments.thread.confirmOnCollapse)` 設定で無効にできます。
 
-#### Quick actions in the comment editor {#quick-actions-in-the-comment-editor}
+#### コメントエディターのクイックアクション {#quick-actions-in-the-comment-editor}
 
-Quick actions can be used from the comments editor.
+コメントエディターからクイックアクションを使用できます。
 
-![Screenshot that shows Quick actions in the Comments editor.](https://code.visualstudio.com/assets/updates/1_97/quick-actions-in-comment.gif)
+![コメントエディターのクイックアクションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/quick-actions-in-comment.gif)
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Git blame information {#git-blame-information}
+### Git blame 情報 {#git-blame-information}
 
-This milestone, we continued to polish the feature to display git blame information in the editor and in the Status Bar. We have also improved the information that is shown when you hover over the editor decoration or the Status Bar item.
+このマイルストーンでは、エディターおよびステータスバーに git blame 情報を表示する機能をさらに磨きました。また、エディターの装飾やステータスバーアイテムにホバーしたときに表示される情報も改善しました。
 
-![Screenshot that shows Git blame information when hovering over the git blame item in the Status Bar.](https://code.visualstudio.com/assets/updates/1_97/scm-git-blame.png)
+![ステータスバーの git blame アイテムにホバーしたときに表示される git blame 情報を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/scm-git-blame.png)
 
-The git blame Status Bar item is now enabled by default, and you can disable it by using the `setting(git.blame.statusBarItem.enabled:false)` setting. Enable the git blame editor decoration with the `setting(git.blame.editorDecoration.enabled:true)` setting.
+git blame ステータスバーアイテムはデフォルトで有効になっており、`setting(git.blame.statusBarItem.enabled:false)` 設定を使用して無効にできます。git blame エディターの装飾を有効にするには、`setting(git.blame.editorDecoration.enabled:true)` 設定を使用します。
 
-We have also added commands to easily toggle the git blame information by using the Command Palette or by using keybindings: **Git: Toggle Git Blame Editor Decoration** and **Git: Toggle Git Blame Status Bar Item**.
+コマンドパレットまたはキーバインディングを使用して git blame 情報を簡単に切り替えるためのコマンドも追加しました: **Git: Git Blame エディターの装飾を切り替える** および **Git: Git Blame ステータスバーアイテムを切り替える**。
 
-### GitHub repositories {#github-repositories}
+### GitHub リポジトリ {#github-repositories}
 
-For repositories that are hosted on GitHub, we have added a new command, **Open on GitHub**, to the timeline context menu and hover, the Source Control Graph context menu and hover, and the git blame editor decoration and Status Bar item hover.
+GitHub にホストされているリポジトリの場合、タイムラインのコンテキストメニューとホバー、ソース管理グラフのコンテキストメニューとホバー、および git blame エディターの装飾とステータスバーアイテムのホバーに新しいコマンド **GitHub で開く** を追加しました。
 
-![Screenshot of the Source Control history item hover, highlighting the Open on GitHub link.](https://code.visualstudio.com/assets/updates/1_97/scm-graph-hover.png)
+![ソース管理履歴アイテムのホバーを示すスクリーンショット。GitHub で開くリンクが強調表示されています。](https://code.visualstudio.com/assets/updates/1_97/scm-graph-hover.png)
 
-GitHub issue and pull request references are rendered as links in the timeline, Source Control Graph, and git blame editor decoration and Status Bar item hovers, so that they can be easily opened in a browser.
+GitHub の issue およびプルリクエストの参照は、タイムライン、ソース管理グラフ、および git blame エディターの装飾とステータスバーアイテムのホバーでリンクとして表示され、ブラウザーで簡単に開くことができます。
 
-Last but not least, we also added the GitHub avatar in the timeline, Source Control Graph, and git blame editor decoration and Status Bar item hovers. Disable the rendering of the GitHub avatar by using the `setting(github.showAvatar:false)` setting.
+最後に、タイムライン、ソース管理グラフ、および git blame エディターの装飾とステータスバーアイテムのホバーに GitHub アバターも追加しました。`setting(github.showAvatar:false)` 設定を使用して、GitHub アバターのレンダリングを無効にします。
 
-### Source Control Graph actions {#source-control-graph-actions}
+### ソース管理グラフアクション {#source-control-graph-actions}
 
-We have expanded the functionality of the Source Control Graph view by adding actions scoped to a history item reference (for example, branch tag) to the context menu. The first actions that we added are **Checkout**, **Delete Branch**, and **DeleteTag** that allow you to easily check out a branch/tag, delete a branch, and delete a tag directly from the Source Control Graph view.
+ソース管理グラフビューの機能を拡張し、履歴アイテム参照 (ブランチタグなど) にスコープされたアクションをコンテキストメニューに追加しました。最初に追加したアクションは、**チェックアウト**、**ブランチの削除**、および **タグの削除** で、ソース管理グラフビューから直接ブランチ/タグを簡単にチェックアウト、削除できます。
 
-We are planning to add more actions in the upcoming milestones.
+今後のマイルストーンでさらに多くのアクションを追加する予定です。
 
-## Notebooks {#notebooks}
+## ノートブック {#notebooks}
 
-### Inline values upon cell execution {#inline-values-upon-cell-execution}
+### セル実行時のインライン値 {#inline-values-upon-cell-execution}
 
-The notebook editor now supports showing inline values after cell execution with the setting `setting(notebook.inlineValues)`. When enabled, after a successful cell execution, inline values are displayed according to the results of a registered `InlineValueProvider`.
+ノートブックエディターは、`setting(notebook.inlineValues)` 設定を使用して、セル実行後にインライン値を表示することをサポートするようになりました。有効にすると、セル実行が成功した後、登録された `InlineValueProvider` の結果に従ってインライン値が表示されます。
 
-If there's no provider, the fallback approach matches values found in the kernel against the cell document via simple regex matching. It's recommended to use a provider from a language extension to ensure more accurate results.
+プロバイダーがない場合、フォールバックアプローチは、カーネル内の値をセルドキュメントと単純な正規表現マッチングを使用して一致させます。より正確な結果を確保するために、言語拡張機能からのプロバイダーを使用することをお勧めします。
 
-![Screenshot that shows inline values after cell execution in the notebook editor.](https://code.visualstudio.com/assets/updates/1_97/nb-inline-values.png)
+![ノートブックエディターでセル実行後のインライン値を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/nb-inline-values.png)
 
-### Custom font family for Markdown cells {#custom-font-family-for-markdown-cells}
+### Markdown セルのカスタムフォントファミリー {#custom-font-family-for-markdown-cells}
 
-The notebook editor now supports setting a custom font family for rendered Markdown cells. This can be controlled with the `setting(notebook.markup.fontFamily)` setting. When left blank, the default workbench font family is used.
+ノートブックエディターは、レンダリングされた Markdown セルのカスタムフォントファミリーを設定することをサポートするようになりました。これは、`setting(notebook.markup.fontFamily)` 設定で制御できます。空白のままにすると、デフォルトのワークベンチフォントファミリーが使用されます。
 
-![Screenshot that shows a custom font for rendered Markdown cells.](https://code.visualstudio.com/assets/updates/1_97/markdown-cell-font-family.png)
+![レンダリングされた Markdown セルのカスタムフォントを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/markdown-cell-font-family.png)
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Ligature support {#ligature-support}
+### リガチャのサポート {#ligature-support}
 
-This feature is now considered stable. Here is a summary of the changes since the last version:
+この機能は安定版と見なされるようになりました。前回のバージョン以降の変更点の概要は次のとおりです。
 
-- The enablement setting changed from `terminal.integrated.fontLigatures` to `setting(terminal.integrated.fontLigatures.enabled)`.
-- Ligatures are now temporarily disabled while the cursor or the selection is within the ligature.
-- Use `setting(terminal.integrated.fontLigatures.featureSettings)` to set ligature sets and variants. This is passed on to the [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) CSS property behind the scenes.
-- Use `setting(terminal.integrated.fontLigatures.fallbackLigatures)` to set ligature sequences manually when the library that we use to parse ligatures is not supported.
+- 有効化設定が `terminal.integrated.fontLigatures` から `setting(terminal.integrated.fontLigatures.enabled)` に変更されました。
+- カーソルまたは選択がリガチャ内にある場合、リガチャは一時的に無効になります。
+- `setting(terminal.integrated.fontLigatures.featureSettings)` を使用して、リガチャセットとバリアントを設定します。これは、内部で [`font-feature-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) CSS プロパティに渡されます。
+- 使用しているライブラリがリガチャを解析できない場合、`setting(terminal.integrated.fontLigatures.fallbackLigatures)` を使用してリガチャシーケンスを手動で設定します。
 
-### Support for ConEmu's progress escape sequences {#support-for-conemus-progress-escape-sequences}
+### ConEmu の進行状況エスケープシーケンスのサポート {#support-for-conemus-progress-escape-sequences}
 
-The `ESC ] 9 ; 4` escape sequence pioneered by ConEmu that reports progress in the terminal is now supported. This is used by some CLI tools such as `winget` to report progress. To view the progress in terminal tabs, add `${progress}` to either `setting(terminal.integrated.tabs.title)` or `setting(terminal.integrated.tabs.description)`. This typically shows as a progress spinner or as a percentage.
+ターミナルで進行状況を報告する ConEmu によって導入された `ESC ] 9 ; 4` エスケープシーケンスがサポートされるようになりました。これは、`winget` などの一部の CLI ツールによって進行状況を報告するために使用されます。ターミナルタブで進行状況を表示するには、`${progress}` を `setting(terminal.integrated.tabs.title)` または `setting(terminal.integrated.tabs.description)` に追加します。通常、進行状況スピナーまたはパーセンテージとして表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/terminal-progress.mp4" title="Video showing a progress indicator in the terminal title while running a 'winget' command." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/terminal-progress.mp4" title="ターミナルタイトルに進行状況インジケーターを表示しながら 'winget' コマンドを実行するビデオ。" autoplay loop controls muted></video>
 
-### Sticky Scroll for truncated commands {#sticky-scroll-for-truncated-commands}
+### 切り捨てられたコマンドのためのスティッキースクロール {#sticky-scroll-for-truncated-commands}
 
-Sticky Scroll in the terminal (`setting(terminal.integrated.stickyScroll.enabled)`) now shows when a command is truncated with an ellipsis at the end:
+ターミナルのスティッキースクロール (`setting(terminal.integrated.stickyScroll.enabled)`) は、コマンドが省略記号で切り捨てられた場合に表示されるようになりました。
 
-![Screenshot that shows an ellipsis at the end of a command in Sticky Scroll when it is truncated.](https://code.visualstudio.com/assets/updates/1_97/terminal-sticky-scroll-ellipsis.png)
+![コマンドが切り捨てられた場合にスティッキースクロールに省略記号が表示されるスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/terminal-sticky-scroll-ellipsis.png)
 
-### Configure the behavior when the last terminal closes {#configure-the-behavior-when-the-last-terminal-closes}
+### 最後のターミナルが閉じられたときの動作を構成する {#configure-the-behavior-when-the-last-terminal-closes}
 
-The new `setting(terminal.integrated.hideOnLastClosed)` setting allows configuring whether the panel will be closed when the last terminal has been closed. Along with this, the experience when there is no terminal open has been improved.
+新しい `setting(terminal.integrated.hideOnLastClosed)` 設定を使用して、最後のターミナルが閉じられたときにパネルが閉じられるかどうかを構成できます。これに加えて、ターミナルが開いていない場合のエクスペリエンスが改善されました。
 
-## Tasks {#tasks}
+## タスク {#tasks}
 
-### Column number variable {#column-number-variable}
+### 列番号変数 {#column-number-variable}
 
-The new `${columnNumber}` variable can be used in [`tasks.json`](https://code.visualstudio.com/docs/editor/tasks) and [`launch.json`](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) to refer to the column number of the cursor position. See the full list of [variables](https://code.visualstudio.com/docs/editor/variables-reference) in the VS Code documentation.
+新しい `${columnNumber}` 変数を [`tasks.json`](https://code.visualstudio.com/docs/editor/tasks) および [`launch.json`](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations) で使用して、カーソル位置の列番号を参照できます。完全な [変数リスト](https://code.visualstudio.com/docs/editor/variables-reference) は VS Code ドキュメントで確認できます。
 
-## Debug {#debug}
+## デバッグ {#debug}
 
-### Filter and search on values {#filter-and-search-on-values}
+### 値のフィルタリングと検索 {#filter-and-search-on-values}
 
-You can now search within a view (`kb(list.find)`) in the Variables and Watch views to filter on variable and expression values, rather than just names.
+変数およびウォッチビューでビュー内を検索 (`kb(list.find)`) して、変数および式の名前だけでなく値でフィルタリングできるようになりました。
 
-![Screenshot that shows the search control in the Variables view when debugging.](https://code.visualstudio.com/assets/updates/1_97/debug-search-values.png)
+![デバッグ時の変数ビューの検索コントロールを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/debug-search-values.png)
 
-### Select in the Debug Console {#select-in-the-debug-console}
+### デバッグコンソールで選択 {#select-in-the-debug-console}
 
-The Debug Console now supports longer and more reliable content selection, allowing easier copy and paste.
+デバッグコンソールは、より長く、より信頼性の高いコンテンツ選択をサポートするようになり、コピーアンドペーストが容易になりました。
 
-### JavaScript debugger {#javascript-debugger}
+### JavaScript デバッガー {#javascript-debugger}
 
-Scripts can now be _pretty printed_ by using the **Debug: Pretty print for debugging** command from the command palette or editor actions, even when they are not the source the debugger is currently paused in.
+スクリプトは、コマンドパレットまたはエディターアクションから **デバッグ用にプリティプリント** コマンドを使用して、デバッガーが現在一時停止しているソースでなくてもプリティプリントできます。
 
-## Languages {#languages}
+## 言語 {#languages}
 
 ### TypeScript 5.7.3 {#typescript-573}
 
-This release includes the [TypeScript 5.7.3](https://github.com/microsoft/typescript/issues?q=is%3Aissue%20state%3Aclosed%20%20milestone%3A%22TypeScript%205.7.3%22) recovery release. This minor update fixes a few import bugs and regressions.
+このリリースには、[TypeScript 5.7.3](https://github.com/microsoft/typescript/issues?q=is%3Aissue%20state%3Aclosed%20%20milestone%3A%22TypeScript%205.7.3%22) 回復リリースが含まれています。このマイナーアップデートでは、いくつかのインポートバグと回帰が修正されています。
 
-### Right click to open images from the Markdown preview {#right-click-to-open-images-from-the-markdown-preview}
+### Markdown プレビューから画像を右クリックして開く {#right-click-to-open-images-from-the-markdown-preview}
 
-You can now right click on a workspace image in the Markdown preview and select **Open Image** to open it in a new editor.
+Markdown プレビューでワークスペース画像を右クリックして **画像を開く** を選択すると、新しいエディターで画像を開くことができるようになりました。
 
-![Screenshot that shows the context menu option to open an image in the Markdown preview.](https://code.visualstudio.com/assets/updates/1_97/md-preview-open-image.png)
+![Markdown プレビューで画像を開くコンテキストメニューオプションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/md-preview-open-image.png)
 
-This is supported for any images that are part of the current workspace.
+これは、現在のワークスペースの一部であるすべての画像に対してサポートされています。
 
-### Markdown link validation status item {#markdown-link-validation-status-item}
+### Markdown リンク検証ステータスアイテム {#markdown-link-validation-status-item}
 
-VS Code's built-in Markdown features support automatically [validating local links to files and images](https://code.visualstudio.com/docs/languages/markdown#_link-validation). This is a great way to catch common mistakes, such as linking to a header that was renamed or to a file that no longer exists on disk.
+VS Code の組み込み Markdown 機能は、ファイルおよび画像へのローカルリンクを自動的に [検証](https://code.visualstudio.com/docs/languages/markdown#_link-validation) することをサポートしています。これは、名前が変更されたヘッダーやディスク上に存在しなくなったファイルへのリンクなど、一般的なミスをキャッチするのに最適な方法です。
 
-To help you discover this feature, we've added a new language status item for link validation:
+この機能を発見しやすくするために、リンク検証の新しい言語ステータスアイテムを追加しました。
 
-![Screenshot that shows the Markdown link validation language status item.](https://code.visualstudio.com/assets/updates/1_97/md-link-status-item.png)
+![Markdown リンク検証言語ステータスアイテムを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/md-link-status-item.png)
 
-With a Markdown file open, select the `{}` in the Status Bar to view the link validation status. You can also use the status item to quickly toggle link validation off and on.
+Markdown ファイルを開いた状態で、ステータスバーの `{}` を選択してリンク検証ステータスを表示します。ステータスアイテムを使用して、リンク検証をすばやくオン/オフすることもできます。
 
-### New Ruby syntax highlighting grammar {#new-ruby-syntax-highlighting-grammar}
+### 新しい Ruby 構文ハイライトグラマー {#new-ruby-syntax-highlighting-grammar}
 
-We've moved away from the old, unmaintained, Ruby grammar from `textmate/ruby.tmbundle` and now get our Ruby grammar from `Shopify/ruby-lsp`.
+古い、メンテナンスされていない `textmate/ruby.tmbundle` からの Ruby グラマーを廃止し、`Shopify/ruby-lsp` からの Ruby グラマーを使用するようになりました。
 
-## Remote Development {#remote-development}
+## リモート開発 {#remote-development}
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[リモート開発拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) を使用すると、[Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)、SSH 経由のリモートマシンまたは [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels)、または [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) を使用して、フル機能の開発環境を利用できます。
 
-Highlights include:
+ハイライトは次のとおりです。
 
-- Migration path for connecting to Linux legacy servers
-- SSH Chat participant improvements
-- SSH configuration improvements
-- Default remote extensions for SSH
+- Linux レガシーサーバーへの接続の移行パス
+- SSH チャット参加者の改善
+- SSH 構成の改善
+- SSH のデフォルトリモート拡張機能
 
-You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md).
+これらの機能の詳細については、[リモート開発リリースノート](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md) を参照してください。
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
-### Microsoft Account {#microsoft-account}
+### Microsoft アカウント {#microsoft-account}
 
-#### Microsoft Account now uses MSAL (with WAM support on Windows) {#microsoft-account-now-uses-msal-with-wam-support-on-windows}
+#### Microsoft アカウントが MSAL (Windows での WAM サポート付き) を使用するようになりました {#microsoft-account-now-uses-msal-with-wam-support-on-windows}
 
-> NOTE: Last month's rollout of an MSAL-based authentication for Microsoft needed to be rolled back due to a critical bug. This bug has been squashed and we are proceeding with the rollout.
+> 注: 先月の Microsoft の MSAL ベースの認証の展開は、重大なバグのためにロールバックする必要がありました。このバグは修正され、展開を進めています。
 
-In order to ensure a strong security baseline for Microsoft authentication, we've adopted the [Microsoft Authentication Library](https://github.com/AzureAD/microsoft-authentication-library-for-js) in the Microsoft Account extension.
+Microsoft 認証の強力なセキュリティベースラインを確保するために、Microsoft アカウント拡張機能で [Microsoft Authentication Library](https://github.com/AzureAD/microsoft-authentication-library-for-js) を採用しました。
 
-One of the stand out features of this work is WAM (Web Account Manager... also known as [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md)) integration. Put simply, rather than going to the browser for Microsoft authentication flows, we now talk to the OS directly, which is the recommended way of acquiring a Microsoft authentication session. Additionally, it's faster since we're able to leverage the accounts that you're already logged into on the OS.
+この作業の際立った機能の1 つは、WAM (Web Account Manager... [Broker](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/dev/lib/msal-node/docs/brokering.md) とも呼ばれます) 統合です。簡単に言えば、Microsoft 認証フローのためにブラウザーに移動するのではなく、OS と直接通信するようになりました。これは、Microsoft 認証セッションを取得するための推奨方法です。さらに、OS に既にログインしているアカウントを活用できるため、より高速です。
 
-![Screenshot that shows an authentication popup that the OS shows over VS Code.](https://code.visualstudio.com/assets/updates/1_97/showingBrokerOSDialog.png)
+![VS Code 上に表示される OS の認証ポップアップを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/showingBrokerOSDialog.png)
 
-Let us know if you see any issues with this new flow. If you do see a major issue and need to revert back to the old Microsoft authentication behavior, you can do so with `setting(microsoft-authentication.implementation)` (setting it to `classic`, and restarting VS Code) but do keep in mind that this setting won't be around for much longer. So, open an issue if you are having trouble with the MSAL flow.
+この新しいフローに問題がある場合はお知らせください。重大な問題が発生し、古い Microsoft 認証の動作に戻す必要がある場合は、`setting(microsoft-authentication.implementation)` を使用して (これを `classic` に設定し、VS Code を再起動します)、戻すことができますが、この設定は長くは続かないことに注意してください。したがって、MSAL フローに問題がある場合は、issue を開いてください。
 
 ### Python {#python}
 
-#### Launch native REPL from the terminal {#launch-native-repl-from-the-terminal}
+#### ターミナルからネイティブ REPL を起動 {#launch-native-repl-from-the-terminal}
 
-You are now able to launch a VS Code Native REPL from your REPL in the terminal. Setting `setting(python.terminal.shellIntegration.enabled)` to `true` should display a clickable link in the Python REPL in the terminal, allowing you to directly open the VS Code Native REPL from the terminal.
+ターミナルの REPL から VS Code ネイティブ REPL を起動できるようになりました。`setting(python.terminal.shellIntegration.enabled)` を `true` に設定すると、ターミナルの Python REPL にクリック可能なリンクが表示され、ターミナルから直接 VS Code ネイティブ REPL を開くことができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/native-repl-link.mp4" title="Video showing the Native REPL entry point link in terminal REPL." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/native-repl-link.mp4" title="ターミナル REPL のネイティブ REPL エントリポイントリンクを示すビデオ。" autoplay loop controls muted></video>
 
-#### No config debug {#no-config-debug}
+#### 設定不要デバッグ {#no-config-debug}
 
-You are now able to debug a Python script or module without setup, right from the terminal as part of the new no-config debug feature! Check out the [wiki page](https://github.com/microsoft/vscode-python-debugger/wiki/No%E2%80%90Config-Debugging) on the feature for all the details and troubleshooting tips.
+新しい設定不要デバッグ機能の一環として、ターミナルから設定なしで Python スクリプトまたはモジュールをデバッグできるようになりました! この機能の詳細とトラブルシューティングのヒントについては、[wiki ページ](https://github.com/microsoft/vscode-python-debugger/wiki/No%E2%80%90Config-Debugging) を参照してください。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/no-config-debug.mp4" title="Video showing the no-config debug feature for Python." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/no-config-debug.mp4" title="Python の設定不要デバッグ機能を示すビデオ。" autoplay loop controls muted></video>
 
-#### Test discovery cancellation {#test-discovery-cancellation}
+#### テスト検出のキャンセル {#test-discovery-cancellation}
 
-When triggering test discovery from the Test Explorer UI, you can now cancel an ongoing test discovery call. Use the Cancel button, which appears in replacement of the Refresh button during discovery.
+テストエクスプローラー UI からテスト検出をトリガーすると、進行中のテスト検出呼び出しをキャンセルできるようになりました。検出中に更新ボタンの代わりに表示されるキャンセルボタンを使用します。
 
-![Screenshot that shows the Test Explorer, highlighting the Cancel button to cancel the test discovery.](https://code.visualstudio.com/assets/updates/1_97/test-discovery-cancelation.png)
+![テストエクスプローラーを示すスクリーンショット。テスト検出をキャンセルするためのキャンセルボタンが強調表示されています。](https://code.visualstudio.com/assets/updates/1_97/test-discovery-cancelation.png)
 
-#### Go to Implementation {#go-to-implementation}
+#### 実装に移動 {#go-to-implementation}
 
-[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now has support for **Go to Implementation**, which allows you to more quickly navigate to the implementation of a function or method directly from its usage. This is a particularly helpful feature when working with inherited classes.
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) は、関数やメソッドの使用から直接実装にすばやく移動できる **実装に移動** をサポートするようになりました。これは、継承されたクラスを操作する際に特に役立つ機能です。
 
-![Screenshot that shows the Go to Implementation displayed via the context menu](https://code.visualstudio.com/assets/updates/1_97/pylance-go-to-implementation.png)
+![コンテキストメニューで表示される実装に移動を示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_97/pylance-go-to-implementation.png)
 
-#### AI Code Action: Generate Symbol (Experimental) {#ai-code-action-generate-symbol-experimental}
+#### AI コードアクション: シンボルの生成 (実験的) {#ai-code-action-generate-symbol-experimental}
 
-There's a new experimental AI Code Action for generating symbols with Pylance and Copilot. To try it out, you can enable the following setting:
+Pylance と Copilot を使用してシンボルを生成するための新しい実験的な AI コードアクションがあります。試してみるには、次の設定を有効にします。
 
 ```
 "python.analysis.aiCodeActions": {"generateSymbol": true}
 ```
 
-Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let Copilot handle the implementation! If you want, you can then leverage Pylance's **Move Symbol** Code Actions to move it to a different file.
+次に、新しいシンボル (クラスや関数など) を定義すると、**Copilot でシンボルを生成** コードアクションを選択して、Copilot に実装を任せることができます! 必要に応じて、Pylance の **シンボルの移動** コードアクションを活用して、別のファイルに移動することもできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_97/pylance-create-symbol-with-copilot.mp4" title="Video showing invoking a new class that doesn't exist and then selecting the 'Create Class With Copilot' code action to implement a new class." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_97/pylance-create-symbol-with-copilot.mp4" title="存在しない新しいクラスを呼び出し、次に 'Copilot でクラスを作成' コードアクションを選択して新しいクラスを実装するビデオ。" autoplay loop controls muted></video>
 
-### GitHub Pull Requests and Issues {#github-pull-requests-and-issues}
+### GitHub プルリクエストと issue {#github-pull-requests-and-issues}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+プルリクエストと issue の作成および管理を行うための [GitHub プルリクエスト](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能の進展がありました。新機能には次のものが含まれます。
 
-* Global pull request queries, with a variable to specify a time range relative to today (`${today-7d}`).
-* `:<emoji-name>:` style emojis are now supported in comments.
-* All non-outdated comments will show in the Comments panel when you open the description of an un-checked out pull request.
+* グローバルプルリクエストクエリ、指定された時間範囲を今日に相対的に指定する変数 (`${today-7d}`)。
+* コメントで `:<emoji-name>:` スタイルの絵文字がサポートされるようになりました。
+* チェックアウトされていないプルリクエストの説明を開くと、すべての非古いコメントがコメントパネルに表示されます。
 
-Review the [changelog for the 0.104.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01040) release of the extension to learn about the other highlights.
+拡張機能の [0.104.0 の変更ログ](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01040) を確認して、他のハイライトについて学んでください。
 
-## Preview Features {#preview-features}
+## プレビュー機能 {#preview-features}
 
-### Agent mode (Experimental) {#agent-mode-experimental}
+### エージェントモード (実験的) {#agent-mode-experimental}
 
-We've been working on a new _agent mode_ for Copilot Edits. When in agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
+Copilot Edits の新しい _エージェントモード_ に取り組んでいます。エージェントモードでは、Copilot がワークスペースを自動的に検索し、関連するコンテキストを見つけ、ファイルを編集し、エラーをチェックし、タスクをエンドツーエンドで完了するためにターミナルコマンドを実行します (許可が必要です)。
 
-![Screenshot that shows agent mode in the Copilot Edits view.](https://code.visualstudio.com/assets/updates/1_97/agent-mode.png)
+![Copilot Edits ビューのエージェントモードを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/agent-mode.png)
 
-You can switch between the current edit mode that we've had for a few months and agent mode with the dropdown in the Copilot Edits view. To see the dropdown, enable the `setting(chat.agent.enabled)` setting. You can start using agent mode in [VS Code Insiders](https://code.visualstudio.com/insiders/) today. We will gradually be rolling it out to VS Code Stable users. If the setting doesn't show up for you in Stable, then it isn't enabled for you yet.
+現在数か月間使用している編集モードとエージェントモードを、Copilot Edits ビューのドロップダウンで切り替えることができます。ドロップダウンを表示するには、`setting(chat.agent.enabled)` 設定を有効にします。今日から [VS Code Insiders](https://code.visualstudio.com/insiders/) でエージェントモードを使用できます。VS Code Stable ユーザーに段階的に展開していきます。Stable で設定が表示されない場合は、まだ有効になっていないことを意味します。
 
-![Screenshot of the agent mode setting in the Settings editor.](https://code.visualstudio.com/assets/updates/1_97/agent-setting.png)
+![設定エディターのエージェントモード設定を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/agent-setting.png)
 
-In agent mode, Copilot runs autonomously, but it can only edit files within your current workspace. When it wants to run a terminal command, it shows you the command and waits for you to review it and select Continue before proceeding.
+エージェントモードでは、Copilot は自律的に動作しますが、現在のワークスペース内のファイルのみを編集できます。ターミナルコマンドを実行したい場合は、コマンドを表示し、確認して [続行] を選択するまで待機します。
 
-> **Note**: Copilot Edits may use many chat requests in agent mode, so it will periodically pause and ask you whether to continue. You can customize this with `setting(chat.agent.maxRequests)`. This defaults to 15 for Copilot paid users, and 5 for Copilot Free users.
+> **注:** エージェントモードでは、Copilot Edits が多くのチャットリクエストを使用する可能性があるため、定期的に一時停止して続行するかどうかを尋ねます。`setting(chat.agent.maxRequests)` でこれをカスタマイズできます。これは、Copilot 有料ユーザーの場合はデフォルトで15、Copilot Free ユーザーの場合は5 です。
 
-Learn more about [agent mode in Copilot Edits](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-agent-mode-preview) in the VS Code documentation.
+VS Code ドキュメントで [Copilot Edits のエージェントモード](https://code.visualstudio.com/docs/copilot/copilot-customization#_use-agent-mode-preview) について詳しく学んでください。
 
-### Agentic codebase search (Preview) {#agentic-codebase-search-preview}
+### エージェントコードベース検索 (プレビュー) {#agentic-codebase-search-preview}
 
-You can add `#codebase` to your query and Copilot Edits will discover relevant files for your task. We've added experimental support for discovering relevant files using additional tools like file and text search, Git repository state, and directory reads. Previously, `#codebase` only performed semantic search.
+クエリに `#codebase` を追加すると、Copilot Edits がタスクに関連するファイルを検出します。ファイルおよびテキスト検索、Git リポジトリの状態、ディレクトリの読み取りなどの追加ツールを使用して関連ファイルを検出する実験的なサポートを追加しました。以前は、`#codebase` はセマンティック検索のみを実行していました。
 
-You can enable it with `setting(github.copilot.chat.edits.codesearch.enabled)`, and please [share any feedback](https://github.com/microsoft/vscode-copilot-release) with us.
+`setting(github.copilot.chat.edits.codesearch.enabled)` を使用して有効にし、フィードバックを [共有](https://github.com/microsoft/vscode-copilot-release) してください。
 
-### Copilot Vision in VS Code Insiders (Preview) {#copilot-vision-in-vs-code-insiders-preview}
+### VS Code Insiders での Copilot Vision (プレビュー) {#copilot-vision-in-vs-code-insiders-preview}
 
-We're introducing end-to-end vision support in the pre-release version of GitHub Copilot Chat in [VS Code Insiders](https://code.visualstudio.com/insiders/). This lets you attach images and interact with images in Copilot Chat prompts. For example, if you're encountering an error while debugging, quickly attach a screenshot of VS Code and ask Copilot to help you resolve the issue.
+[VS Code Insiders](https://code.visualstudio.com/insiders/) の GitHub Copilot Chat のプレリリースバージョンで、エンドツーエンドのビジョンサポートを導入しています。これにより、画像を添付し、Copilot Chat プロンプトで画像と対話できます。たとえば、デバッグ中にエラーが発生した場合、VS Code のスクリーンショットをすばやく添付して、Copilot に問題の解決を依頼できます。
 
-![Screenshot that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](https://code.visualstudio.com/assets/updates/1_97/image-attachments.gif)
+![Copilot Chat プロンプトに添付された画像を示すスクリーンショット。画像にホバーするとプレビューが表示されます。](https://code.visualstudio.com/assets/updates/1_97/image-attachments.gif)
 
-You can now attach images using several methods:
+次の方法で画像を添付できるようになりました。
 
-- Drag and drop images from your OS or from the Explorer view
-- Paste an image from the clipboard
-- Attach a screenshot of the VS Code window (select Attach > Screenshot Window)
+- OS またはエクスプローラービューから画像をドラッグアンドドロップ
+- クリップボードから画像を貼り付け
+- VS Code ウィンドウのスクリーンショットを添付 (添付 > ウィンドウのスクリーンショットを選択)
 
-A warning is shown if the selected model currently does not have the capability to handle images. The only supported model at the moment will be `GPT 4o`. Currently, the supported image types are `JPEG/JPG`, `PNG`, `GIF`, and `WEBP`.
+選択したモデルが現在画像を処理できない場合、警告が表示されます。現在サポートされている唯一のモデルは `GPT 4o` です。現在サポートされている画像タイプは `JPEG/JPG`、`PNG`、`GIF`、および `WEBP` です。
 
-### Reusable prompts (Experimental) {#reusable-prompts-experimental}
+### 再利用可能なプロンプト (実験的) {#reusable-prompts-experimental}
 
-This feature lets you build, store, and share reusable prompts. A prompt file is a `.prompt.md` Markdown file that follows the same format used for writing prompts in Copilot Chat, and it can link to other files or even other prompts. You can attach prompt files for task-specific guidance, aid with code generation, or keep complete prompts for later use.
+この機能により、再利用可能なプロンプトを作成、保存、および共有できます。プロンプトファイルは `.prompt.md` Markdown ファイルで、Copilot Chat でプロンプトを書くのと同じ形式に従い、他のファイルやプロンプトへのリンクを含めることができます。タスク固有のガイダンスを提供するためにプロンプトファイルを添付したり、コード生成を支援したり、後で使用するために完全なプロンプトを保持したりできます。
 
-To enable prompt files, set `setting(chat.promptFiles)` to `true`, or use the `{ "/path/to/folder": boolean }` notation to specify a different path. The `.github/prompts` folder is used by default to locate prompt files (`*.prompt.md`), if no other path is specified.
+プロンプトファイルを有効にするには、`setting(chat.promptFiles)` を `true` に設定するか、`{ "/path/to/folder": boolean }` 表記を使用して別のパスを指定します。指定されていない場合、デフォルトで `.github/prompts` フォルダーがプロンプトファイル (`*.prompt.md`) を見つけるために使用されます。
 
-Learn more about [prompt files](https://aka.ms/vscode-ghcp-prompt-snippets) in the VS Code documentation.
+VS Code ドキュメントで [プロンプトファイル](https://aka.ms/vscode-ghcp-prompt-snippets) について詳しく学んでください。
 
-### Custom title bar on Linux (Experimental) {#custom-title-bar-on-linux-experimental}
+### Linux でのカスタムタイトルバー (実験的) {#custom-title-bar-on-linux-experimental}
 
-This milestone, we are starting an experiment to enable the custom title bar for a subset of Linux users.
+このマイルストーンでは、一部の Linux ユーザー向けにカスタムタイトルバーを有効にする実験を開始しています。
 
-![Screenshot that shows the custom VS Code title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/custom-title.png)
+![Linux でのカスタム VS Code タイトルバーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/custom-title.png)
 
-If you are not part of the experiment, you can manually configure `setting(window.titleBarStyle)` as `custom` to try it out.
+実験の対象でない場合は、`setting(window.titleBarStyle)` を `custom` に手動で設定して試してみることができます。
 
-You can always revert back to the native title decorations, either from the custom title context menu or by configuring `setting(window.titleBarStyle)` to `native`.
+ネイティブタイトルの装飾に戻すには、カスタムタイトルのコンテキストメニューから、または `setting(window.titleBarStyle)` を `native` に設定して戻すことができます。
 
-![Screenshot that shows the content menu option to disable the custom title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/restore-title.png)
+![Linux でカスタムタイトルバーを無効にするコンテンツメニューオプションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/restore-title.png)
 
-### TypeScript 5.8 beta support {#typescript-58-beta-support}
+### TypeScript 5.8 ベータサポート {#typescript-58-beta-support}
 
-This release includes support for the TypeScript 5.8 beta release. Check out the [TypeScript 5.8 blog post](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/) for details on what's in store for this release.
+このリリースには、TypeScript 5.8 ベータリリースのサポートが含まれています。TypeScript 5.8 のリリースで何が予定されているかについては、[TypeScript 5.8 ブログ投稿](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/) を確認してください。
 
-To start using preview builds of TypeScript 5.8, install the [TypeScript Nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next). Share your feedback and let us know if you run into any bugs with TypeScript 5.8.
+TypeScript 5.8 のプレビュービルドを使用するには、[TypeScript Nightly 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next) をインストールします。フィードバックを共有し、TypeScript 5.8 にバグがある場合はお知らせください。
 
-### Terminal completions for more shells {#terminal-completions-for-more-shells}
+### より多くのシェルのためのターミナル補完 {#terminal-completions-for-more-shells}
 
-We have iterated on the general terminal completions that [were introduced in the last version](https://code.visualstudio.com/updates/v1_96#_terminal-completions-for-more-shells) that are build on our new proposed API. Once enabled with `setting(terminal.integrated.suggest.enabled)`, the new completions now replace the previous built-in provider for PowerShell but can now be customized with `setting(terminal.integrated.suggest.providers)`.
+[前回のバージョンで導入された](https://code.visualstudio.com/updates/v1_96#_terminal-completions-for-more-shells)一般的なターミナル補完に基づいて、提案された新しい API を使用して反復しました。有効にすると (`setting(terminal.integrated.suggest.enabled)`)、新しい補完は PowerShell の以前の組み込みプロバイダーを置き換えますが、`setting(terminal.integrated.suggest.providers)` でカスタマイズできます。
 
-Here are the key updates this release:
+このリリースの主な更新点は次のとおりです。
 
-- Enhanced widget styling and configuration to align with the editor's suggest widget.
-- A configurable status bar (`setting(terminal.integrated.suggest.showStatusBar)`) provides contextual actions and information.
-- Improved argument awareness for commands, including: `code`, `code-insiders`, `cd`, `ls`, `rm`, `echo`, `mkdir`, `rmdir`, `touch`.
-- Displays command or resource paths as additional details.
-- Added support for directory navigation shortcuts like `.`, `..`, and `../../`.
-- Enabled screen reader usage.
-- Entries pulled from the `$PATH` will now only show when they are executable files. Since Windows does not have the concept of an executable bit in file metadata, the list of extensions can be configured with `setting(terminal.integrated.suggest.windowsExecutableExtensions)`. These now also use the actual shell environment when available using an upcoming proposed API.
-- Enhanced keyboard support to toggle details, `kb(workbench.action.terminal.suggestToggleDetails)` and toggle suggest details focus `kb(workbench.action.terminal.suggestToggleDetailsFocus)`.
-- Suggestions will now always be on every type, aligning closer to how quick suggestions work in the editor.
-- PowerShell-specific global completions such as `Get-ChildItem`, `Write-Host`, etc. will now be suggested.
+- エディターの提案ウィジェットに合わせたウィジェットのスタイリングと構成の強化。
+- コンテキストアクションと情報を提供する構成可能なステータスバー (`setting(terminal.integrated.suggest.showStatusBar)`)。
+- コマンドの引数認識の改善、次を含む: `code`、`code-insiders`、`cd`、`ls`、`rm`、`echo`、`mkdir`、`rmdir`、`touch`。
+- 追加の詳細としてコマンドまたはリソースパスを表示。
+- `.`、`..`、および `../../` などのディレクトリナビゲーションショートカットのサポートを追加。
+- スクリーンリーダーの使用を有効にしました。
+- `$PATH` から取得されたエントリは、実行可能ファイルである場合にのみ表示されます。Windows にはファイルメタデータに実行可能ビットの概念がないため、拡張子のリストは `setting(terminal.integrated.suggest.windowsExecutableExtensions)` で構成できます。これらは、利用可能な場合に実際のシェル環境を使用して、提案された新しい API を使用します。
+- 詳細を切り替えるためのキーボードサポートの強化、`kb(workbench.action.terminal.suggestToggleDetails)` および提案の詳細フォーカスを切り替える `kb(workbench.action.terminal.suggestToggleDetailsFocus)`。
+- 提案は常にすべてのタイプで表示され、エディターのクイック提案の動作に近づきます。
+- PowerShell 固有のグローバル補完 (例: `Get-ChildItem`、`Write-Host` など) が提案されるようになりました。
 
-### Tree-Sitter based syntax highlighting for typescript {#tree-sitter-based-syntax-highlighting-for-typescript}
+### TypeScript の Tree-Sitter ベースの構文ハイライト {#tree-sitter-based-syntax-highlighting-for-typescript}
 
-Since many of our Textmate grammars are no longer maintained, we've been investigating using Tree-Sitter for syntax highlighting. We've started with TypeScript so the team can selfhost it and provide feedback. You can try out an early preview it out with the `setting(editor.experimental.preferTreeSitter)` setting.
+多くの Textmate グラマーがメンテナンスされなくなったため、構文ハイライトに Tree-Sitter を使用することを検討しています。フィードバックを提供し、TypeScript チームが自己ホストできるようにするために、TypeScript から始めました。`setting(editor.experimental.preferTreeSitter)` 設定を使用して、早期プレビューを試してみてください。
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能の作成 {#extension-authoring}
 
-### Document paste API {#document-paste-api}
+### ドキュメントの貼り付け API {#document-paste-api}
 
-The document paste API allows extensions to hook into copy/paste operations in text documents. Using this API, your extension can:
+ドキュメントの貼り付け API を使用すると、拡張機能がテキストドキュメントのコピー/貼り付け操作にフックできます。この API を使用して、拡張機能は次のことができます。
 
-- On copy, write data to the clipboard. This includes writing metadata that the can be picked up on paste.
+- コピー時にデータをクリップボードに書き込みます。これには、貼り付け時に取得できるメタデータの書き込みが含まれます。
 
-- On paste, generate a custom edit that applies the paste. This can change the text content being pasted or make more complex workspace edits, such as creating new files.
+- 貼り付け時に、貼り付けを適用するカスタム編集を生成します。これにより、貼り付けられるテキストコンテンツを変更したり、ファイルの作成などのより複雑なワークスペース編集を行ったりできます。
 
-- Provide multiple ways that content can be pasted. Users can select how content should be pasted using the paste control or with the `editor.pasteAs.preferences` setting.
+- コンテンツを貼り付ける複数の方法を提供します。ユーザーは、貼り付けコントロールを使用するか、`editor.pasteAs.preferences` 設定を使用して、コンテンツを貼り付ける方法を選択できます。
 
-VS Code uses the document paste API to implement features such as [updating imports on paste for JavaScript and TypeScript](https://code.visualstudio.com/updates/v1_95#_update-imports-on-paste-for-javascript-and-typescript) and [automatically creating Markdown links when pasting URLs](https://code.visualstudio.com/updates/v1_81#_markdown-paste-urls-as-formatted-links).
+VS Code は、JavaScript および TypeScript の [貼り付け時のインポートの更新](https://code.visualstudio.com/updates/v1_95#_update-imports-on-paste-for-javascript-and-typescript) や、URL を貼り付けるときに Markdown リンクを自動的に作成する [機能](https://code.visualstudio.com/updates/v1_81#_markdown-paste-urls-as-formatted-links) を実装するために、ドキュメントの貼り付け API を使用します。
 
-To get started with the document paste API, check out the [document paste extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/document-paste). For a more complex example, check out how the built-in Markdown extension [implements pasting of image files](https://github.com/microsoft/vscode/blob/8237317c2ff4d0a3dadfaeb67cd35630cf1a6b75/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts#L31) to insert images into Markdown documents.
+ドキュメントの貼り付け API の使用を開始するには、[ドキュメントの貼り付け拡張サンプル](https://github.com/microsoft/vscode-extension-samples/tree/main/document-paste) を確認してください。より複雑な例については、組み込みの Markdown 拡張機能が [画像ファイルの貼り付け](https://github.com/microsoft/vscode/blob/8237317c2ff4d0a3dadfaeb67cd35630cf1a6b75/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts#L31) を実装して、Markdown ドキュメントに画像を挿入する方法を確認してください。
 
-### File `openLabel` shows in the simple file picker {#file-openlabel-shows-in-the-simple-file-picker}
+### シンプルファイルピッカーにファイル `openLabel` が表示される {#file-openlabel-shows-in-the-simple-file-picker}
 
-The `openLabel` property in the `OpenDialogOptions` is now supported in the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (in addition to the system file picker, where it was previously exclusively supported). This allows you to provide a custom label for the button in the file picker.
+`OpenDialogOptions` の `openLabel` プロパティが、システムファイルピッカー (以前は専用にサポートされていた) に加えて、[シンプルファイルピッカー](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) でもサポートされるようになりました。これにより、ファイルピッカーのボタンにカスタムラベルを提供できます。
 
-### File-level comments API {#file-level-comments-api}
+### ファイルレベルのコメント API {#file-level-comments-api}
 
-The comments API supports making and showing file-level comments. File-level comments show at the top of the file, before the first line. They are not attached to a specific line or range in the file. To show a file-level comment, set the `range` of the comment to `undefined`. To support leaving file-level comments from your commenting range provider, set the `enableFileComments` property on your `CommentingRangeProvider` to `true`.
+コメント API は、ファイルレベルのコメントの作成と表示をサポートしています。ファイルレベルのコメントは、ファイルの最初の行の前に表示されます。ファイル内の特定の行や範囲に添付されていません。ファイルレベルのコメントを表示するには、コメントの `range` を `undefined` に設定します。コメント範囲プロバイダーからファイルレベルのコメントをサポートするには、`CommentingRangeProvider` の `enableFileComments` プロパティを `true` に設定します。
 
-## Proposed APIs {#proposed-apis}
+## 提案された API {#proposed-apis}
 
-### Terminal completion provider {#terminal-completion-provider}
+### ターミナル補完プロバイダー {#terminal-completion-provider}
 
-You can now [register a terminal completion provider](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts#L79-L87) and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/226562).
+[ターミナル補完プロバイダーを登録](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalCompletionProvider.d.ts#L79-L87) して、この [GitHub issue](https://github.com/microsoft/vscode/issues/226562) でフィードバックをお知らせください。
 
-An example of this can be found in our terminal suggest extension, which provides completions when enabled via `setting(terminal.integrated.suggest.enabled)`.
+この例は、`setting(terminal.integrated.suggest.enabled)` を使用して有効にすると、補完を提供するターミナル提案拡張機能にあります。
 
-### Terminal shell type {#terminal-shell-type}
+### ターミナルシェルタイプ {#terminal-shell-type}
 
-Extensions will be able to [access currently active shell type information](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalShellType.d.ts).
-The `shellType` field will be part of `TerminalState`.
+拡張機能は、[現在アクティブなシェルタイプ情報にアクセス](https://github.com/microsoft/vscode/blob/8d5f6f0050af2abde8c9977f1a269ef6eade6915/src/vscode-dts/vscode.proposed.terminalShellType.d.ts) できるようになります。
+`shellType` フィールドは `TerminalState` の一部になります。
 
-Use this shell type information to perform shell-specific operations that you need.
+このシェルタイプ情報を使用して、必要なシェル固有の操作を実行します。
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### Housekeeping {#housekeeping}
+### ハウスキーピング {#housekeeping}
 
-As part of our annual housekeeping efforts in December, we focused on cleaning up our GitHub issues and pull requests across all repositories. This year, we achieved a net reduction of 3,821 issues and pull requests, ensuring that our backlog remains relevant and manageable.
+12 月の年次ハウスキーピングの一環として、すべてのリポジトリで GitHub の issue とプルリクエストのクリーンアップに注力しました。今年は、3,821 件の issue とプルリクエストの純減を達成し、バックログが関連性を保ち、管理可能であることを確認しました。
 
-By following our issue cleanup guide, we reviewed and triaged outdated, duplicated, and no longer relevant issues. This helps us maintain an efficient development workflow and focus on improving Visual Studio Code for our users.
+issue クリーンアップガイドに従って、古い、重複した、もはや関連性のない issue をレビューし、トリアージしました。これにより、効率的な開発ワークフローを維持し、ユーザーのために Visual Studio Code を改善することに集中できます。
 
-We appreciate the community’s continued engagement and feedback — your contributions make VS Code better every day! 🚀
+コミュニティの継続的な関与とフィードバックに感謝します。皆さんの貢献が VS Code を日々向上させています! 🚀
 
-![Chart that shows the trend of the number of open issues over the last years. The chart shows a steep decline each year during December, the housekeeping month.](https://code.visualstudio.com/assets/updates/1_97/housekeeping.png)
+![過去数年間のオープン issue 数の傾向を示すチャート。チャートは、毎年12 月のハウスキーピング月間中に急激な減少を示しています。](https://code.visualstudio.com/assets/updates/1_97/housekeeping.png)
 
-### Resource optimization for file watching in TypeScript workspaces {#resource-optimization-for-file-watching-in-typescript-workspaces}
+### TypeScript ワークスペースでのファイル監視のリソース最適化 {#resource-optimization-for-file-watching-in-typescript-workspaces}
 
-A couple of optimizations have been made to reduce the overhead that file watching has in large TypeScript workspaces (thousands of TypeScript files or projects). Specifically, when opening such a workspace and initializing the watcher, you should no longer see CPU spikes or CPU usage should settle quickly.
+大規模な TypeScript ワークスペース (数千の TypeScript ファイルまたはプロジェクト) でファイル監視が持つオーバーヘッドを削減するために、いくつかの最適化が行われました。具体的には、そのようなワークスペースを開いてウォッチャーを初期化する際に、CPU スパイクが発生しないか、CPU 使用率がすぐに安定するはずです。
 
-See this [VS Code issue](https://github.com/microsoft/vscode/issues/237351) for more details.
+詳細については、この [VS Code issue](https://github.com/microsoft/vscode/issues/237351) を参照してください。
 
-## Notable fixes {#notable-fixes}
+## 注目の修正 {#notable-fixes}
 
-* [160325](https://github.com/microsoft/vscode/issues/160325) Suppress terminal launch failure after ctrl+D is pressed
-* [230438](https://github.com/microsoft/vscode/issues/230438) Support for code page `1125` aka `cp866u`
-* [238577](https://github.com/microsoft/vscode/issues/238577) Increase default window size
-* [197377](https://github.com/microsoft/vscode/issues/197377) workspaceFolder variable substitution in launch.json or tasks.json should use URI for virtual filesystems
-* [229857](https://github.com/microsoft/vscode/issues/229857) a11y view is blank after running `focus comment on line`
+* [160325](https://github.com/microsoft/vscode/issues/160325) `ctrl+D` を押した後のターミナル起動失敗を抑制
+* [230438](https://github.com/microsoft/vscode/issues/230438) コードページ `1125` こと `cp866u` のサポート
+* [238577](https://github.com/microsoft/vscode/issues/238577) デフォルトのウィンドウサイズを増やす
+* [197377](https://github.com/microsoft/vscode/issues/197377) `launch.json` または `tasks.json` の `workspaceFolder` 変数の置換は仮想ファイルシステムの URI を使用する必要があります
+* [229857](https://github.com/microsoft/vscode/issues/229857) `focus comment on line` を実行した後、アクセシビリティビューが空白になる
 
-## Thank you {#thank-you}
+## ありがとう {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆さんに大きな _**ありがとう**_ を伝えたいと思います。
 
-### Issue tracking {#issue-tracking}
+### issue トラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+issue トラッキングへの貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
@@ -638,132 +638,132 @@ Contributions to our issue tracking:
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@starball5 (starball)](https://github.com/starball5)
 
-### Pull requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@Abrifq (Arda Aydın)](https://github.com/Abrifq): Change `Create New Terminal` to focus accordingly to the terminal location [PR #237404](https://github.com/microsoft/vscode/pull/237404)
-* [@adrianstephens](https://github.com/adrianstephens): custom editor preview [PR #235533](https://github.com/microsoft/vscode/pull/235533)
-* [@andrewsuzuki (Andrew Suzuki)](https://github.com/andrewsuzuki): Fix 'new Color' string typo for editorBracketHighlight.unexpectedBracket.foreground [PR #237236](https://github.com/microsoft/vscode/pull/237236)
+* [@Abrifq (Arda Aydın)](https://github.com/Abrifq): ターミナルの場所に応じて `Create New Terminal` をフォーカスするように変更 [PR #237404](https://github.com/microsoft/vscode/pull/237404)
+* [@adrianstephens](https://github.com/adrianstephens): カスタムエディタープレビュー [PR #235533](https://github.com/microsoft/vscode/pull/235533)
+* [@andrewsuzuki (Andrew Suzuki)](https://github.com/andrewsuzuki): `new Color` 文字列のタイプミスを修正、`editorBracketHighlight.unexpectedBracket.foreground` [PR #237236](https://github.com/microsoft/vscode/pull/237236)
 * [@aslezar (Shivam Garg)](https://github.com/aslezar)
-  * Fix incorrect GLIBC version parsing [PR #236082](https://github.com/microsoft/vscode/pull/236082)
-  * feat: support custom js switch-case indentation [PR #237069](https://github.com/microsoft/vscode/pull/237069)
-* [@atreids (Aaron Donaldson)](https://github.com/atreids): chore: fix typo in VSIX progress notification [PR #238845](https://github.com/microsoft/vscode/pull/238845)
-* [@BABA983 (BABA)](https://github.com/BABA983): Resolve custom editor with canonical resource [PR #226614](https://github.com/microsoft/vscode/pull/226614)
-* [@congyuandong (scott)](https://github.com/congyuandong): fix: remove duplicate `!**/*.mk` entry in dependenciesSrc [PR #236683](https://github.com/microsoft/vscode/pull/236683)
-* [@DetachHead](https://github.com/DetachHead): remove `javascript.inlayHints.enumMemberValues.enabled` because javascript does not have enums [PR #236297](https://github.com/microsoft/vscode/pull/236297)
-* [@devm33 (Devraj Mehta)](https://github.com/devm33): Use Electron fetch or Node fetch for github-authentication to support proxies [PR #238149](https://github.com/microsoft/vscode/pull/238149)
-* [@dmitrysonder (Dmitry Sonder)](https://github.com/dmitrysonder): refactor: use EventType constants for events [PR #236941](https://github.com/microsoft/vscode/pull/236941)
-* [@fa0311 (ふぁ)](https://github.com/fa0311): Fix ${unixTime} Placeholder to Use Full Millisecond Timestamp in markdown.copyFiles.destination [PR #239061](https://github.com/microsoft/vscode/pull/239061)
-* [@g122622](https://github.com/g122622): Scrollbar for File menu is displaying over Open Recent [PR #236998](https://github.com/microsoft/vscode/pull/236998)
-* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Add a Configure option to overflow menu of Open Editors view [PR #237678](https://github.com/microsoft/vscode/pull/237678)
-* [@goodmind (andretshurotshka)](https://github.com/goodmind): Fixes #44237: Add column number in tasks [PR #65264](https://github.com/microsoft/vscode/pull/65264)
+  * GLIBC バージョンの解析の誤りを修正 [PR #236082](https://github.com/microsoft/vscode/pull/236082)
+  * カスタム js スイッチケースのインデントをサポート [PR #237069](https://github.com/microsoft/vscode/pull/237069)
+* [@atreids (Aaron Donaldson)](https://github.com/atreids): ちょっとした修正: VSIX 進行状況通知のタイプミスを修正 [PR #238845](https://github.com/microsoft/vscode/pull/238845)
+* [@BABA983 (BABA)](https://github.com/BABA983): カスタムエディターを正規リソースで解決 [PR #226614](https://github.com/microsoft/vscode/pull/226614)
+* [@congyuandong (scott)](https://github.com/congyuandong): 修正: `dependenciesSrc` に重複する `!**/*.mk` エントリを削除 [PR #236683](https://github.com/microsoft/vscode/pull/236683)
+* [@DetachHead](https://github.com/DetachHead): `javascript.inlayHints.enumMemberValues.enabled` を削除、JavaScript に列挙型がないため [PR #236297](https://github.com/microsoft/vscode/pull/236297)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): プロキシをサポートするために github-authentication に Electron fetch または Node fetch を使用 [PR #238149](https://github.com/microsoft/vscode/pull/238149)
+* [@dmitrysonder (Dmitry Sonder)](https://github.com/dmitrysonder): リファクタリング: イベントに EventType 定数を使用 [PR #236941](https://github.com/microsoft/vscode/pull/236941)
+* [@fa0311 (ふぁ)](https://github.com/fa0311): `${unixTime}` プレースホルダーを使用して、markdown.copyFiles.destination の完全なミリ秒タイムスタンプを使用するように修正 [PR #239061](https://github.com/microsoft/vscode/pull/239061)
+* [@g122622](https://github.com/g122622): ファイルメニューのスクロールバーが [最近開いたファイル] の上に表示される [PR #236998](https://github.com/microsoft/vscode/pull/236998)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): [開いているエディター] ビューのオーバーフローメニューに [構成] オプションを追加 [PR #237678](https://github.com/microsoft/vscode/pull/237678)
+* [@goodmind (andretshurotshka)](https://github.com/goodmind): #44237 を修正: タスクに列番号を追加 [PR #65264](https://github.com/microsoft/vscode/pull/65264)
 * [@HD787 (Henry)](https://github.com/HD787)
-  * Add ${unixTime} Placeholder for markdown.copyFiles.destination Option [PR #238027](https://github.com/microsoft/vscode/pull/238027)
-  * enable typescript commands when only config files are open [PR #238630](https://github.com/microsoft/vscode/pull/238630)
-* [@iamdereky (Derek Yang)](https://github.com/iamdereky): Fix CSS errors when using HTML escaped quotes [PR #235367](https://github.com/microsoft/vscode/pull/235367)
-* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): Remove paths from tsconfig.base.json [PR #238475](https://github.com/microsoft/vscode/pull/238475)
-* [@janajar (Jawad Najar)](https://github.com/janajar): Fix: When no results in search editor it throws an error [PR #235031](https://github.com/microsoft/vscode/pull/235031)
-* [@jaymroy](https://github.com/jaymroy): Issue: #214481 Add Option to Ignore Code Blocks in Text-to-Speech [PR #235697](https://github.com/microsoft/vscode/pull/235697)
-* [@jogibear9988 (Jochen Kühner)](https://github.com/jogibear9988): support svg's in image preview [PR #237217](https://github.com/microsoft/vscode/pull/237217)
-* [@Jules-Bertholet (Jules Bertholet)](https://github.com/Jules-Bertholet): Support back and forward keys in default shortcuts [PR #237701](https://github.com/microsoft/vscode/pull/237701)
-* [@Legend-Master (Tony)](https://github.com/Legend-Master): Reland fix custom task shell doesn't work without manually passing in "run command" arg/flag [PR #236058](https://github.com/microsoft/vscode/pull/236058)
-* [@LemmusLemmus](https://github.com/LemmusLemmus): Add $ to surrounding pairs in markdown [PR #233981](https://github.com/microsoft/vscode/pull/233981)
-* [@leopardracer (leopardracer)](https://github.com/leopardracer): fix: typos in documentation files [PR #235968](https://github.com/microsoft/vscode/pull/235968)
-* [@misode (Misode)](https://github.com/misode): Fix missing uri to file path conversion when loading json schema [PR #237275](https://github.com/microsoft/vscode/pull/237275)
-* [@mohankumarelec (mohanram)](https://github.com/mohankumarelec): Fixes #236973 [PR #236974](https://github.com/microsoft/vscode/pull/236974)
-* [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango): Add 'open image' context in markdown preview [PR #234649](https://github.com/microsoft/vscode/pull/234649)
-* [@numbermaniac](https://github.com/numbermaniac): Fix typo in InlayHintKind docs [PR #238032](https://github.com/microsoft/vscode/pull/238032)
-* [@oltolm (oltolm)](https://github.com/oltolm): debug: ignore error when stopping a process [PR #236009](https://github.com/microsoft/vscode/pull/236009)
+  * markdown.copyFiles.destination オプションのために `${unixTime}` プレースホルダーを追加 [PR #238027](https://github.com/microsoft/vscode/pull/238027)
+  * 設定ファイルのみが開かれている場合に TypeScript コマンドを有効にする [PR #238630](https://github.com/microsoft/vscode/pull/238630)
+* [@iamdereky (Derek Yang)](https://github.com/iamdereky): HTML エスケープされた引用符を使用する場合の CSS エラーを修正 [PR #235367](https://github.com/microsoft/vscode/pull/235367)
+* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): tsconfig.base.json からパスを削除 [PR #238475](https://github.com/microsoft/vscode/pull/238475)
+* [@janajar (Jawad Najar)](https://github.com/janajar): 修正: 検索エディターに結果がない場合、エラーが発生する [PR #235031](https://github.com/microsoft/vscode/pull/235031)
+* [@jaymroy](https://github.com/jaymroy): Issue: #214481 テキスト読み上げでコードブロックを無視するオプションを追加 [PR #235697](https://github.com/microsoft/vscode/pull/235697)
+* [@jogibear9988 (Jochen Kühner)](https://github.com/jogibear9988): 画像プレビューで svg をサポート [PR #237217](https://github.com/microsoft/vscode/pull/237217)
+* [@Jules-Bertholet (Jules Bertholet)](https://github.com/Jules-Bertholet): デフォルトのショートカットで戻るおよび進むキーをサポート [PR #237701](https://github.com/microsoft/vscode/pull/237701)
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): カスタムタスクシェルが "run command" 引数/フラグを手動で渡さずに機能しない問題を修正 [PR #236058](https://github.com/microsoft/vscode/pull/236058)
+* [@LemmusLemmus](https://github.com/LemmusLemmus): Markdown の囲むペアに $ を追加 [PR #233981](https://github.com/microsoft/vscode/pull/233981)
+* [@leopardracer (leopardracer)](https://github.com/leopardracer): 修正: ドキュメントファイルのタイプミス [PR #235968](https://github.com/microsoft/vscode/pull/235968)
+* [@misode (Misode)](https://github.com/misode): json スキーマの読み込み時に uri をファイルパスに変換するのを忘れないように修正 [PR #237275](https://github.com/microsoft/vscode/pull/237275)
+* [@mohankumarelec (mohanram)](https://github.com/mohankumarelec): #236973 を修正 [PR #236974](https://github.com/microsoft/vscode/pull/236974)
+* [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango): Markdown プレビューで画像を開くコンテキストメニューを追加 [PR #234649](https://github.com/microsoft/vscode/pull/234649)
+* [@numbermaniac](https://github.com/numbermaniac): InlayHintKind ドキュメントのタイプミスを修正 [PR #238032](https://github.com/microsoft/vscode/pull/238032)
+* [@oltolm (oltolm)](https://github.com/oltolm): デバッグ: プロセスを停止する際のエラーを無視 [PR #236009](https://github.com/microsoft/vscode/pull/236009)
 * [@oxcened (Alen Ajam)](https://github.com/oxcened)
-  * fix: set _lastFocusedWidget as undefined on widget blur [PR #234610](https://github.com/microsoft/vscode/pull/234610)
-  * fix: check whether lastFocusedList is valid when assigned [PR #238765](https://github.com/microsoft/vscode/pull/238765)
-* [@pankajk07 (Pankaj Khandelwal)](https://github.com/pankajk07): fix: synchronous script loading from web workers of extensions [PR #233175](https://github.com/microsoft/vscode/pull/233175)
+  * 修正: ウィジェットのフォーカスが外れたときに _lastFocusedWidget を未定義に設定 [PR #234610](https://github.com/microsoft/vscode/pull/234610)
+  * 修正: lastFocusedList が有効かどうかを確認してから割り当て [PR #238765](https://github.com/microsoft/vscode/pull/238765)
+* [@pankajk07 (Pankaj Khandelwal)](https://github.com/pankajk07): 修正: 拡張機能の Web ワーカーからの同期スクリプト読み込み [PR #233175](https://github.com/microsoft/vscode/pull/233175)
 * [@Parasaran-Python (Parasaran)](https://github.com/Parasaran-Python)
-  * fix 227150: Added a recursive git clone button [PR #232497](https://github.com/microsoft/vscode/pull/232497)
-  * fix 235221: Sanitizing the html content by closing the unclosed tags [PR #236145](https://github.com/microsoft/vscode/pull/236145)
-* [@r3m0t (Tomer Chachamu)](https://github.com/r3m0t): Fix revealing a notebook cell from the debugger stopping and revealing active statement (Fixes #225290) [PR #225292](https://github.com/microsoft/vscode/pull/225292)
-* [@rcjsuen (Remy Suen)](https://github.com/rcjsuen): Fix typo in the help text of the icon extension point [PR #238393](https://github.com/microsoft/vscode/pull/238393)
+  * #227150 を修正: 再帰的な git クローンボタンを追加 [PR #232497](https://github.com/microsoft/vscode/pull/232497)
+  * #235221 を修正: 閉じていないタグを閉じることで HTML コンテンツをサニタイズ [PR #236145](https://github.com/microsoft/vscode/pull/236145)
+* [@r3m0t (Tomer Chachamu)](https://github.com/r3m0t): デバッガーが停止してアクティブなステートメントを表示する際にノートブックセルを表示する問題を修正 (#225290) [PR #225292](https://github.com/microsoft/vscode/pull/225292)
+* [@rcjsuen (Remy Suen)](https://github.com/rcjsuen): アイコン拡張ポイントのヘルプテキストのタイプミスを修正 [PR #238393](https://github.com/microsoft/vscode/pull/238393)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
-  * Fix extension preview codeblock language getter [PR #235880](https://github.com/microsoft/vscode/pull/235880)
-  * Add `outdated` and `recentlyUpdated` suggestions to extension filter [PR #235884](https://github.com/microsoft/vscode/pull/235884)
+  * 拡張プレビューのコードブロック言語取得を修正 [PR #235880](https://github.com/microsoft/vscode/pull/235880)
+  * 拡張フィルターに `outdated` および `recentlyUpdated` の提案を追加 [PR #235884](https://github.com/microsoft/vscode/pull/235884)
 * [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
-  * Mark bun.lock as jsonc [PR #235917](https://github.com/microsoft/vscode/pull/235917)
-  * Allow the .ndjson extension for the jsonl language [PR #235921](https://github.com/microsoft/vscode/pull/235921)
-* [@RiskyMH (Michael H)](https://github.com/RiskyMH): `bun.lock` as package manager lockfile [PR #236012](https://github.com/microsoft/vscode/pull/236012)
-* [@sunnylost (sunnylost)](https://github.com/sunnylost): fix(settings-editor): ensure the width of the key name does not shrink [PR #229919](https://github.com/microsoft/vscode/pull/229919)
-* [@tcostew](https://github.com/tcostew): Allow Github Copilot chat to appear in QuickAccess [PR #210805](https://github.com/microsoft/vscode/pull/210805)
+  * bun.lock を jsonc としてマーク [PR #235917](https://github.com/microsoft/vscode/pull/235917)
+  * jsonl 言語のために .ndjson 拡張子を許可 [PR #235921](https://github.com/microsoft/vscode/pull/235921)
+* [@RiskyMH (Michael H)](https://github.com/RiskyMH): `bun.lock` をパッケージマネージャーロックファイルとして追加 [PR #236012](https://github.com/microsoft/vscode/pull/236012)
+* [@sunnylost (sunnylost)](https://github.com/sunnylost): 修正(settings-editor): キー名の幅が縮小しないようにする [PR #229919](https://github.com/microsoft/vscode/pull/229919)
+* [@tcostew](https://github.com/tcostew): GitHub Copilot チャットを QuickAccess に表示できるようにする [PR #210805](https://github.com/microsoft/vscode/pull/210805)
 * [@tmm1 (Aman Karmani)](https://github.com/tmm1)
-  * build: update to include more tsc boilerplate [PR #238422](https://github.com/microsoft/vscode/pull/238422)
-  * build: switch `build/tsconfig.json` to `module: nodenext` [PR #238426](https://github.com/microsoft/vscode/pull/238426)
-* [@tobil4sk](https://github.com/tobil4sk): Merge diverging findExecutable functions [PR #228373](https://github.com/microsoft/vscode/pull/228373)
-* [@zWingz (zWing)](https://github.com/zWingz): fix(git-ext): fix limitWarning block the git status progress [PR #226577](https://github.com/microsoft/vscode/pull/226577)
+  * ビルド: さらに多くの tsc ボイラープレートを含むように更新 [PR #238422](https://github.com/microsoft/vscode/pull/238422)
+  * ビルド: `build/tsconfig.json` を `module: nodenext` に切り替え [PR #238426](https://github.com/microsoft/vscode/pull/238426)
+* [@tobil4sk](https://github.com/tobil4sk): 分岐する findExecutable 関数をマージ [PR #228373](https://github.com/microsoft/vscode/pull/228373)
+* [@zWingz (zWing)](https://github.com/zWingz): 修正(git-ext): git ステータスの進行状況をブロックする limitWarning を修正 [PR #226577](https://github.com/microsoft/vscode/pull/226577)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献:
 
-* [@ShahinSorkh (Shahin Sorkh)](https://github.com/ShahinSorkh): clarify where to set `eslint.runtime` and `eslint.execArgv` options [PR #1973](https://github.com/microsoft/vscode-eslint/pull/1973)
+* [@ShahinSorkh (Shahin Sorkh)](https://github.com/ShahinSorkh): `eslint.runtime` および `eslint.execArgv` オプションを設定する場所を明確にする [PR #1973](https://github.com/microsoft/vscode-eslint/pull/1973)
 
-Contributions to `vscode-extension-samples`:
+`vscode-extension-samples` への貢献:
 
-* [@IsBenben](https://github.com/IsBenben): Fixes cannot find module 'semver' [PR #1129](https://github.com/microsoft/vscode-extension-samples/pull/1129)
+* [@IsBenben](https://github.com/IsBenben): モジュール 'semver' が見つからない問題を修正 [PR #1129](https://github.com/microsoft/vscode-extension-samples/pull/1129)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@mdh1418 (Mitchell Hwang)](https://github.com/mdh1418): Update BlazorDebugger telemetry report event [PR #2158](https://github.com/microsoft/vscode-js-debug/pull/2158)
+* [@mdh1418 (Mitchell Hwang)](https://github.com/mdh1418): BlazorDebugger テレメトリレポートイベントを更新 [PR #2158](https://github.com/microsoft/vscode-js-debug/pull/2158)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献:
 
-* [@gy-mate (Máté Gyöngyösi)](https://github.com/gy-mate): Capitalize 'URL' [PR #16340](https://github.com/microsoft/vscode-jupyter/pull/16340)
-* [@pwang347 (Paul)](https://github.com/pwang347): Add `waitUntil` for `onDidStart` event [PR #16375](https://github.com/microsoft/vscode-jupyter/pull/16375)
+* [@gy-mate (Máté Gyöngyösi)](https://github.com/gy-mate): 'URL' を大文字に [PR #16340](https://github.com/microsoft/vscode-jupyter/pull/16340)
+* [@pwang347 (Paul)](https://github.com/pwang347): `onDidStart` イベントに `waitUntil` を追加 [PR #16375](https://github.com/microsoft/vscode-jupyter/pull/16375)
 
-Contributions to `vscode-loc`:
+`vscode-loc` への貢献:
 
-* [@NicoWeio (Nicolai Weitkemper)](https://github.com/NicoWeio): improve grammar in README [PR #1367](https://github.com/microsoft/vscode-loc/pull/1367)
+* [@NicoWeio (Nicolai Weitkemper)](https://github.com/NicoWeio): README の文法を改善 [PR #1367](https://github.com/microsoft/vscode-loc/pull/1367)
 
-Contributions to `vscode-prompt-tsx`:
+`vscode-prompt-tsx` への貢献:
 
 * [@atxtechbro (Morgan Joyce)](https://github.com/atxtechbro)
-  * docs: fix typo in Passing Priority description [PR #140](https://github.com/microsoft/vscode-prompt-tsx/pull/140)
-  * docs: fix grammar in budget allocation description [PR #141](https://github.com/microsoft/vscode-prompt-tsx/pull/141)
+  * ドキュメント: 優先度の説明のタイプミスを修正 [PR #140](https://github.com/microsoft/vscode-prompt-tsx/pull/140)
+  * ドキュメント: 予算配分の説明の文法を修正 [PR #141](https://github.com/microsoft/vscode-prompt-tsx/pull/141)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@mikeseese (Mike Seese)](https://github.com/mikeseese): Add opt-in to always prompt for repo for issue creation and add comment to issue file specifying the repo [PR #6115](https://github.com/microsoft/vscode-pull-request-github/pull/6115)
-* [@NellyWhads (Nelly Whads)](https://github.com/NellyWhads): Remove the python language user mention exception [PR #6525](https://github.com/microsoft/vscode-pull-request-github/pull/6525)
-* [@Ronny-zzl (Zhang)](https://github.com/Ronny-zzl): Don't show hover cards for @-mentioned users in JSDocs in jsx and tsx files [PR #6531](https://github.com/microsoft/vscode-pull-request-github/pull/6531)
+* [@mikeseese (Mike Seese)](https://github.com/mikeseese): issue 作成時に常にリポジトリをプロンプトするオプトインを追加し、リポジトリを指定するコメントを issue ファイルに追加 [PR #6115](https://github.com/microsoft/vscode-pull-request-github/pull/6115)
+* [@NellyWhads (Nelly Whads)](https://github.com/NellyWhads): Python 言語ユーザーの言及例外を削除 [PR #6525](https://github.com/microsoft/vscode-pull-request-github/pull/6525)
+* [@Ronny-zzl (Zhang)](https://github.com/Ronny-zzl): jsx および tsx ファイルの JSDocs で @-メンションされたユーザーのホバーカードを表示しない [PR #6531](https://github.com/microsoft/vscode-pull-request-github/pull/6531)
 
-Contributions to `vscode-pylint`:
+`vscode-pylint` への貢献:
 
-* [@DetachHead](https://github.com/DetachHead): workaround for memory leak caused by pylint bug [PR #585](https://github.com/microsoft/vscode-pylint/pull/585)
+* [@DetachHead](https://github.com/DetachHead): pylint バグによるメモリリークの回避策 [PR #585](https://github.com/microsoft/vscode-pylint/pull/585)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
 * [@rchiodo (Rich Chiodo)](https://github.com/rchiodo)
-  * Update to 1.8.11 [PR #536](https://github.com/microsoft/vscode-python-debugger/pull/536)
-  * Support the clientOS property in VS code [PR #550](https://github.com/microsoft/vscode-python-debugger/pull/550)
-  * Update `debugpy` to 1.8.12 [PR #558](https://github.com/microsoft/vscode-python-debugger/pull/558)
+  * 1.8.11 に更新 [PR #536](https://github.com/microsoft/vscode-python-debugger/pull/536)
+  * VS code で `clientOS` プロパティをサポート [PR #550](https://github.com/microsoft/vscode-python-debugger/pull/550)
+  * `debugpy` を 1.8.12 に更新 [PR #558](https://github.com/microsoft/vscode-python-debugger/pull/558)
 
-Contributions to `vscode-ripgrep`:
+`vscode-ripgrep` への貢献:
 
-* [@fiji-flo (Florian Dieminger)](https://github.com/fiji-flo): fix long download [PR #62](https://github.com/microsoft/vscode-ripgrep/pull/62)
-* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Fix for arm64 windows [PR #63](https://github.com/microsoft/vscode-ripgrep/pull/63)
+* [@fiji-flo (Florian Dieminger)](https://github.com/fiji-flo): 長いダウンロードを修正 [PR #62](https://github.com/microsoft/vscode-ripgrep/pull/62)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): arm64 Windows の修正 [PR #63](https://github.com/microsoft/vscode-ripgrep/pull/63)
 
-Contributions to `vscode-test`:
+`vscode-test` への貢献:
 
-* [@kamaal111 (Kamaal Farah)](https://github.com/kamaal111): docs: update Github Actions link to point to sample [PR #297](https://github.com/microsoft/vscode-test/pull/297)
+* [@kamaal111 (Kamaal Farah)](https://github.com/kamaal111): ドキュメント: Github Actions リンクをサンプルにポイントするように更新 [PR #297](https://github.com/microsoft/vscode-test/pull/297)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
 * [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721): cython-lsp [PR #2064](https://github.com/microsoft/language-server-protocol/pull/2064)
-* [@catwell (Pierre Chapuis)](https://github.com/catwell): Add Teal LSP [PR #2078](https://github.com/microsoft/language-server-protocol/pull/2078)
+* [@catwell (Pierre Chapuis)](https://github.com/catwell): Teal LSP を追加 [PR #2078](https://github.com/microsoft/language-server-protocol/pull/2078)
 * [@Enaium (Enaium)](https://github.com/Enaium)
-  * Add Jimmer DTO [PR #2070](https://github.com/microsoft/language-server-protocol/pull/2070)
-  * Change Maintainer [PR #2071](https://github.com/microsoft/language-server-protocol/pull/2071)
-* [@g-plane (Pig Fang)](https://github.com/g-plane): New language server: wasm-language-tools [PR #2065](https://github.com/microsoft/language-server-protocol/pull/2065)
-* [@jcs090218 (Jen-Chieh Shen)](https://github.com/jcs090218): chore(_implementors/servers.md): Update Ellsp link [PR #2073](https://github.com/microsoft/language-server-protocol/pull/2073)
-* [@kbwo (Kodai Kabasawa)](https://github.com/kbwo): Add testing-language-server in servers.md [PR #2076](https://github.com/microsoft/language-server-protocol/pull/2076)
-* [@kylebonnici (Kyle Micallef Bonnici)](https://github.com/kylebonnici): Add Devicetree LSP to list [PR #2085](https://github.com/microsoft/language-server-protocol/pull/2085)
-* [@ribru17 (Riley Bruins)](https://github.com/ribru17): Add ts_query_ls (Tree-sitter query language server) [PR #2068](https://github.com/microsoft/language-server-protocol/pull/2068)
+  * Jimmer DTO を追加 [PR #2070](https://github.com/microsoft/language-server-protocol/pull/2070)
+  * メンテナーを変更 [PR #2071](https://github.com/microsoft/language-server-protocol/pull/2071)
+* [@g-plane (Pig Fang)](https://github.com/g-plane): 新しい言語サーバー: wasm-language-tools [PR #2065](https://github.com/microsoft/language-server-protocol/pull/2065)
+* [@jcs090218 (Jen-Chieh Shen)](https://github.com/jcs090218): ちょっとした修正(_implementors/servers.md): Ellsp リンクを更新 [PR #2073](https://github.com/microsoft/language-server-protocol/pull/2073)
+* [@kbwo (Kodai Kabasawa)](https://github.com/kbwo): servers.md に testing-language-server を追加 [PR #2076](https://github.com/microsoft/language-server-protocol/pull/2076)
+* [@kylebonnici (Kyle Micallef Bonnici)](https://github.com/kylebonnici): Devicetree LSP をリストに追加 [PR #2085](https://github.com/microsoft/language-server-protocol/pull/2085)
+* [@ribru17 (Riley Bruins)](https://github.com/ribru17): ts_query_ls (Tree-sitter クエリ言語サーバー) を追加 [PR #2068](https://github.com/microsoft/language-server-protocol/pull/2068)
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/3773262cfe38945c2b4a93984aa7f77fbc2e43c7

For future reference ...

1. Checkout original file (CLI command)
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```