### PR TITLE
Translate February 2025 (version 1.98)

### DIFF
--- a/docs/release-notes/v1_98.md
+++ b/docs/release-notes/v1_98.md
@@ -1,0 +1,799 @@
+---
+Order: 107
+TOCTitle: February 2025
+PageTitle: Visual Studio Code February 2025
+MetaDescription: Learn what is new in the Visual Studio Code February 2025 Release (1.98)
+MetaSocialImage: 1_98/release-highlights.png
+Date: 2025-03-05
+DownloadVersion: 1.98.0
+---
+# February 2025 (version 1.98)
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the February 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* [Next Edit Suggestions (preview)](#collapsed-mode-for-next-edit-suggestions-preview) - Copilot predicts the next edit you are likely to make.
+* [Agent mode (preview)](#agent-mode-improvements-experimental) - Copilot autonomously completes tasks.
+* [Copilot Edits for notebooks](#notebook-support-in-copilot-edits-preview) - Iterate quickly on edits for your notebooks.
+* [Code search](#more-advanced-codebase-search-in-copilot-chat) - Let Copilot find relevant files for your chat prompt.
+* [Terminal IntelliSense (preview)](#terminal-intellisense-preview) - Rich completion support for your terminal.
+* [Drag & drop references](#peek-references-drag-and-drop-support) - Quickly open peek references in a new editor.
+* [Linux custom title bar](#custom-title-bar-on-linux) - Custom title bar support for Linux enabled by default.
+* [Unresolved diagnostics (preview)](#diagnostics-commit-hook-experimental) - Prompt when committing with unresolved diagnostics.
+* [Soft-delete in source control](#discard-untracked-changes-improvements) - Move untracked files to trash instead of deleting them.
+* [Custom instructions GA](#custom-instructions-generally-available) - Use custom instructions to tailor Copilot to your needs.
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## GitHub Copilot
+
+Copilot features might go through different early access stages, which are typically enabled and configured through settings.
+
+| Stage | Description |
+|-------|-------------|
+| **Experimental** | The feature is still in development and not yet ready for general use.<br/>View the [experimental features](command:workbench.action.openSettings?%5B%22%40tag%3Aexperimental%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:experimental`). |
+| **Preview** | The feature is still under refinement, yet ready to use. Feedback is welcome.<br/>View the [preview features](command:workbench.action.openSettings?%5B%22%40tag%3Apreview%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:preview`). |
+| **Stable** | The feature is ready for general use. |
+
+### Copilot Edits
+
+#### Agent mode improvements (Experimental)
+
+Last month, we introduced _agent mode_ for Copilot Edits in [VS Code Insiders](https://code.visualstudio.com/insiders/). In agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
+
+> **Note**: Agent mode is available today in [VS Code Insiders](https://code.visualstudio.com/insiders/), and we just started rolling it out gradually in **VS Code Stable**. Once agent mode is enabled for you, you will see a mode dropdown in the Copilot Edits view — simply select **Agent**.
+
+We made several improvements to the UX of tool usages this month:
+
+* Terminal commands are now shown inline, so you can keep track of which commands were run.
+* You can edit the suggested terminal command in the chat response before running it.
+* Confirm a terminal command with the `kb(workbench.action.chat.acceptTool)` shortcut.
+
+<video src="images/1_98/edit-terminal.mp4" title="Video that shows editing a suggested terminal command in Chat." autoplay loop controls muted></video>
+
+Agent mode autonomously searches your codebase for relevant context. Expand the message to see the results of which searches were done.
+
+![Screenshot that shows the expandable list of search results in Copilot Edits.](images/1_98/agent-mode-search-results.png)
+
+We've also made various improvements to the prompt and behavior of agent mode:
+
+* The undo and redo actions in chat now undo or redo the last file edit made in a chat response. This is useful for agent mode, as you can now undo certain steps the model took without rolling back the entire chat response.
+* Agent mode can now run your build [tasks](https://code.visualstudio.com/docs/editor/tasks) automatically or when instructed to do so. Disable this functionality via the `setting(github.copilot.chat.agent.runTasks)` setting, in the event that you see the model running tasks when it should not.
+
+Learn more about [Copilot Edits agent mode](https://code.visualstudio.com/docs/copilot/copilot-edits#_use-agent-mode-preview) or read the [agent mode announcement blog post](https://code.visualstudio.com/blogs/2025/02/24/introducing-copilot-agent-mode).
+
+> **Note**: If you are a Copilot Business or Enterprise user, an administrator of your organization [must opt in](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) to the use of Copilot "Editor Preview Features" for agent mode to be available.
+
+#### Notebook support in Copilot Edits (Preview)
+
+We are introducing notebook support in Copilot Edits as a preview feature in [VS Code Insiders](https://code.visualstudio.com/insiders). You can now use Copilot to edit notebook files with the same intuitive experience as editing code files. Create new notebooks from scratch, modify content across multiple cells, insert and delete cells, and change cell types. This preview feature provides a seamless workflow when working with data science or documentation notebooks.
+
+> **Note**: This feature is currently only available in [VS Code Insiders](https://code.visualstudio.com/insiders/) with the pre-release version of GitHub Copilot Chat. We'll continue to improve the experience before bringing it to VS Code Stable in a future release.
+
+<video src="images/1_98/notebook_copilot_edits.mp4" title="Video that shows using Copilot Edits to modify a notebook." autoplay loop controls muted></video>
+
+#### Refined editor integration
+
+We have polished the integration of Copilot Edits with code and notebook editors:
+
+* No more scrolling while changes are being applied. The viewport remains in place, making it easier to focus on what changes.
+* Renamed the edit review actions from "Accept" to "Keep" and "Discard" to "Undo" to better reflect what’s happening. Changes for Copilot Edits are live, they are applied and saved as they are made and users keep or undo them.
+* After keeping or undoing a file, the next file is automatically revealed.
+
+The video demonstrates how edits are applied and saved as they occur. The live preview updates, and the user decided to "Keep" the changes. Undoing and further tweaking is also still possible.
+
+<video src="images/1_98/edits_editor.mp4" title="Video that shows that changes from Copilot Edits are saved automatically and the user decided to keep them." autoplay loop controls muted></video>
+
+#### Refreshed UI
+
+In preparation for unifying Copilot Edits with Copilot Chat, we've given Copilot Edits a facelift. Files that are attached and not yet sent, are now rendered as regular chat attachments. Only files that have been modified with AI are added to the changed files list, which is located above the chat input part.
+
+With the `setting(chat.renderRelatedFiles)` setting, you can enable getting suggestions for related files. Related file suggestions are rendered below the chat attachments.
+
+![Screenshot that shows the updated Copilot Edits attachments and changed files user experience.](images/1_98/copilot_edits_ui.png)
+
+#### Removed Copilot Edits limits
+
+Previously, you were limited to attach 10 files to your prompt in Copilot Edits. With this release, we removed this limit. Additionally, we've removed the client-side rate limit of 14 interactions per 10 minutes.
+
+> Note that service-side usage rate limits still apply.
+
+### Custom instructions generally available
+
+**Setting**: `setting(github.copilot.chat.codeGeneration.useInstructionFiles)`
+
+Custom instructions enable you to tailor GitHub Copilot to provide chat responses and code suggestions to the way you and your team work. Describe your specific requirements Markdown format in a `.github/copilot-instructions.md` file in your workspace.
+
+This milestone, we are making custom instructions with `.github/copilot-instructions.md` generally available. Make sure that the `setting(github.copilot.chat.codeGeneration.useInstructionFiles)` VS Code setting is enabled, and Copilot will then use these instructions when generating responses.
+
+Learn more about [custom instructions in Copilot](https://code.visualstudio.com/docs/copilot/copilot-customization).
+
+### Smoother authentication flows in chat
+
+If you host your source code in a GitHub repository, you're able to leverage several features, including advanced code searching, the `@github` chat participant, and more!
+
+However, for private GitHub repositories, VS Code needs to have permission to interact with your repositories on GitHub. For a while, this was presented with our usual VS Code authentication flow, where a modal dialog showed up when you invoked certain functionality (for example, asking `@workspace` or `@github` a question, or using the `#codebase` tool).
+
+To make this experience smoother, we've introduced this confirmation in chat:
+
+![Screenshot that shows the authentication confirmation dialog in Chat, showing the three options to continue.](images/1_98/confirmation-auth-dialog.png)
+
+Not only is it not as jarring as a modal dialog, but it also has new functionality:
+
+1. **Grant:** you're taken through the regular authentication flow like before (via the modal).
+1. **Not Now:** VS Code remembers your choice and won't bother you again until your next VS Code window session. The only exception to this is if the feature needs this additional permission to function, like `@github`.
+1. **Never Ask Again:** VS Code remembers your choice and persists it via the `setting(github.copilot.advanced.authPermissions)` setting. Any feature that needs this additional permission will fail.
+
+It's important to note that this confirmation does not confirm or deny Copilot (the service) access to your repositories. This is only how VS Code's Copilot experience authenticates. To configure what Copilot can access, please read the docs [on content exclusion](https://docs.github.com/en/copilot/managing-copilot/configuring-and-auditing-content-exclusion/excluding-content-from-github-copilot).
+
+### More advanced codebase search in Copilot Chat
+
+**Setting**: `setting(github.copilot.chat.codesearch.enabled)`
+
+When you add `#codebase` to your Copilot Chat query, Copilot helps you find relevant code in your workspace for your chat prompt. `#codebase` can now run tools like text search and file search to pull in additional context from your workspace.
+
+Set `setting(github.copilot.chat.codesearch.enabled)` to enable this behavior. The full list of tools is:
+
+* Embeddings-based semantic search
+* Text search
+* File search
+* Git modified files
+* Project structure
+* Read file
+* Read directory
+* Workspace symbol search
+
+### Attach problems as chat context
+
+To help with fixing code or other issues in your workspace, you can now attach problems from the Problems panel to your chat as context for your prompt.
+
+Either drag an item from the Problems panel onto the Chat view, type `#problems` in your prompt, or select the paperclip 📎 button. You can attach specific problems, all problems in a file, or all files in your codebase.
+
+### Attach folders as context
+
+Previously, you could attach folders as context by using drag and drop from the Explorer view. Now, you can also attach a folder by selecting the paperclip 📎 icon or by typing `#folder:` followed by the folder name in your chat prompt.
+
+### Collapsed mode for Next Edit Suggestions (Preview)
+
+**Settings**:
+
+* `setting(github.copilot.nextEditSuggestions.enabled)`
+* `setting(editor.inlineSuggest.edits.showCollapsed:true)`
+
+We've added a collapsed mode for NES. When you enable this mode, only the NES suggestion indicator is shown in the left editor margin. The code suggestion itself is revealed only when you navigate to it by pressing `kb(editor.action.inlineSuggest.jump)`. Consecutive suggestions are shown immediately until a suggestion is not accepted.
+
+<video src="images/1_98/NEScollapsedMode.mp4" title="Video that shows Next Edit Suggestions collapsed mode." autoplay loop controls muted></video>
+
+The collapsed mode is disabled by default and can be enabled by configuring `setting(editor.inlineSuggest.edits.showCollapsed:true)`, or you can enable or disable it in the NES gutter indicator menu.
+
+![Screenshot that shows the Next Edit Suggestions context menu in the editor left margin, highlighting the Show Collapsed option.](images/1_98/NESgutterMenu.png)
+
+### Change completions model
+
+You could already change the language model for Copilot Chat and Copilot Edits, and now you can also change the model for inline suggestions.
+
+Alternatively, you can change the model that is used for code completions via **Change Completions Model** command in the Command Palette or the **Configure Code Completions** item in the Copilot menu in the title bar.
+
+> **Note:** the list of available models might vary and change over time. If you are a Copilot Business or Enterprise user, your Administrator needs to enable certain models for your organization by opting in to `Editor Preview Features` in the [Copilot policy settings](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) on GitHub.com.
+
+### Model availability
+
+This release, we added more models to choose from when using Copilot. The following models are now available in the model picker in Visual Studio Code and github.com chat:
+
+* **GPT 4.5 (Preview)**: OpenAI’s latest model, GPT-4.5, is now available in GitHub Copilot Chat to Copilot Enterprise users. GPT-4.5 is a large language model designed with advanced capabilities in intuition, writing style, and broad knowledge. Learn more about the GPT-4.5 model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-27-openai-gpt-4-5-in-github-copilot-now-available-in-public-preview).
+
+* **Claude 3.7 Sonnet (Preview)**: Claude 3.7 Sonnet is now available to all customers on paid Copilot plans. This new Sonnet model supports both thinking and non-thinking modes in Copilot. In initial testing, we’ve seen particularly strong improvements in agentic scenarios. Learn more about the Claude 3.7 Sonnet model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-24-claude-3-7-sonnet-is-now-available-in-github-copilot-in-public-preview/).
+
+### Copilot Vision (Preview)
+
+We're quickly rolling out end-to-end vision support in this version of Copilot Chat. This lets you attach images and interact with images in chat prompts. For example, if you encounter an error while debugging, attach a screenshot of VS Code, and ask Copilot to help you resolve the issue. You might also use it to attach some UI mockup and let Copilot provide some HTML and CSS to implement the mockup.
+
+![Animation that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](images/1_97/image-attachments.gif)
+
+You can attach images in multiple ways:
+
+* Drag and drop images from your OS or from the Explorer view
+* Paste an image from your clipboard
+* Attach a screenshot of the VS Code window (select the **paperclip 📎 button** > **Screenshot Window**)
+
+A warning is shown if the selected model currently does not have the capability to handle the file type. The only supported model at the moment will be `GPT 4o`, but support for image attachments with `Claude 3.5 Sonnet` and `Gemini 2.0 Flash` will be rolling out soon as well. Currently, the supported image types are `JPEG/JPG`, `PNG`, `GIF`, and `WEBP`.
+
+### Copilot status overview (Experimental)
+
+**Setting**: `setting(chat.experimental.statusIndicator.enabled)`
+
+We are experimenting with a new centralized Copilot status overview that provides a quick overview of your Copilot status and key editor settings:
+
+* Quota information if you are a [Copilot Free](https://code.visualstudio.com/blogs/2024/12/18/free-github-copilot) user
+* Editor related settings such as Code Completions
+* Useful keyboard shortcuts to use other Copilot features
+
+This Copilot status overview is accessible via the Copilot icon in the Status Bar.
+
+![Screenshot that shows the Copilot status overview in the Status Bar.](images/1_98/copilot-status.png)
+
+Enable the Copilot status overview with the `setting(chat.experimental.statusIndicator.enabled)` setting.
+
+### TypeScript context for inline completions (Experimental)
+
+**Setting**: `setting(chat.languageContext.typescript.enabled)`
+
+We are experimenting with enhanced context for inline completions and `/fix` commands for TypeScript files. The experiment is currently scoped to Insider releases and can be enabled with the `setting(chat.languageContext.typescript.enabled)` setting.
+
+### Custom instructions for pull request title and description
+
+You can provide custom instructions for generating pull request title and description with the setting `setting(github.copilot.chat.pullRequestDescriptionGeneration.instructions)`.  You can point the setting to a file in your workspace, or you can provide instructions inline in your settings. Get more details about using [customizing Copilot in VS Code](https://code.visualstudio.com/docs/copilot/copilot-customization).
+
+The following sample shows how to provide a custom instruction inline in settings.
+
+```json
+{
+  "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+    {
+      "text": "Prefix every PR title with an emoji."
+    }
+  ]
+}
+```
+
+Generating a title and description requires the GitHub Pull Requests extension to be installed.
+
+## Accessibility
+
+### Copilot Edits accessibility
+
+We made Copilot Edits much more accessible.
+
+* There are now audio signals for files with modifications and for changed regions (insertions, modifications, and deletions).
+* The accessible diff viewer is now available for modified files. Just like in diff editors, select `kb(chatEditor.action.showAccessibleDiffView)` to enable it.
+
+### `activeEditorState` window title variable
+
+We have a new `setting(window.title)` variable, `activeEditorState`, to indicate editor information such as modified state, the number of problems, and when a file has pending Copilot Edits to screen reader users. When in Screen Reader Optimized mode, this is appended by default and can be disabled with `setting(accessibility.windowTitleOptimized:false)`.
+
+## Workbench
+
+### Custom title bar on Linux
+
+The custom title bar is now enabled by default on Linux. The custom title bar gives you access to layout controls, the Copilot menu, and more.
+
+![Screenshot that shows the custom VS Code title bar on Linux.](images/1_97/custom-title.png)
+
+You can always revert back to the native title decorations, either from the custom title context menu or by configuring `setting(window.titleBarStyle)` to `native`.
+
+![Screenshot that shows the content menu option to disable the custom title bar on Linux.](images/1_97/restore-title.png)
+
+We are happy for continued feedback on this experience and are already working on improving this for future milestones based on existing feedback.
+
+### Use labels for Secondary Side Bar views
+
+We decided to change the appearance of views in the Secondary Side Bar to show labels instead of icons, similar to what we have in the Panel area. This makes it easier to distinguish between different views, for example the **Copilot Edits** and **Copilot Chat** views. You can switch back to showing icons at any time by configuring `setting(workbench.secondarySideBar.showLabels)`.
+
+![Screenshot that shows Secondary Side Bar with labels instead of icons.](images/1_98/aux-sidebar.png)
+
+### New Settings editor key-matching algorithm (Preview)
+
+**Setting**: `setting(workbench.settings.useWeightedKeySearch:true)`
+
+We have added a new Settings editor search algorithm that prioritizes more relevant key matches. The search algorithm attempts to match the setting ID and labels in more ways than before, but it also filters down the results more so that only the best match types are shown.
+
+You can try out the preview feature by enabling the `setting(workbench.settings.useWeightedKeySearch:true)` setting.
+
+<video src="images/1_98/new-settings-search.mp4" title="Video that shows searching for tab and font before and after. After shows more relevant settings at the top of the search results." autoplay loop controls muted></video>
+
+_Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
+
+### Option to hide dot files in simple file picker
+
+When using the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (either when connected to a remote or when using `setting(files.simpleDialog.enable:true)`, you can now hide dot files by using the **Show/Hide dot files** button.
+
+![Screenshot that shows the simple file picker, highlighting the button to show or hide dot files.](images/1_98/hide-dot-file.png)
+
+## Editor
+
+### Peek references drag and drop support
+
+The [peek](https://code.visualstudio.com/docs/editor/editingevolved#_peek) view now supports drag & drop. Invoke **Peek References**, **Peek Implementation**, or any of the other peek commands, and drag entries from its tree to open them as separate editors.
+
+<video src="images/1_98/peek_dnd.mp4" title="Video that shows drag and drop of a peek reference as new editor group." autoplay loop controls muted></video>
+_Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
+
+### Occurrences highlight delay
+
+The delay for occurrence highlighting within the editor is now set to 0 by default. This results in an overall more responsive editor feel. You can still control the delay with the `setting(editor.occurrencesHighlightDelay)` setting.
+
+## Source Control
+
+### Updated view titles
+
+When we added the **Source Control Graph** view to the Source Control view, it emphasized the duplication of section titles in the Source Control view: "Source Control Repositories", "Source Control", and "Source Control Graph". This milestone we have revisited the titles of the views, so that they are shorter and no longer duplicate the view title: "Repositories", "Changes", and "Graph".
+
+### Discard untracked changes improvements
+
+**Setting**: `setting(git.discardUntrackedChangesToTrash)`
+
+Over the years we have received multiple reports about data loss because discarding an untracked file would permanently delete the file, even though VS Code shows a modal dialog making it clear that the file will be deleted permanently.
+
+Starting this milestone, discarding an untracked file will move the file to the Recycle Bin/Trash when possible, so that the file can be easily recovered. You can disable this functionality using the `setting(git.discardUntrackedChangesToTrash)` setting.
+
+![Screenshot of the modal dialog shown when discarding an untracked file.](images/1_98/scm-move-to-trash.png)
+
+### Diagnostics commit hook (Experimental)
+
+**Settings**:
+
+* `setting(git.diagnosticsCommitHook.Enabled:true)`
+* `setting(git.diagnosticsCommitHook.Sources)`
+
+This milestone, we introduced a new commit hook that prompts you if there are any unresolved diagnostics for the changed files. This is currently an experimental feature that can be enabled using the `setting(git.diagnosticsCommitHook.Enabled:true)` setting.
+
+By default, the commit hook prompts for any error level diagnostics, but the diagnostics sources and levels can be customized using the `setting(git.diagnosticsCommitHook.Sources)` setting. Give it a try and let us know your feedback.
+
+![Screenshot of the modal dialog shown when there are unresolved diagnostics for the changed files.](images/1_98/scm-diagnostics-commit-hook.png)
+
+## Notebooks
+
+### Inline notebook diff view (Experimental)
+
+**Setting**: `setting(notebook.diff.experimental.toggleInline:true)`
+
+You can now enable an inline diff view for notebooks. This feature enables you to view changes within notebook cells in a single inline view, rather than the traditional side-by-side comparison.
+
+Enable this feature by setting `setting(notebook.diff.experimental.toggleInline:true)` to `true`. You can then toggle the diff view to inline using the editor menu in the top right corner.
+
+<video src="images/1_98/inline_notebook_diff.mp4" title="Video that shows toggling an edit suggestion from side-by-side to an inline diff for notebooks." autoplay loop controls muted></video>
+
+### Notebook inline values hover
+
+Notebook inline values now have their decoration truncated to fit the width of the viewport and have a rich hover to show the full value, maintaining whitespace formatting. This maintains the shape of variables like dataframes, making values easier to read at a glance.
+
+![Screenshot that shows the cursor hovering above a dataframe object's inline decoration. A rich value hover is shown.](images/1_98/nb-inline-values-rich-hover.png)
+
+## Terminal IntelliSense (Preview)
+
+**Setting**: `setting(terminal.integrated.suggest.enabled:true)`
+
+We've significantly improved terminal shell completions across bash, zsh, fish, and PowerShell by adding completion specs (`git` for example), refining command-line parsing for better suggestions, and enhancing file and folder completions. Enable this feature with `setting(terminal.integrated.suggest.enabled:true)`.
+
+### Enhanced Fig completion support
+
+We leverage [Fig completion specs](https://github.com/withfig/autocomplete) to power intelligent completions for specific CLIs. We only had a small number of these before, but this iteration we added the following CLIs to the list we ship with VS Code:
+
+* Basic tools: `cat`, `chmod`, `chown`, `cp`, `curl`, `df`, `du`, `echo`, `find`, `grep`, `head`, `less`, `ls`, `mkdir`, `more`, `mv`, `pwd`, `rm`, `rmdir`, `tail`, `top`, `touch`, `uname`
+* Process tools: `kill`, `killall`, `ps`
+* Package managers: `apt`, `brew`
+* Node.js ecosystem: `node`, `npm`, `npx`, `nvm`, `pnpm`, `yarn`
+* SCM, languages, editors: `git`, `nano`, `python`, `python3`, `vim`
+* Network: `scp`, `ssh`, `wget`
+
+In addition to the new specs, we now also support _generators_, which dynamically generate completions by running commands when they're requested. One example of this in action is presenting all branches for `git checkout`:
+
+![Screenshot that shows completions for "git checkout tyriar/xterm", showing several results, including fuzzy results that don't match the query exactly.](images/1_98/terminal-git-checkout.png)
+_Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire/Sapphire))_
+
+Behind the scenes, this runs `git --no-optional-locks branch -a --no-color --sort=-committerdate` to get the list of branches before processing them into completions. A similar approach is used to also fetch tags.
+
+### Configurable quick suggestions
+
+**Setting**: `setting(terminal.integrated.suggest.quickSuggestions)`
+
+Similar to the editor, _quick suggestions_ are what automatically shows IntelliSense when typing _anything_, as opposed to _trigger characters_, which show when certain characters like `\` or `-` are used. The new `setting(terminal.integrated.suggest.quickSuggestions)` setting allows precise control over when quick suggestions should be presented.
+
+The default value enables quick suggestions for commands and arguments, and now disabled by default falling back to paths which we heard could get noisy and frustrating as they often weren't applicable. This is the default:
+
+```js
+"terminal.integrated.suggest.quickSuggestions": {
+  "commands": "on",
+  "arguments": "on",
+  "unknown": "off"
+}
+```
+
+### Inline suggestion detection
+
+**Setting**: `setting(terminal.integrated.suggest.inlineSuggestion)`
+
+One problem inline suggestion detection has had to date, has been confusion introduced by competing with suggestions from different sources. Specifically, the inline suggestion that often appears when typing in shells:
+
+![Screenshot that shows fish shell showing suggestions, such as previous git commit commands when typing a prefix.](images/1_98/terminal-fish-autosuggest.png)
+
+These suggestions are actually shell-level features (auto suggestions in fish/zsh, predictions in pwsh, etc.), which might not be obvious to the user, especially when presented alongside IntelliSense.
+
+The IntelliSense feature requires that we detect this inline suggestion, which previously used a naive implementation that only checked whether the text was styled with _faint_ or _italics_ SGR attributes. It turns out that this was insufficient, not only when the user customized the styles, but also fish shell did not use either of these styles by default. We now detect the majority of cases by analyzing the command line context and cursor position.
+
+Building upon this new and improved detection, the inline suggestion is now presented as the top option with a star icon to both align closer with how the editor behaves and to make it more clear what `kstyle(Tab)` will do in this case.
+
+![Screenshot that shows when an inline suggestion shows up, it will be detected and put beside a star icon at the top of IntelliSense.](images/1_98/terminal-fish-inline-suggest.png)
+
+The default is to always show this suggestion as the top suggestions, but can be configured with `setting(terminal.integrated.suggest.inlineSuggestion)`.
+
+### Detailed command completions
+
+Completions for bash and zsh built-in commands and PowerShell commands are now more detailed, providing details on available arguments. This information is sourced from the shell's documentation or help commands.
+
+For bash, `help <command>` is used to get a basic description:
+
+![Screenshot that shows the history completion in bash, showing usage information and description.](images/1_98/terminal-bash-builtin-completions.png)
+
+For zsh, `man zshbuiltins` is used to get a detailed description:
+
+![Screenshot that shows completions in zsh, displaying detailed information from the manpage.](images/1_98/terminal-zsh-builtin-completions.png)
+
+For PowerShell, more properties of `Get-Command` are shown in the completion:
+
+![Screenshot that shows the completion for Get-ChildItem, showing the module Microsoft.PowerShell.Management and its version.](images/1_98/terminal-pwsh-module.png)
+
+![Screenshot that shows the completion for ConvertTo-Json, showing the signature of the command.](images/1_98/terminal-pwsh-signature.png)
+
+### Improved sorting
+
+Command completions now feature improved sorting, specifically:
+
+* Completions with more details generally appear above less detailed completions
+* Builtin commands take precedence over paths from `$PATH`
+
+![Screenshot that shows the more useful alias and autoload commands showing before others in zsh.](images/1_98/terminal-zsh-order.png)
+
+For paths, the following improvements were made:
+
+* Paths starting with `_` get a penalty as this is often an indicator that they are special and generally shouldn't be changed much (for example, `__init__.py`).
+* Punctuation is ignored when sorting, so files starting with `.` will be mixed in with others.
+
+![Screenshot that shows __init__.py will show below other files, while a .build dir will show immediately above a build file.](images/1_98/terminal-underscore-punc.png)
+
+### CDPATH support
+
+**Setting**: `setting(terminal.integrated.suggest.cdPath)`
+
+The `$CDPATH` environment variable is a common shell feature that contains a colon-separated list of paths, similar to `$PATH`, and allows navigating to them as if they were relative regardless of the current working directory. Fish actually shows CDPATH entries in `cd` tab completion:
+
+![Screenshot that shows tab completion in fish, displaying entries from CDPATH.](images/1_98/terminal-fish-cdpath.png)
+
+We now support showing `$CDPATH` entries as completions when using `cd`:
+
+![Screenshot that shows CDPATH entries now show up in IntelliSense.](images/1_98/terminal-fish-cdpath-completions.png)
+
+This feature also works on Windows (`;` separators) and doesn't need the shell to natively support the feature, since the default is using the absolute path.
+
+![Screenshot that shows a CDPATH containing 2 paths separated by a semi-colon, including all sub-directories even on PowerShell which does not support CDPATH natively.](images/1_98/terminal-cdpath-pwsh.png)
+
+Configure this with `setting(terminal.integrated.suggest.cdPath)`.
+
+#### Absolute paths
+
+Absolute paths are now supported.
+
+![Screenshot that shows "cd c:\Github\mi" will show results for all absolute folders matching that term.](images/1_98/terminal-absolute-windows.png)
+
+![Screenshot that shows cd to absolute paths also works with Unix-style paths.](images/1_98/terminal-absolute-mac.png)
+
+### Alias support
+
+Command aliases are now also detected for bash, zsh and fish and feature a new distinct icon:
+
+![Screenshot that shows the alias c->code-insiders will now be detected and show with the command icon with a little arrow in the corner.](images/1_98/terminal-alias.png)
+
+### Differentiated options and flags
+
+CLI options (that have a value) and flags (that don't) are now differentiated in the UI via a different icon:
+
+![Screenshot that shows flags like --help will show a flag icon, options like --diff will show a different icon.](images/1_98/terminal-flags-options.png)
+
+## Tasks
+
+### Task rerun action
+
+We have a new **rerun** task action for terminals, `kb(workbench.action.tasks.rerunForActiveTerminal)`. The action appears on the terminal tab's inline toolbar and in the terminal's context menu.
+
+<video src="images/1_98/terminal-rerun-task.mp4" title="Video that shows the terminal rerun task." autoplay loop controls muted></video>
+
+## Debug
+
+### Debug inline values hover
+
+If the setting `setting(debug.inlineValues)` is enabled, the inline value decorations now have an inline hover, making it easier to read longer values at a glance.
+
+![Screenshot that shows the cursor hovering above a dataframe object's inline decoration in an active debugging session. Rich value hover is shown.](images/1_98/debug-inline-values-rich-hover.png)
+
+## Languages
+
+### TypeScript 5.8
+
+VS Code now includes TypeScript 5.8.2. This major update brings new language improvements, including [improved checking of types from conditional expressions](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) and [support for write code that confirms to Node's new --experimental-strip-types option](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#the---erasablesyntaxonly-option). It also included a number of tooling improvements and bug fixes.
+
+Check out the [TypeScript 5.8 release blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) for more details on this update.
+
+## Remote Development
+
+The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+
+Highlights include:
+
+* EOL for Linux legacy server
+* Expanded proxy configurability
+
+You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_98.md).
+
+## Enterprise support
+
+### Multi-line support for allowed extensions
+
+You can now configure allowed extensions in the group policy on Windows using a multi-line string. This allows for more flexible and extensive configuration of allowed extensions. Learn more about [configuring allowed extensions](https://code.visualstudio.com/docs/setup/enterprise#_configure-allowed-extensions).
+
+## Contributions to extensions
+
+### Python
+
+#### Automatic quotation insertion when breaking long strings
+
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now supports automatic insertion of quotation marks to enable a seamless experience when breaking long strings.
+
+#### Pylance memory consumption improvements
+
+Some optimizations were made to improve Pylance's memory consumption, particularly when working with large workspaces. [This enhancement](https://github.com/microsoft/pyright/pull/9993) was made to Pyright, the static type checker that powers Pylance's language server features.
+
+#### Improvements to Python shell integration
+
+After modifying `setting(python.terminal.shellIntegration.enabled)`, you will no longer have to reload in order for changes to take effect. Simply create a new terminal to see desired changes on your Python REPL in terminal.
+
+#### Correct workspace prompt for Windows Git Bash
+
+Python users on Windows using Git Bash will now see correct working directory in their terminal prompt.
+These changes apply to those opted into the `pythonTerminalEnvVarActivation` experiment.
+
+#### New setting for auto test discovery file pattern
+
+You can now refine which files auto test discovery occurs by specifying a glob pattern in the `setting(python.testing.autoTestDiscoverOnSavePattern)` setting. Its default value is set to `**/*.py`.
+
+#### Read test debug config from settings.json as fallback
+
+We now look for test debug configurations in both `settings.json` and `launch.json` files, expanding where you can define these configurations.
+
+### GitHub authentication
+
+#### Improved proxy support with Electron `fetch` adoption
+
+The GitHub Authentication extension now leverages Electron's version of `fetch` in order to make web requests. This has helped users with certain proxy & firewall settings. If you know you run in an environment that has a proxy setup and you are unable to authenticate to GitHub inside of VS Code, don't hesitate to create an issue!
+
+## Extension authoring
+
+### Authentication
+
+> **Important**:
+> We are renaming `AuthenticationForceNewSessionOptions` to `AuthenticationGetSessionPresentationOptions` and leaving a deprecated `AuthenticationForceNewSessionOptions` for now. There is no functional difference, so this is not a breaking change in the runtime, but you should update your code to use `AuthenticationGetSessionPresentationOptions` instead of `AuthenticationForceNewSessionOptions` since it will be removed in the future.
+
+Looking at these two authentication calls:
+```ts
+vscode.authentication.getSession(provider, scopes, { createIfNone: options });
+vscode.authentication.getSession(provider, scopes, { forceNewSession: options });
+```
+
+`createIfNone` and `forceNewSession` will now take in either a `boolean` or a `AuthenticationGetSessionPresentationOptions`:
+```ts
+/**
+ * Optional options to be used when calling {@link authentication.getSession} with interactive options `forceNewSession` & `createIfNone`.
+ */
+export interface AuthenticationGetSessionPresentationOptions {
+	/**
+	 * An optional message that will be displayed to the user when we ask to re-authenticate. Providing additional context
+	 * as to why you are asking a user to re-authenticate can help increase the odds that they will accept.
+	 */
+	detail?: string;
+}
+```
+_[full typings can be found here](https://github.com/microsoft/vscode/blob/release/1.98/src/vscode-dts/vscode.d.ts#L17520-L17551)_...
+
+This is a new addition for `createIfNone`, but it's a modification for `forceNewSession`, which used to take in a `AuthenticationForceNewSessionOptions` that had the same signature as the new `AuthenticationGetSessionPresentationOptions`.
+
+If you are explicitly using `AuthenticationForceNewSessionOptions`, you will see it is marked as deprecated and you should replace it with `AuthenticationGetSessionPresentationOptions`, as `AuthenticationForceNewSessionOptions` will be removed in a future version.
+
+It's important to note that the only thing that is changing here are the types. **There is no runtime change, so this is not a breaking change from that perspective.**
+
+Additionally, the `authLearnMore` [proposed API](https://github.com/microsoft/vscode/blob/release/1.98/src/vscode-dts/vscode.proposed.authLearnMore.d.ts) has been updated from `AuthenticationForceNewSessionOptions` to `AuthenticationGetSessionPresentationOptions`.
+
+Here's an example that leverages `detail` and the `learnMore` proposal:
+
+![Screenshot that shows the authentication modal dialog, featuring a message that says 'To get more relevant Copilot Chat results, we need permission to read the contents of your repository on GitHub.' and a button to learn more.](images/1_98/auth-presentation.png)
+
+### Refined Snippet API
+
+You can now control the whitespace normalization when inserting snippets. This applies to the [`insertSnippet`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L1306)-API and to the [`SnippetTextEdit`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L3753)-API and control is the indentation of additional lines of snippets are adjusted or not
+
+```js
+const snippet = `This is an indented
+    snippet`;
+
+// keepWhitespace: false, undefined
+function indentedFunctionWithSnippet() {
+    return `This is an indented
+        snippet`; // adjusted indentation
+}
+
+// keepWhitespace: true
+function indentedFunctionWithSnippet() {
+    return `This is an indented
+    snippet`; // original indentation
+}
+
+```
+
+## Proposed APIs
+
+### Text Encodings
+
+We added new proposed API to work with [text encodings](https://github.com/microsoft/vscode/blob/501ee833b16b8e83ba656c46e0888aadd9d2db04/src/vscode-dts/vscode.proposed.textDocumentEncoding.d.ts#L1) in VS Code.
+
+Specifically, this new API allows to:
+
+* Get the current `encoding` of a `TextDocument`
+* Open a `TextDocument` with a specific `encoding`
+* Encode a `string` to a `Uint8Array` with a specific `encoding`
+* Decode a `Uint8Array` to a `string` using a specific `encoding`
+
+Try it out and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/241449).
+
+### Shell environment
+
+Extensions are able to access the user's currently active shell environment information for pwsh, zsh, bash, and fish shell that are opened from the VS Code integrated terminal. This is only available when `setting(terminal.integrated.shellIntegration.enabled)` is enabled.
+
+The user can decide whether or not to report their shell environment information with `setting(terminal.integrated.shellIntegration.environmentReporting)`.
+
+Give it a try and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/227467).
+
+## Engineering
+
+### Electron 34 update
+
+In this milestone, we are promoting the Electron 34 update to users on our stable release. This update comes with Chromium 132.0.6834.196 and Node.js 20.18.2. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+
+### macOS 10.15 support has ended
+
+VS Code `1.97` is the last release that supports macOS 10.15 (macOS Catalina). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
+
+### Dev-time tracking of leaked disposables
+
+VS Code uses the disposable pattern for explicit resource management, for example to close files, clean up DOM elements, or remove event listeners. Not disposing of resources means memory is wasted and memory usage accumulates over time.
+
+We are constantly on the hunt for such leaks and have added another tool for detecting this. We utilize the [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) API as it informs us when an object has been garbage collected. If such an object represented a `disposable`, which has not been disposed of, this means we have a leak. These are collected and shown to the developers of VS Code, so that we can clean things up as we go.
+
+## Notable fixes
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Diff selection indicator line should use menu.separatorBackground instead of menu.border [PR #228825](https://github.com/microsoft/vscode/pull/228825)
+* [@bchu1 (Bryan Chu)](https://github.com/bchu1): Fix to header misplacement in minimap [PR #217581](https://github.com/microsoft/vscode/pull/217581)
+* [@cassidoo (Cassidy Williams)](https://github.com/cassidoo): Fix #241903: Add override for GitHub in settingsLayout.ts [PR #241911](https://github.com/microsoft/vscode/pull/241911)
+* [@cdce8p (Marc Mueller)](https://github.com/cdce8p): Add panelTitleBadge color variables [PR #240645](https://github.com/microsoft/vscode/pull/240645)
+* [@cenviity (Vincent Ging Ho Yim)](https://github.com/cenviity): Fix typos in `editorOptions.ts` [PR #239929](https://github.com/microsoft/vscode/pull/239929)
+* [@cmbrose (Caleb Brose)](https://github.com/cmbrose): Update chat's `newEditSession` command to take an input prompt [PR #241796](https://github.com/microsoft/vscode/pull/241796)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): fix: add electron as an external for webpack [PR #239134](https://github.com/microsoft/vscode/pull/239134)
+* [@dmotte (Motte)](https://github.com/dmotte): Fix behavior of terminal.integrated.confirmOnExit [PR #240074](https://github.com/microsoft/vscode/pull/240074)
+* [@dvangonen (Daniil Vangonen)](https://github.com/dvangonen): Remove unnecessary classes from body [PR #240633](https://github.com/microsoft/vscode/pull/240633)
+* [@gabritto (Gabriela Araujo Britto)](https://github.com/gabritto): Revert "[typescript-language-features] Expandable hover (#228255)" [PR #240011](https://github.com/microsoft/vscode/pull/240011)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+  * Supply multiselects to `scm/resourceGroup/context` menu commands (fix #92337) [PR #192172](https://github.com/microsoft/vscode/pull/192172)
+  * Add `scmResourceGroupState` context key (#192009) [PR #194804](https://github.com/microsoft/vscode/pull/194804)
+  * SCM - Briefer titles on SCM views [PR #230693](https://github.com/microsoft/vscode/pull/230693)
+  * Fix `Show User Keybindings' option on Keyboard Shortcuts editor (fix #240068) [PR #240085](https://github.com/microsoft/vscode/pull/240085)
+  * Bad 'OK' capitalization on 'Add Triggered Breakpoint...' (fix #240490) [PR #240492](https://github.com/microsoft/vscode/pull/240492)
+* [@hickford (M Hickford)](https://github.com/hickford): Log provider in "tunnel user show" [PR #240692](https://github.com/microsoft/vscode/pull/240692)
+* [@ihavecoke (ihavecoke)](https://github.com/ihavecoke): Clamp tab_size setting between 1 and 16 [PR #228957](https://github.com/microsoft/vscode/pull/228957)
+* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): Preserve --disable-extensions in extension host development [PR #240415](https://github.com/microsoft/vscode/pull/240415)
+* [@jamestut (James Nugraha)](https://github.com/jamestut): Compute TextModel limits before initializing the tokenizer [PR #240919](https://github.com/microsoft/vscode/pull/240919)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413)
+  * Fix terminal split view disposable leaked [PR #241597](https://github.com/microsoft/vscode/pull/241597)
+  * Fix broken terminal link hover, hides before being able to hover over the contents [PR #241599](https://github.com/microsoft/vscode/pull/241599)
+  * Fix timeline view leaks event listeners [PR #241607](https://github.com/microsoft/vscode/pull/241607)
+* [@KexyBiscuit (Kexy Biscuit a.k.a. るる)](https://github.com/KexyBiscuit): Allow detection of powershell-preview snap [PR #240054](https://github.com/microsoft/vscode/pull/240054)
+* [@klaussner (Christian Klaussner)](https://github.com/klaussner): Fix traffic light centering on macOS [PR #212471](https://github.com/microsoft/vscode/pull/212471)
+* [@naman108 (Natha Paquette)](https://github.com/naman108): Typo in storage URI docs [PR #241600](https://github.com/microsoft/vscode/pull/241600)
+* [@nknguyenhc (Nguyen)](https://github.com/nknguyenhc): Extension detail content escapes container [PR #240134](https://github.com/microsoft/vscode/pull/240134)
+* [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango)
+  * Make Command Center debug launcher offer most recently used configuration first [PR #240744](https://github.com/microsoft/vscode/pull/240744)
+  * Adopt Markdown to use vscode log output channel [PR #241342](https://github.com/microsoft/vscode/pull/241342)
+* [@pouyakary (Pouya Kary ✨)](https://github.com/pouyakary): Feat: Custom Minimap Section Header Marker Detection RegExp ✨ [PR #210271](https://github.com/microsoft/vscode/pull/210271)
+* [@rgrunber (Roland Grunberg)](https://github.com/rgrunber): Expose adjustWhitespace to TextEditor API. [PR #234858](https://github.com/microsoft/vscode/pull/234858)
+* [@silamon (Simon Lamon)](https://github.com/silamon): Diff editor: Correct `1 files` to `1 file` [PR #240092](https://github.com/microsoft/vscode/pull/240092)
+* [@simon-id (simon-id)](https://github.com/simon-id): fix: workbench search use correct findMatch colors (fix #237909) [PR #237910](https://github.com/microsoft/vscode/pull/237910)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): fix: memory leak in settings indicators [PR #236417](https://github.com/microsoft/vscode/pull/236417)
+* [@ssigwart (Stephen Sigwart)](https://github.com/ssigwart): Fix unexpected tab completion when attempting to indent [PR #136572](https://github.com/microsoft/vscode/pull/136572)
+* [@SunsetTechuila (Grigory)](https://github.com/SunsetTechuila): feat(commands): add `insertFinalNewLine` [PR #241126](https://github.com/microsoft/vscode/pull/241126)
+* [@tcvdh (Thijs van den Heuvel)](https://github.com/tcvdh): Fix: Wait for clear command to execute before reusing terminal [PR #240970](https://github.com/microsoft/vscode/pull/240970)
+* [@terrymun (Terry Mun-Andersen)](https://github.com/terrymun): fix: remove extraneous backtick in CONTRIBUTING.md [PR #240305](https://github.com/microsoft/vscode/pull/240305)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): tsb: fix for deleted and re-added source file not being re-generated [PR #238409](https://github.com/microsoft/vscode/pull/238409)
+* [@xymopen (xymopen_Official)](https://github.com/xymopen)
+  * Add node as npm script runner [PR #236967](https://github.com/microsoft/vscode/pull/236967)
+  * Add node as npm script runner (2nd) [PR #240527](https://github.com/microsoft/vscode/pull/240527)
+* [@zardoy (Vitaly)](https://github.com/zardoy): [Git] Migrate to git autostash when pulling for better performance [PR #187850](https://github.com/microsoft/vscode/pull/187850)
+
+Contributions to `vscode-css-languageservice`:
+
+* [@GauravB159 (Gaurav Bhagchandani)](https://github.com/GauravB159): lab() and lch() color previews added [PR #306](https://github.com/microsoft/vscode-css-languageservice/pull/306)
+
+Contributions to `vscode-eslint`:
+
+* [@edemaine (Erik Demaine)](https://github.com/edemaine): Probing support for Civet [PR #1965](https://github.com/microsoft/vscode-eslint/pull/1965)
+* [@mustevenplay (mustevenplay)](https://github.com/mustevenplay): Add Typescript configuration files detection [PR #1968](https://github.com/microsoft/vscode-eslint/pull/1968)
+
+Contributions to `vscode-hexeditor`:
+
+* [@tomilho (Tomás Silva)](https://github.com/tomilho): Moved Hex Compare Selected below Compare Selected [PR #561](https://github.com/microsoft/vscode-hexeditor/pull/561)
+
+Contributions to `vscode-jupyter`:
+
+* [@thesuperzapper (Mathew Wicks)](https://github.com/thesuperzapper): Fix reading `JUPYTER_RUNTIME_DIR` and `XDG_RUNTIME_DIR` [PR #16451](https://github.com/microsoft/vscode-jupyter/pull/16451)
+
+Contributions to `vscode-languageserver-node`:
+
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs)
+  * Add capability information to the metamodel [PR #1591](https://github.com/microsoft/vscode-languageserver-node/pull/1591)
+  * Fix text document didOpen/didClose server capabilities [PR #1615](https://github.com/microsoft/vscode-languageserver-node/pull/1615)
+  * Fix capabilities for range formatting requests [PR #1617](https://github.com/microsoft/vscode-languageserver-node/pull/1617)
+* [@mciccale (Marco Ciccalè Baztán)](https://github.com/mciccale): minor typo semaphore.ts [PR #1618](https://github.com/microsoft/vscode-languageserver-node/pull/1618)
+* [@yf-yang](https://github.com/yf-yang): fix: avoid dispose unmatched handlers [PR #1614](https://github.com/microsoft/vscode-languageserver-node/pull/1614)
+
+Contributions to `vscode-mypy`:
+
+* [@DetachHead](https://github.com/DetachHead)
+  * use correct capitalization of file paths to work around mypy issue [PR #342](https://github.com/microsoft/vscode-mypy/pull/342)
+  * update capitalization of cwd to match file path [PR #344](https://github.com/microsoft/vscode-mypy/pull/344)
+* [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): fix: usage of `node12 which is deprecated` in CI [PR #336](https://github.com/microsoft/vscode-mypy/pull/336)
+* [@ivirabyan (Ivan Virabyan)](https://github.com/ivirabyan): Add dmypy status file setting [PR #347](https://github.com/microsoft/vscode-mypy/pull/347)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@christianvuerings (Christian Vuerings)](https://github.com/christianvuerings): Fix Copy GitHub Permalink with custom SSH [PR #6669](https://github.com/microsoft/vscode-pull-request-github/pull/6669)
+
+Contributions to `vscode-python-debugger`:
+
+* [@TCPsoftware (tcpsoft)](https://github.com/TCPsoftware): Make "args": "${command:pickArgs}" as default debug configuration [PR #548](https://github.com/microsoft/vscode-python-debugger/pull/548)
+
+Contributions to `vscode-vsce`:
+
+* [@mohankumarelec (mohanram)](https://github.com/mohankumarelec): Updated the semver comparison [PR #1078](https://github.com/microsoft/vscode-vsce/pull/1078)
+* [@stevedlawrence (Steve Lawrence)](https://github.com/stevedlawrence): Allow for reproducible .vsix packages [PR #1100](https://github.com/microsoft/vscode-vsce/pull/1100)
+
+Contributions to `debug-adapter-protocol`:
+
+* [@angelozerr (Angelo)](https://github.com/angelozerr): Add IntelliJ / LSP4IJ DAP support [PR #529](https://github.com/microsoft/debug-adapter-protocol/pull/529)
+* [@samisalreadytaken](https://github.com/samisalreadytaken): Add Squirrel Debugger to adapters.md [PR #530](https://github.com/microsoft/debug-adapter-protocol/pull/530)
+* [@SpartanJ (Martín Lucas Golini)](https://github.com/SpartanJ): Update tools.md adding a new DAP client: ecode [PR #526](https://github.com/microsoft/debug-adapter-protocol/pull/526)
+* [@sssooonnnggg (Song)](https://github.com/sssooonnnggg): chore: add luau debugger [PR #516](https://github.com/microsoft/debug-adapter-protocol/pull/516)
+* [@theIDinside (Simon Farre)](https://github.com/theIDinside): Add Midas to Debug Adapter list, w/ VSCode [PR #528](https://github.com/microsoft/debug-adapter-protocol/pull/528)
+
+Contributions to `language-server-protocol`:
+
+* [@ind1go (Ben Cox)](https://github.com/ind1go): Typo in workspace diagnostics [PR #2086](https://github.com/microsoft/language-server-protocol/pull/2086)
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs)
+  * Add capability information to metamodel [PR #2096](https://github.com/microsoft/language-server-protocol/pull/2096)
+  * Update metamodel [PR #2104](https://github.com/microsoft/language-server-protocol/pull/2104)
+* [@MuntasirSZN (Muntasir Mahmud)](https://github.com/MuntasirSZN): feat: copilot language server in server list [PR #2107](https://github.com/microsoft/language-server-protocol/pull/2107)
+* [@Szasza (Szasza Palmer)](https://github.com/Szasza): adding Wing language server to server list [PR #2101](https://github.com/microsoft/language-server-protocol/pull/2101)
+* [@the-mikedavis (Michael Davis)](https://github.com/the-mikedavis): Clarify that `$0` should not use any other snippet syntax [PR #2087](https://github.com/microsoft/language-server-protocol/pull/2087)
+* [@yassun7010 (yassun7010)](https://github.com/yassun7010): add Tombi to LSP list. [PR #2089](https://github.com/microsoft/language-server-protocol/pull/2089)
+
+Contributions to `python-environment-tools`:
+
+* [@pantheraleo-7](https://github.com/pantheraleo-7): Add support for detecting `$VIRTUAL_ENV` [PR #181](https://github.com/microsoft/python-environment-tools/pull/181)
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_98.md
+++ b/docs/release-notes/v1_98.md
@@ -549,7 +549,7 @@ Windows で Git Bash を使用する Python ユーザーは、ターミナルプ
 
 `setting(python.testing.autoTestDiscoverOnSavePattern)` 設定でグロブパターンを指定することで、自動テスト検出が行われるファイルを絞り込むことができます。デフォルト値は `**/*.py` に設定されています。
 
-#### 設定.json からのテストデバッグ構成の読み取り {#read-test-debug-config-from-settings.json-as-fallback}
+#### settings.json からのテストデバッグ構成の読み取り {#read-test-debug-config-from-settings.json-as-fallback}
 
 テストデバッグ構成を `settings.json` および `launch.json` ファイルの両方で検索するようになり、これらの構成を定義できる場所が拡張されました。
 

--- a/docs/release-notes/v1_98.md
+++ b/docs/release-notes/v1_98.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_98/release-highlights.png
 Date: 2025-03-05
 DownloadVersion: 1.98.0
 ---
-# February 2025 (version 1.98)
+# February 2025 (version 1.98) {#february-2025-version-198}
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
@@ -29,7 +29,7 @@ Welcome to the February 2025 release of Visual Studio Code. There are many updat
 >If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 **Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
 
-## GitHub Copilot
+## GitHub Copilot {#github-copilot}
 
 Copilot features might go through different early access stages, which are typically enabled and configured through settings.
 
@@ -39,9 +39,9 @@ Copilot features might go through different early access stages, which are typic
 | **Preview** | The feature is still under refinement, yet ready to use. Feedback is welcome.<br/>View the [preview features](command:workbench.action.openSettings?%5B%22%40tag%3Apreview%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:preview`). |
 | **Stable** | The feature is ready for general use. |
 
-### Copilot Edits
+### Copilot Edits {#copilot-edits}
 
-#### Agent mode improvements (Experimental)
+#### Agent mode improvements (Experimental) {#agent-mode-improvements-experimental}
 
 Last month, we introduced _agent mode_ for Copilot Edits in [VS Code Insiders](https://code.visualstudio.com/insiders/). In agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
 
@@ -68,7 +68,7 @@ Learn more about [Copilot Edits agent mode](https://code.visualstudio.com/docs/c
 
 > **Note**: If you are a Copilot Business or Enterprise user, an administrator of your organization [must opt in](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) to the use of Copilot "Editor Preview Features" for agent mode to be available.
 
-#### Notebook support in Copilot Edits (Preview)
+#### Notebook support in Copilot Edits (Preview) {#notebook-support-in-copilot-edits-preview}
 
 We are introducing notebook support in Copilot Edits as a preview feature in [VS Code Insiders](https://code.visualstudio.com/insiders). You can now use Copilot to edit notebook files with the same intuitive experience as editing code files. Create new notebooks from scratch, modify content across multiple cells, insert and delete cells, and change cell types. This preview feature provides a seamless workflow when working with data science or documentation notebooks.
 
@@ -76,7 +76,7 @@ We are introducing notebook support in Copilot Edits as a preview feature in [VS
 
 <video src="https://code.visualstudio.com/assets/updates/1_98/notebook_copilot_edits.mp4" title="Video that shows using Copilot Edits to modify a notebook." autoplay loop controls muted></video>
 
-#### Refined editor integration
+#### Refined editor integration {#refined-editor-integration}
 
 We have polished the integration of Copilot Edits with code and notebook editors:
 
@@ -88,7 +88,7 @@ The video demonstrates how edits are applied and saved as they occur. The live p
 
 <video src="https://code.visualstudio.com/assets/updates/1_98/edits_editor.mp4" title="Video that shows that changes from Copilot Edits are saved automatically and the user decided to keep them." autoplay loop controls muted></video>
 
-#### Refreshed UI
+#### Refreshed UI {#refreshed-ui}
 
 In preparation for unifying Copilot Edits with Copilot Chat, we've given Copilot Edits a facelift. Files that are attached and not yet sent, are now rendered as regular chat attachments. Only files that have been modified with AI are added to the changed files list, which is located above the chat input part.
 
@@ -96,13 +96,13 @@ With the `setting(chat.renderRelatedFiles)` setting, you can enable getting sugg
 
 ![Screenshot that shows the updated Copilot Edits attachments and changed files user experience.](https://code.visualstudio.com/assets/updates/1_98/copilot_edits_ui.png)
 
-#### Removed Copilot Edits limits
+#### Removed Copilot Edits limits {#removed-copilot-edits-limits}
 
 Previously, you were limited to attach 10 files to your prompt in Copilot Edits. With this release, we removed this limit. Additionally, we've removed the client-side rate limit of 14 interactions per 10 minutes.
 
 > Note that service-side usage rate limits still apply.
 
-### Custom instructions generally available
+### Custom instructions generally available {#custom-instructions-generally-available}
 
 **Setting**: `setting(github.copilot.chat.codeGeneration.useInstructionFiles)`
 
@@ -112,7 +112,7 @@ This milestone, we are making custom instructions with `.github/copilot-instruct
 
 Learn more about [custom instructions in Copilot](https://code.visualstudio.com/docs/copilot/copilot-customization).
 
-### Smoother authentication flows in chat
+### Smoother authentication flows in chat {#smoother-authentication-flows-in-chat}
 
 If you host your source code in a GitHub repository, you're able to leverage several features, including advanced code searching, the `@github` chat participant, and more!
 
@@ -130,7 +130,7 @@ Not only is it not as jarring as a modal dialog, but it also has new functionali
 
 It's important to note that this confirmation does not confirm or deny Copilot (the service) access to your repositories. This is only how VS Code's Copilot experience authenticates. To configure what Copilot can access, please read the docs [on content exclusion](https://docs.github.com/en/copilot/managing-copilot/configuring-and-auditing-content-exclusion/excluding-content-from-github-copilot).
 
-### More advanced codebase search in Copilot Chat
+### More advanced codebase search in Copilot Chat {#more-advanced-codebase-search-in-copilot-chat}
 
 **Setting**: `setting(github.copilot.chat.codesearch.enabled)`
 
@@ -147,17 +147,17 @@ Set `setting(github.copilot.chat.codesearch.enabled)` to enable this behavior. T
 * Read directory
 * Workspace symbol search
 
-### Attach problems as chat context
+### Attach problems as chat context {#attach-problems-as-chat-context}
 
 To help with fixing code or other issues in your workspace, you can now attach problems from the Problems panel to your chat as context for your prompt.
 
 Either drag an item from the Problems panel onto the Chat view, type `#problems` in your prompt, or select the paperclip 📎 button. You can attach specific problems, all problems in a file, or all files in your codebase.
 
-### Attach folders as context
+### Attach folders as context {#attach-folders-as-context}
 
 Previously, you could attach folders as context by using drag and drop from the Explorer view. Now, you can also attach a folder by selecting the paperclip 📎 icon or by typing `#folder:` followed by the folder name in your chat prompt.
 
-### Collapsed mode for Next Edit Suggestions (Preview)
+### Collapsed mode for Next Edit Suggestions (Preview) {#collapsed-mode-for-next-edit-suggestions-preview}
 
 **Settings**:
 
@@ -172,7 +172,7 @@ The collapsed mode is disabled by default and can be enabled by configuring `set
 
 ![Screenshot that shows the Next Edit Suggestions context menu in the editor left margin, highlighting the Show Collapsed option.](https://code.visualstudio.com/assets/updates/1_98/NESgutterMenu.png)
 
-### Change completions model
+### Change completions model {#change-completions-model}
 
 You could already change the language model for Copilot Chat and Copilot Edits, and now you can also change the model for inline suggestions.
 
@@ -180,7 +180,7 @@ Alternatively, you can change the model that is used for code completions via **
 
 > **Note:** the list of available models might vary and change over time. If you are a Copilot Business or Enterprise user, your Administrator needs to enable certain models for your organization by opting in to `Editor Preview Features` in the [Copilot policy settings](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) on GitHub.com.
 
-### Model availability
+### Model availability {#model-availability}
 
 This release, we added more models to choose from when using Copilot. The following models are now available in the model picker in Visual Studio Code and github.com chat:
 
@@ -188,7 +188,7 @@ This release, we added more models to choose from when using Copilot. The follow
 
 * **Claude 3.7 Sonnet (Preview)**: Claude 3.7 Sonnet is now available to all customers on paid Copilot plans. This new Sonnet model supports both thinking and non-thinking modes in Copilot. In initial testing, we’ve seen particularly strong improvements in agentic scenarios. Learn more about the Claude 3.7 Sonnet model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-24-claude-3-7-sonnet-is-now-available-in-github-copilot-in-public-preview/).
 
-### Copilot Vision (Preview)
+### Copilot Vision (Preview) {#copilot-vision-preview}
 
 We're quickly rolling out end-to-end vision support in this version of Copilot Chat. This lets you attach images and interact with images in chat prompts. For example, if you encounter an error while debugging, attach a screenshot of VS Code, and ask Copilot to help you resolve the issue. You might also use it to attach some UI mockup and let Copilot provide some HTML and CSS to implement the mockup.
 
@@ -202,7 +202,7 @@ You can attach images in multiple ways:
 
 A warning is shown if the selected model currently does not have the capability to handle the file type. The only supported model at the moment will be `GPT 4o`, but support for image attachments with `Claude 3.5 Sonnet` and `Gemini 2.0 Flash` will be rolling out soon as well. Currently, the supported image types are `JPEG/JPG`, `PNG`, `GIF`, and `WEBP`.
 
-### Copilot status overview (Experimental)
+### Copilot status overview (Experimental) {#copilot-status-overview-experimental}
 
 **Setting**: `setting(chat.experimental.statusIndicator.enabled)`
 
@@ -218,13 +218,13 @@ This Copilot status overview is accessible via the Copilot icon in the Status Ba
 
 Enable the Copilot status overview with the `setting(chat.experimental.statusIndicator.enabled)` setting.
 
-### TypeScript context for inline completions (Experimental)
+### TypeScript context for inline completions (Experimental) {#typescript-context-for-inline-completions-experimental}
 
 **Setting**: `setting(chat.languageContext.typescript.enabled)`
 
 We are experimenting with enhanced context for inline completions and `/fix` commands for TypeScript files. The experiment is currently scoped to Insider releases and can be enabled with the `setting(chat.languageContext.typescript.enabled)` setting.
 
-### Custom instructions for pull request title and description
+### Custom instructions for pull request title and description {#custom-instructions-for-pull-request-title-and-description}
 
 You can provide custom instructions for generating pull request title and description with the setting `setting(github.copilot.chat.pullRequestDescriptionGeneration.instructions)`.  You can point the setting to a file in your workspace, or you can provide instructions inline in your settings. Get more details about using [customizing Copilot in VS Code](https://code.visualstudio.com/docs/copilot/copilot-customization).
 
@@ -242,22 +242,22 @@ The following sample shows how to provide a custom instruction inline in setting
 
 Generating a title and description requires the GitHub Pull Requests extension to be installed.
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Copilot Edits accessibility
+### Copilot Edits accessibility {#copilot-edits-accessibility}
 
 We made Copilot Edits much more accessible.
 
 * There are now audio signals for files with modifications and for changed regions (insertions, modifications, and deletions).
 * The accessible diff viewer is now available for modified files. Just like in diff editors, select `kb(chatEditor.action.showAccessibleDiffView)` to enable it.
 
-### `activeEditorState` window title variable
+### `activeEditorState` window title variable {#activeeditorstate-window-title-variable}
 
 We have a new `setting(window.title)` variable, `activeEditorState`, to indicate editor information such as modified state, the number of problems, and when a file has pending Copilot Edits to screen reader users. When in Screen Reader Optimized mode, this is appended by default and can be disabled with `setting(accessibility.windowTitleOptimized:false)`.
 
-## Workbench
+## Workbench {#workbench}
 
-### Custom title bar on Linux
+### Custom title bar on Linux {#custom-title-bar-on-linux}
 
 The custom title bar is now enabled by default on Linux. The custom title bar gives you access to layout controls, the Copilot menu, and more.
 
@@ -269,13 +269,13 @@ You can always revert back to the native title decorations, either from the cust
 
 We are happy for continued feedback on this experience and are already working on improving this for future milestones based on existing feedback.
 
-### Use labels for Secondary Side Bar views
+### Use labels for Secondary Side Bar views {#use-labels-for-secondary-side-bar-views}
 
 We decided to change the appearance of views in the Secondary Side Bar to show labels instead of icons, similar to what we have in the Panel area. This makes it easier to distinguish between different views, for example the **Copilot Edits** and **Copilot Chat** views. You can switch back to showing icons at any time by configuring `setting(workbench.secondarySideBar.showLabels)`.
 
 ![Screenshot that shows Secondary Side Bar with labels instead of icons.](https://code.visualstudio.com/assets/updates/1_98/aux-sidebar.png)
 
-### New Settings editor key-matching algorithm (Preview)
+### New Settings editor key-matching algorithm (Preview) {#new-settings-editor-key-matching-algorithm-preview}
 
 **Setting**: `setting(workbench.settings.useWeightedKeySearch:true)`
 
@@ -287,32 +287,32 @@ You can try out the preview feature by enabling the `setting(workbench.settings.
 
 _Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
 
-### Option to hide dot files in simple file picker
+### Option to hide dot files in simple file picker {#option-to-hide-dot-files-in-simple-file-picker}
 
 When using the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (either when connected to a remote or when using `setting(files.simpleDialog.enable:true)`, you can now hide dot files by using the **Show/Hide dot files** button.
 
 ![Screenshot that shows the simple file picker, highlighting the button to show or hide dot files.](https://code.visualstudio.com/assets/updates/1_98/hide-dot-file.png)
 
-## Editor
+## Editor {#editor}
 
-### Peek references drag and drop support
+### Peek references drag and drop support {#peek-references-drag-and-drop-support}
 
 The [peek](https://code.visualstudio.com/docs/editor/editingevolved#_peek) view now supports drag & drop. Invoke **Peek References**, **Peek Implementation**, or any of the other peek commands, and drag entries from its tree to open them as separate editors.
 
 <video src="https://code.visualstudio.com/assets/updates/1_98/peek_dnd.mp4" title="Video that shows drag and drop of a peek reference as new editor group." autoplay loop controls muted></video>
 _Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
 
-### Occurrences highlight delay
+### Occurrences highlight delay {#occurrences-highlight-delay}
 
 The delay for occurrence highlighting within the editor is now set to 0 by default. This results in an overall more responsive editor feel. You can still control the delay with the `setting(editor.occurrencesHighlightDelay)` setting.
 
-## Source Control
+## Source Control {#source-control}
 
-### Updated view titles
+### Updated view titles {#updated-view-titles}
 
 When we added the **Source Control Graph** view to the Source Control view, it emphasized the duplication of section titles in the Source Control view: "Source Control Repositories", "Source Control", and "Source Control Graph". This milestone we have revisited the titles of the views, so that they are shorter and no longer duplicate the view title: "Repositories", "Changes", and "Graph".
 
-### Discard untracked changes improvements
+### Discard untracked changes improvements {#discard-untracked-changes-improvements}
 
 **Setting**: `setting(git.discardUntrackedChangesToTrash)`
 
@@ -322,7 +322,7 @@ Starting this milestone, discarding an untracked file will move the file to the 
 
 ![Screenshot of the modal dialog shown when discarding an untracked file.](https://code.visualstudio.com/assets/updates/1_98/scm-move-to-trash.png)
 
-### Diagnostics commit hook (Experimental)
+### Diagnostics commit hook (Experimental) {#diagnostics-commit-hook-experimental}
 
 **Settings**:
 
@@ -335,9 +335,9 @@ By default, the commit hook prompts for any error level diagnostics, but the dia
 
 ![Screenshot of the modal dialog shown when there are unresolved diagnostics for the changed files.](https://code.visualstudio.com/assets/updates/1_98/scm-diagnostics-commit-hook.png)
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Inline notebook diff view (Experimental)
+### Inline notebook diff view (Experimental) {#inline-notebook-diff-view-experimental}
 
 **Setting**: `setting(notebook.diff.experimental.toggleInline:true)`
 
@@ -347,19 +347,19 @@ Enable this feature by setting `setting(notebook.diff.experimental.toggleInline:
 
 <video src="https://code.visualstudio.com/assets/updates/1_98/inline_notebook_diff.mp4" title="Video that shows toggling an edit suggestion from side-by-side to an inline diff for notebooks." autoplay loop controls muted></video>
 
-### Notebook inline values hover
+### Notebook inline values hover {#notebook-inline-values-hover}
 
 Notebook inline values now have their decoration truncated to fit the width of the viewport and have a rich hover to show the full value, maintaining whitespace formatting. This maintains the shape of variables like dataframes, making values easier to read at a glance.
 
 ![Screenshot that shows the cursor hovering above a dataframe object's inline decoration. A rich value hover is shown.](https://code.visualstudio.com/assets/updates/1_98/nb-inline-values-rich-hover.png)
 
-## Terminal IntelliSense (Preview)
+## Terminal IntelliSense (Preview) {#terminal-intellisense-preview}
 
 **Setting**: `setting(terminal.integrated.suggest.enabled:true)`
 
 We've significantly improved terminal shell completions across bash, zsh, fish, and PowerShell by adding completion specs (`git` for example), refining command-line parsing for better suggestions, and enhancing file and folder completions. Enable this feature with `setting(terminal.integrated.suggest.enabled:true)`.
 
-### Enhanced Fig completion support
+### Enhanced Fig completion support {#enhanced-fig-completion-support}
 
 We leverage [Fig completion specs](https://github.com/withfig/autocomplete) to power intelligent completions for specific CLIs. We only had a small number of these before, but this iteration we added the following CLIs to the list we ship with VS Code:
 
@@ -377,7 +377,7 @@ _Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.th
 
 Behind the scenes, this runs `git --no-optional-locks branch -a --no-color --sort=-committerdate` to get the list of branches before processing them into completions. A similar approach is used to also fetch tags.
 
-### Configurable quick suggestions
+### Configurable quick suggestions {#configurable-quick-suggestions}
 
 **Setting**: `setting(terminal.integrated.suggest.quickSuggestions)`
 
@@ -393,7 +393,7 @@ The default value enables quick suggestions for commands and arguments, and now 
 }
 ```
 
-### Inline suggestion detection
+### Inline suggestion detection {#inline-suggestion-detection}
 
 **Setting**: `setting(terminal.integrated.suggest.inlineSuggestion)`
 
@@ -411,7 +411,7 @@ Building upon this new and improved detection, the inline suggestion is now pres
 
 The default is to always show this suggestion as the top suggestions, but can be configured with `setting(terminal.integrated.suggest.inlineSuggestion)`.
 
-### Detailed command completions
+### Detailed command completions {#detailed-command-completions}
 
 Completions for bash and zsh built-in commands and PowerShell commands are now more detailed, providing details on available arguments. This information is sourced from the shell's documentation or help commands.
 
@@ -429,7 +429,7 @@ For PowerShell, more properties of `Get-Command` are shown in the completion:
 
 ![Screenshot that shows the completion for ConvertTo-Json, showing the signature of the command.](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-signature.png)
 
-### Improved sorting
+### Improved sorting {#improved-sorting}
 
 Command completions now feature improved sorting, specifically:
 
@@ -445,7 +445,7 @@ For paths, the following improvements were made:
 
 ![Screenshot that shows __init__.py will show below other files, while a .build dir will show immediately above a build file.](https://code.visualstudio.com/assets/updates/1_98/terminal-underscore-punc.png)
 
-### CDPATH support
+### CDPATH support {#cdpath-support}
 
 **Setting**: `setting(terminal.integrated.suggest.cdPath)`
 
@@ -463,7 +463,7 @@ This feature also works on Windows (`;` separators) and doesn't need the shell t
 
 Configure this with `setting(terminal.integrated.suggest.cdPath)`.
 
-#### Absolute paths
+#### Absolute paths {#absolute-paths}
 
 Absolute paths are now supported.
 
@@ -471,43 +471,43 @@ Absolute paths are now supported.
 
 ![Screenshot that shows cd to absolute paths also works with Unix-style paths.](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-mac.png)
 
-### Alias support
+### Alias support {#alias-support}
 
 Command aliases are now also detected for bash, zsh and fish and feature a new distinct icon:
 
 ![Screenshot that shows the alias c->code-insiders will now be detected and show with the command icon with a little arrow in the corner.](https://code.visualstudio.com/assets/updates/1_98/terminal-alias.png)
 
-### Differentiated options and flags
+### Differentiated options and flags {#differentiated-options-and-flags}
 
 CLI options (that have a value) and flags (that don't) are now differentiated in the UI via a different icon:
 
 ![Screenshot that shows flags like --help will show a flag icon, options like --diff will show a different icon.](https://code.visualstudio.com/assets/updates/1_98/terminal-flags-options.png)
 
-## Tasks
+## Tasks {#tasks}
 
-### Task rerun action
+### Task rerun action {#task-rerun-action}
 
 We have a new **rerun** task action for terminals, `kb(workbench.action.tasks.rerunForActiveTerminal)`. The action appears on the terminal tab's inline toolbar and in the terminal's context menu.
 
 <video src="https://code.visualstudio.com/assets/updates/1_98/terminal-rerun-task.mp4" title="Video that shows the terminal rerun task." autoplay loop controls muted></video>
 
-## Debug
+## Debug {#debug}
 
-### Debug inline values hover
+### Debug inline values hover {#debug-inline-values-hover}
 
 If the setting `setting(debug.inlineValues)` is enabled, the inline value decorations now have an inline hover, making it easier to read longer values at a glance.
 
 ![Screenshot that shows the cursor hovering above a dataframe object's inline decoration in an active debugging session. Rich value hover is shown.](https://code.visualstudio.com/assets/updates/1_98/debug-inline-values-rich-hover.png)
 
-## Languages
+## Languages {#languages}
 
-### TypeScript 5.8
+### TypeScript 5.8 {#typescript-58}
 
 VS Code now includes TypeScript 5.8.2. This major update brings new language improvements, including [improved checking of types from conditional expressions](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) and [support for write code that confirms to Node's new --experimental-strip-types option](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#the---erasablesyntaxonly-option). It also included a number of tooling improvements and bug fixes.
 
 Check out the [TypeScript 5.8 release blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) for more details on this update.
 
-## Remote Development
+## Remote Development {#remote-development}
 
 The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
 
@@ -518,50 +518,50 @@ Highlights include:
 
 You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_98.md).
 
-## Enterprise support
+## Enterprise support {#enterprise-support}
 
-### Multi-line support for allowed extensions
+### Multi-line support for allowed extensions {#multi-line-support-for-allowed-extensions}
 
 You can now configure allowed extensions in the group policy on Windows using a multi-line string. This allows for more flexible and extensive configuration of allowed extensions. Learn more about [configuring allowed extensions](https://code.visualstudio.com/docs/setup/enterprise#_configure-allowed-extensions).
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### Python
+### Python {#python}
 
-#### Automatic quotation insertion when breaking long strings
+#### Automatic quotation insertion when breaking long strings {#automatic-quotation-insertion-when-breaking-long-strings}
 
 [Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now supports automatic insertion of quotation marks to enable a seamless experience when breaking long strings.
 
-#### Pylance memory consumption improvements
+#### Pylance memory consumption improvements {#pylance-memory-consumption-improvements}
 
 Some optimizations were made to improve Pylance's memory consumption, particularly when working with large workspaces. [This enhancement](https://github.com/microsoft/pyright/pull/9993) was made to Pyright, the static type checker that powers Pylance's language server features.
 
-#### Improvements to Python shell integration
+#### Improvements to Python shell integration {#improvements-to-python-shell-integration}
 
 After modifying `setting(python.terminal.shellIntegration.enabled)`, you will no longer have to reload in order for changes to take effect. Simply create a new terminal to see desired changes on your Python REPL in terminal.
 
-#### Correct workspace prompt for Windows Git Bash
+#### Correct workspace prompt for Windows Git Bash {#correct-workspace-prompt-for-windows-git-bash}
 
 Python users on Windows using Git Bash will now see correct working directory in their terminal prompt.
 These changes apply to those opted into the `pythonTerminalEnvVarActivation` experiment.
 
-#### New setting for auto test discovery file pattern
+#### New setting for auto test discovery file pattern {#new-setting-for-auto-test-discovery-file-pattern}
 
 You can now refine which files auto test discovery occurs by specifying a glob pattern in the `setting(python.testing.autoTestDiscoverOnSavePattern)` setting. Its default value is set to `**/*.py`.
 
-#### Read test debug config from settings.json as fallback
+#### Read test debug config from settings.json as fallback {#read-test-debug-config-from-settings.json-as-fallback}
 
 We now look for test debug configurations in both `settings.json` and `launch.json` files, expanding where you can define these configurations.
 
-### GitHub authentication
+### GitHub authentication {#github-authentication}
 
-#### Improved proxy support with Electron `fetch` adoption
+#### Improved proxy support with Electron `fetch` adoption {#improved-proxy-support-with-electron-fetch-adoption}
 
 The GitHub Authentication extension now leverages Electron's version of `fetch` in order to make web requests. This has helped users with certain proxy & firewall settings. If you know you run in an environment that has a proxy setup and you are unable to authenticate to GitHub inside of VS Code, don't hesitate to create an issue!
 
-## Extension authoring
+## Extension authoring {#extension-authoring}
 
-### Authentication
+### Authentication {#authentication}
 
 > **Important**:
 > We are renaming `AuthenticationForceNewSessionOptions` to `AuthenticationGetSessionPresentationOptions` and leaving a deprecated `AuthenticationForceNewSessionOptions` for now. There is no functional difference, so this is not a breaking change in the runtime, but you should update your code to use `AuthenticationGetSessionPresentationOptions` instead of `AuthenticationForceNewSessionOptions` since it will be removed in the future.
@@ -599,7 +599,7 @@ Here's an example that leverages `detail` and the `learnMore` proposal:
 
 ![Screenshot that shows the authentication modal dialog, featuring a message that says 'To get more relevant Copilot Chat results, we need permission to read the contents of your repository on GitHub.' and a button to learn more.](https://code.visualstudio.com/assets/updates/1_98/auth-presentation.png)
 
-### Refined Snippet API
+### Refined Snippet API {#refined-snippet-api}
 
 You can now control the whitespace normalization when inserting snippets. This applies to the [`insertSnippet`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L1306)-API and to the [`SnippetTextEdit`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L3753)-API and control is the indentation of additional lines of snippets are adjusted or not
 
@@ -621,9 +621,9 @@ function indentedFunctionWithSnippet() {
 
 ```
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Text Encodings
+### Text Encodings {#text-encodings}
 
 We added new proposed API to work with [text encodings](https://github.com/microsoft/vscode/blob/501ee833b16b8e83ba656c46e0888aadd9d2db04/src/vscode-dts/vscode.proposed.textDocumentEncoding.d.ts#L1) in VS Code.
 
@@ -636,7 +636,7 @@ Specifically, this new API allows to:
 
 Try it out and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/241449).
 
-### Shell environment
+### Shell environment {#shell-environment}
 
 Extensions are able to access the user's currently active shell environment information for pwsh, zsh, bash, and fish shell that are opened from the VS Code integrated terminal. This is only available when `setting(terminal.integrated.shellIntegration.enabled)` is enabled.
 
@@ -644,29 +644,29 @@ The user can decide whether or not to report their shell environment information
 
 Give it a try and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/227467).
 
-## Engineering
+## Engineering {#engineering}
 
-### Electron 34 update
+### Electron 34 update {#electron-34-update}
 
 In this milestone, we are promoting the Electron 34 update to users on our stable release. This update comes with Chromium 132.0.6834.196 and Node.js 20.18.2. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
 
-### macOS 10.15 support has ended
+### macOS 10.15 support has ended {#macos-1015-support-has-ended}
 
 VS Code `1.97` is the last release that supports macOS 10.15 (macOS Catalina). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
 
-### Dev-time tracking of leaked disposables
+### Dev-time tracking of leaked disposables {#dev-time-tracking-of-leaked-disposables}
 
 VS Code uses the disposable pattern for explicit resource management, for example to close files, clean up DOM elements, or remove event listeners. Not disposing of resources means memory is wasted and memory usage accumulates over time.
 
 We are constantly on the hunt for such leaks and have added another tool for detecting this. We utilize the [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) API as it informs us when an object has been garbage collected. If such an object represented a `disposable`, which has not been disposed of, this means we have a leak. These are collected and shown to the developers of VS Code, so that we can clean things up as we go.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -675,7 +675,7 @@ Contributions to our issue tracking:
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 
-### Pull requests
+### Pull requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_98.md
+++ b/docs/release-notes/v1_98.md
@@ -53,11 +53,11 @@ We made several improvements to the UX of tool usages this month:
 * You can edit the suggested terminal command in the chat response before running it.
 * Confirm a terminal command with the `kb(workbench.action.chat.acceptTool)` shortcut.
 
-<video src="images/1_98/edit-terminal.mp4" title="Video that shows editing a suggested terminal command in Chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/edit-terminal.mp4" title="Video that shows editing a suggested terminal command in Chat." autoplay loop controls muted></video>
 
 Agent mode autonomously searches your codebase for relevant context. Expand the message to see the results of which searches were done.
 
-![Screenshot that shows the expandable list of search results in Copilot Edits.](images/1_98/agent-mode-search-results.png)
+![Screenshot that shows the expandable list of search results in Copilot Edits.](https://code.visualstudio.com/assets/updates/1_98/agent-mode-search-results.png)
 
 We've also made various improvements to the prompt and behavior of agent mode:
 
@@ -74,7 +74,7 @@ We are introducing notebook support in Copilot Edits as a preview feature in [VS
 
 > **Note**: This feature is currently only available in [VS Code Insiders](https://code.visualstudio.com/insiders/) with the pre-release version of GitHub Copilot Chat. We'll continue to improve the experience before bringing it to VS Code Stable in a future release.
 
-<video src="images/1_98/notebook_copilot_edits.mp4" title="Video that shows using Copilot Edits to modify a notebook." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/notebook_copilot_edits.mp4" title="Video that shows using Copilot Edits to modify a notebook." autoplay loop controls muted></video>
 
 #### Refined editor integration
 
@@ -86,7 +86,7 @@ We have polished the integration of Copilot Edits with code and notebook editors
 
 The video demonstrates how edits are applied and saved as they occur. The live preview updates, and the user decided to "Keep" the changes. Undoing and further tweaking is also still possible.
 
-<video src="images/1_98/edits_editor.mp4" title="Video that shows that changes from Copilot Edits are saved automatically and the user decided to keep them." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/edits_editor.mp4" title="Video that shows that changes from Copilot Edits are saved automatically and the user decided to keep them." autoplay loop controls muted></video>
 
 #### Refreshed UI
 
@@ -94,7 +94,7 @@ In preparation for unifying Copilot Edits with Copilot Chat, we've given Copilot
 
 With the `setting(chat.renderRelatedFiles)` setting, you can enable getting suggestions for related files. Related file suggestions are rendered below the chat attachments.
 
-![Screenshot that shows the updated Copilot Edits attachments and changed files user experience.](images/1_98/copilot_edits_ui.png)
+![Screenshot that shows the updated Copilot Edits attachments and changed files user experience.](https://code.visualstudio.com/assets/updates/1_98/copilot_edits_ui.png)
 
 #### Removed Copilot Edits limits
 
@@ -120,7 +120,7 @@ However, for private GitHub repositories, VS Code needs to have permission to in
 
 To make this experience smoother, we've introduced this confirmation in chat:
 
-![Screenshot that shows the authentication confirmation dialog in Chat, showing the three options to continue.](images/1_98/confirmation-auth-dialog.png)
+![Screenshot that shows the authentication confirmation dialog in Chat, showing the three options to continue.](https://code.visualstudio.com/assets/updates/1_98/confirmation-auth-dialog.png)
 
 Not only is it not as jarring as a modal dialog, but it also has new functionality:
 
@@ -166,11 +166,11 @@ Previously, you could attach folders as context by using drag and drop from the 
 
 We've added a collapsed mode for NES. When you enable this mode, only the NES suggestion indicator is shown in the left editor margin. The code suggestion itself is revealed only when you navigate to it by pressing `kb(editor.action.inlineSuggest.jump)`. Consecutive suggestions are shown immediately until a suggestion is not accepted.
 
-<video src="images/1_98/NEScollapsedMode.mp4" title="Video that shows Next Edit Suggestions collapsed mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/NEScollapsedMode.mp4" title="Video that shows Next Edit Suggestions collapsed mode." autoplay loop controls muted></video>
 
 The collapsed mode is disabled by default and can be enabled by configuring `setting(editor.inlineSuggest.edits.showCollapsed:true)`, or you can enable or disable it in the NES gutter indicator menu.
 
-![Screenshot that shows the Next Edit Suggestions context menu in the editor left margin, highlighting the Show Collapsed option.](images/1_98/NESgutterMenu.png)
+![Screenshot that shows the Next Edit Suggestions context menu in the editor left margin, highlighting the Show Collapsed option.](https://code.visualstudio.com/assets/updates/1_98/NESgutterMenu.png)
 
 ### Change completions model
 
@@ -192,7 +192,7 @@ This release, we added more models to choose from when using Copilot. The follow
 
 We're quickly rolling out end-to-end vision support in this version of Copilot Chat. This lets you attach images and interact with images in chat prompts. For example, if you encounter an error while debugging, attach a screenshot of VS Code, and ask Copilot to help you resolve the issue. You might also use it to attach some UI mockup and let Copilot provide some HTML and CSS to implement the mockup.
 
-![Animation that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](images/1_97/image-attachments.gif)
+![Animation that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](https://code.visualstudio.com/assets/updates/1_97/image-attachments.gif)
 
 You can attach images in multiple ways:
 
@@ -214,7 +214,7 @@ We are experimenting with a new centralized Copilot status overview that provide
 
 This Copilot status overview is accessible via the Copilot icon in the Status Bar.
 
-![Screenshot that shows the Copilot status overview in the Status Bar.](images/1_98/copilot-status.png)
+![Screenshot that shows the Copilot status overview in the Status Bar.](https://code.visualstudio.com/assets/updates/1_98/copilot-status.png)
 
 Enable the Copilot status overview with the `setting(chat.experimental.statusIndicator.enabled)` setting.
 
@@ -261,11 +261,11 @@ We have a new `setting(window.title)` variable, `activeEditorState`, to indicate
 
 The custom title bar is now enabled by default on Linux. The custom title bar gives you access to layout controls, the Copilot menu, and more.
 
-![Screenshot that shows the custom VS Code title bar on Linux.](images/1_97/custom-title.png)
+![Screenshot that shows the custom VS Code title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/custom-title.png)
 
 You can always revert back to the native title decorations, either from the custom title context menu or by configuring `setting(window.titleBarStyle)` to `native`.
 
-![Screenshot that shows the content menu option to disable the custom title bar on Linux.](images/1_97/restore-title.png)
+![Screenshot that shows the content menu option to disable the custom title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/restore-title.png)
 
 We are happy for continued feedback on this experience and are already working on improving this for future milestones based on existing feedback.
 
@@ -273,7 +273,7 @@ We are happy for continued feedback on this experience and are already working o
 
 We decided to change the appearance of views in the Secondary Side Bar to show labels instead of icons, similar to what we have in the Panel area. This makes it easier to distinguish between different views, for example the **Copilot Edits** and **Copilot Chat** views. You can switch back to showing icons at any time by configuring `setting(workbench.secondarySideBar.showLabels)`.
 
-![Screenshot that shows Secondary Side Bar with labels instead of icons.](images/1_98/aux-sidebar.png)
+![Screenshot that shows Secondary Side Bar with labels instead of icons.](https://code.visualstudio.com/assets/updates/1_98/aux-sidebar.png)
 
 ### New Settings editor key-matching algorithm (Preview)
 
@@ -283,7 +283,7 @@ We have added a new Settings editor search algorithm that prioritizes more relev
 
 You can try out the preview feature by enabling the `setting(workbench.settings.useWeightedKeySearch:true)` setting.
 
-<video src="images/1_98/new-settings-search.mp4" title="Video that shows searching for tab and font before and after. After shows more relevant settings at the top of the search results." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/new-settings-search.mp4" title="Video that shows searching for tab and font before and after. After shows more relevant settings at the top of the search results." autoplay loop controls muted></video>
 
 _Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
 
@@ -291,7 +291,7 @@ _Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.li
 
 When using the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (either when connected to a remote or when using `setting(files.simpleDialog.enable:true)`, you can now hide dot files by using the **Show/Hide dot files** button.
 
-![Screenshot that shows the simple file picker, highlighting the button to show or hide dot files.](images/1_98/hide-dot-file.png)
+![Screenshot that shows the simple file picker, highlighting the button to show or hide dot files.](https://code.visualstudio.com/assets/updates/1_98/hide-dot-file.png)
 
 ## Editor
 
@@ -299,7 +299,7 @@ When using the [simple file picker](https://code.visualstudio.com/docs/getstarte
 
 The [peek](https://code.visualstudio.com/docs/editor/editingevolved#_peek) view now supports drag & drop. Invoke **Peek References**, **Peek Implementation**, or any of the other peek commands, and drag entries from its tree to open them as separate editors.
 
-<video src="images/1_98/peek_dnd.mp4" title="Video that shows drag and drop of a peek reference as new editor group." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/peek_dnd.mp4" title="Video that shows drag and drop of a peek reference as new editor group." autoplay loop controls muted></video>
 _Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
 
 ### Occurrences highlight delay
@@ -320,7 +320,7 @@ Over the years we have received multiple reports about data loss because discard
 
 Starting this milestone, discarding an untracked file will move the file to the Recycle Bin/Trash when possible, so that the file can be easily recovered. You can disable this functionality using the `setting(git.discardUntrackedChangesToTrash)` setting.
 
-![Screenshot of the modal dialog shown when discarding an untracked file.](images/1_98/scm-move-to-trash.png)
+![Screenshot of the modal dialog shown when discarding an untracked file.](https://code.visualstudio.com/assets/updates/1_98/scm-move-to-trash.png)
 
 ### Diagnostics commit hook (Experimental)
 
@@ -333,7 +333,7 @@ This milestone, we introduced a new commit hook that prompts you if there are an
 
 By default, the commit hook prompts for any error level diagnostics, but the diagnostics sources and levels can be customized using the `setting(git.diagnosticsCommitHook.Sources)` setting. Give it a try and let us know your feedback.
 
-![Screenshot of the modal dialog shown when there are unresolved diagnostics for the changed files.](images/1_98/scm-diagnostics-commit-hook.png)
+![Screenshot of the modal dialog shown when there are unresolved diagnostics for the changed files.](https://code.visualstudio.com/assets/updates/1_98/scm-diagnostics-commit-hook.png)
 
 ## Notebooks
 
@@ -345,13 +345,13 @@ You can now enable an inline diff view for notebooks. This feature enables you t
 
 Enable this feature by setting `setting(notebook.diff.experimental.toggleInline:true)` to `true`. You can then toggle the diff view to inline using the editor menu in the top right corner.
 
-<video src="images/1_98/inline_notebook_diff.mp4" title="Video that shows toggling an edit suggestion from side-by-side to an inline diff for notebooks." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/inline_notebook_diff.mp4" title="Video that shows toggling an edit suggestion from side-by-side to an inline diff for notebooks." autoplay loop controls muted></video>
 
 ### Notebook inline values hover
 
 Notebook inline values now have their decoration truncated to fit the width of the viewport and have a rich hover to show the full value, maintaining whitespace formatting. This maintains the shape of variables like dataframes, making values easier to read at a glance.
 
-![Screenshot that shows the cursor hovering above a dataframe object's inline decoration. A rich value hover is shown.](images/1_98/nb-inline-values-rich-hover.png)
+![Screenshot that shows the cursor hovering above a dataframe object's inline decoration. A rich value hover is shown.](https://code.visualstudio.com/assets/updates/1_98/nb-inline-values-rich-hover.png)
 
 ## Terminal IntelliSense (Preview)
 
@@ -372,7 +372,7 @@ We leverage [Fig completion specs](https://github.com/withfig/autocomplete) to p
 
 In addition to the new specs, we now also support _generators_, which dynamically generate completions by running commands when they're requested. One example of this in action is presenting all branches for `git checkout`:
 
-![Screenshot that shows completions for "git checkout tyriar/xterm", showing several results, including fuzzy results that don't match the query exactly.](images/1_98/terminal-git-checkout.png)
+![Screenshot that shows completions for "git checkout tyriar/xterm", showing several results, including fuzzy results that don't match the query exactly.](https://code.visualstudio.com/assets/updates/1_98/terminal-git-checkout.png)
 _Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire/Sapphire))_
 
 Behind the scenes, this runs `git --no-optional-locks branch -a --no-color --sort=-committerdate` to get the list of branches before processing them into completions. A similar approach is used to also fetch tags.
@@ -399,7 +399,7 @@ The default value enables quick suggestions for commands and arguments, and now 
 
 One problem inline suggestion detection has had to date, has been confusion introduced by competing with suggestions from different sources. Specifically, the inline suggestion that often appears when typing in shells:
 
-![Screenshot that shows fish shell showing suggestions, such as previous git commit commands when typing a prefix.](images/1_98/terminal-fish-autosuggest.png)
+![Screenshot that shows fish shell showing suggestions, such as previous git commit commands when typing a prefix.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-autosuggest.png)
 
 These suggestions are actually shell-level features (auto suggestions in fish/zsh, predictions in pwsh, etc.), which might not be obvious to the user, especially when presented alongside IntelliSense.
 
@@ -407,7 +407,7 @@ The IntelliSense feature requires that we detect this inline suggestion, which p
 
 Building upon this new and improved detection, the inline suggestion is now presented as the top option with a star icon to both align closer with how the editor behaves and to make it more clear what `kstyle(Tab)` will do in this case.
 
-![Screenshot that shows when an inline suggestion shows up, it will be detected and put beside a star icon at the top of IntelliSense.](images/1_98/terminal-fish-inline-suggest.png)
+![Screenshot that shows when an inline suggestion shows up, it will be detected and put beside a star icon at the top of IntelliSense.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-inline-suggest.png)
 
 The default is to always show this suggestion as the top suggestions, but can be configured with `setting(terminal.integrated.suggest.inlineSuggestion)`.
 
@@ -417,17 +417,17 @@ Completions for bash and zsh built-in commands and PowerShell commands are now m
 
 For bash, `help <command>` is used to get a basic description:
 
-![Screenshot that shows the history completion in bash, showing usage information and description.](images/1_98/terminal-bash-builtin-completions.png)
+![Screenshot that shows the history completion in bash, showing usage information and description.](https://code.visualstudio.com/assets/updates/1_98/terminal-bash-builtin-completions.png)
 
 For zsh, `man zshbuiltins` is used to get a detailed description:
 
-![Screenshot that shows completions in zsh, displaying detailed information from the manpage.](images/1_98/terminal-zsh-builtin-completions.png)
+![Screenshot that shows completions in zsh, displaying detailed information from the manpage.](https://code.visualstudio.com/assets/updates/1_98/terminal-zsh-builtin-completions.png)
 
 For PowerShell, more properties of `Get-Command` are shown in the completion:
 
-![Screenshot that shows the completion for Get-ChildItem, showing the module Microsoft.PowerShell.Management and its version.](images/1_98/terminal-pwsh-module.png)
+![Screenshot that shows the completion for Get-ChildItem, showing the module Microsoft.PowerShell.Management and its version.](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-module.png)
 
-![Screenshot that shows the completion for ConvertTo-Json, showing the signature of the command.](images/1_98/terminal-pwsh-signature.png)
+![Screenshot that shows the completion for ConvertTo-Json, showing the signature of the command.](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-signature.png)
 
 ### Improved sorting
 
@@ -436,14 +436,14 @@ Command completions now feature improved sorting, specifically:
 * Completions with more details generally appear above less detailed completions
 * Builtin commands take precedence over paths from `$PATH`
 
-![Screenshot that shows the more useful alias and autoload commands showing before others in zsh.](images/1_98/terminal-zsh-order.png)
+![Screenshot that shows the more useful alias and autoload commands showing before others in zsh.](https://code.visualstudio.com/assets/updates/1_98/terminal-zsh-order.png)
 
 For paths, the following improvements were made:
 
 * Paths starting with `_` get a penalty as this is often an indicator that they are special and generally shouldn't be changed much (for example, `__init__.py`).
 * Punctuation is ignored when sorting, so files starting with `.` will be mixed in with others.
 
-![Screenshot that shows __init__.py will show below other files, while a .build dir will show immediately above a build file.](images/1_98/terminal-underscore-punc.png)
+![Screenshot that shows __init__.py will show below other files, while a .build dir will show immediately above a build file.](https://code.visualstudio.com/assets/updates/1_98/terminal-underscore-punc.png)
 
 ### CDPATH support
 
@@ -451,15 +451,15 @@ For paths, the following improvements were made:
 
 The `$CDPATH` environment variable is a common shell feature that contains a colon-separated list of paths, similar to `$PATH`, and allows navigating to them as if they were relative regardless of the current working directory. Fish actually shows CDPATH entries in `cd` tab completion:
 
-![Screenshot that shows tab completion in fish, displaying entries from CDPATH.](images/1_98/terminal-fish-cdpath.png)
+![Screenshot that shows tab completion in fish, displaying entries from CDPATH.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-cdpath.png)
 
 We now support showing `$CDPATH` entries as completions when using `cd`:
 
-![Screenshot that shows CDPATH entries now show up in IntelliSense.](images/1_98/terminal-fish-cdpath-completions.png)
+![Screenshot that shows CDPATH entries now show up in IntelliSense.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-cdpath-completions.png)
 
 This feature also works on Windows (`;` separators) and doesn't need the shell to natively support the feature, since the default is using the absolute path.
 
-![Screenshot that shows a CDPATH containing 2 paths separated by a semi-colon, including all sub-directories even on PowerShell which does not support CDPATH natively.](images/1_98/terminal-cdpath-pwsh.png)
+![Screenshot that shows a CDPATH containing 2 paths separated by a semi-colon, including all sub-directories even on PowerShell which does not support CDPATH natively.](https://code.visualstudio.com/assets/updates/1_98/terminal-cdpath-pwsh.png)
 
 Configure this with `setting(terminal.integrated.suggest.cdPath)`.
 
@@ -467,21 +467,21 @@ Configure this with `setting(terminal.integrated.suggest.cdPath)`.
 
 Absolute paths are now supported.
 
-![Screenshot that shows "cd c:\Github\mi" will show results for all absolute folders matching that term.](images/1_98/terminal-absolute-windows.png)
+![Screenshot that shows "cd c:\Github\mi" will show results for all absolute folders matching that term.](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-windows.png)
 
-![Screenshot that shows cd to absolute paths also works with Unix-style paths.](images/1_98/terminal-absolute-mac.png)
+![Screenshot that shows cd to absolute paths also works with Unix-style paths.](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-mac.png)
 
 ### Alias support
 
 Command aliases are now also detected for bash, zsh and fish and feature a new distinct icon:
 
-![Screenshot that shows the alias c->code-insiders will now be detected and show with the command icon with a little arrow in the corner.](images/1_98/terminal-alias.png)
+![Screenshot that shows the alias c->code-insiders will now be detected and show with the command icon with a little arrow in the corner.](https://code.visualstudio.com/assets/updates/1_98/terminal-alias.png)
 
 ### Differentiated options and flags
 
 CLI options (that have a value) and flags (that don't) are now differentiated in the UI via a different icon:
 
-![Screenshot that shows flags like --help will show a flag icon, options like --diff will show a different icon.](images/1_98/terminal-flags-options.png)
+![Screenshot that shows flags like --help will show a flag icon, options like --diff will show a different icon.](https://code.visualstudio.com/assets/updates/1_98/terminal-flags-options.png)
 
 ## Tasks
 
@@ -489,7 +489,7 @@ CLI options (that have a value) and flags (that don't) are now differentiated in
 
 We have a new **rerun** task action for terminals, `kb(workbench.action.tasks.rerunForActiveTerminal)`. The action appears on the terminal tab's inline toolbar and in the terminal's context menu.
 
-<video src="images/1_98/terminal-rerun-task.mp4" title="Video that shows the terminal rerun task." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/terminal-rerun-task.mp4" title="Video that shows the terminal rerun task." autoplay loop controls muted></video>
 
 ## Debug
 
@@ -497,7 +497,7 @@ We have a new **rerun** task action for terminals, `kb(workbench.action.tasks.re
 
 If the setting `setting(debug.inlineValues)` is enabled, the inline value decorations now have an inline hover, making it easier to read longer values at a glance.
 
-![Screenshot that shows the cursor hovering above a dataframe object's inline decoration in an active debugging session. Rich value hover is shown.](images/1_98/debug-inline-values-rich-hover.png)
+![Screenshot that shows the cursor hovering above a dataframe object's inline decoration in an active debugging session. Rich value hover is shown.](https://code.visualstudio.com/assets/updates/1_98/debug-inline-values-rich-hover.png)
 
 ## Languages
 
@@ -597,7 +597,7 @@ Additionally, the `authLearnMore` [proposed API](https://github.com/microsoft/vs
 
 Here's an example that leverages `detail` and the `learnMore` proposal:
 
-![Screenshot that shows the authentication modal dialog, featuring a message that says 'To get more relevant Copilot Chat results, we need permission to read the contents of your repository on GitHub.' and a button to learn more.](images/1_98/auth-presentation.png)
+![Screenshot that shows the authentication modal dialog, featuring a message that says 'To get more relevant Copilot Chat results, we need permission to read the contents of your repository on GitHub.' and a button to learn more.](https://code.visualstudio.com/assets/updates/1_98/auth-presentation.png)
 
 ### Refined Snippet API
 

--- a/docs/release-notes/v1_98.md
+++ b/docs/release-notes/v1_98.md
@@ -7,383 +7,383 @@ MetaSocialImage: 1_98/release-highlights.png
 Date: 2025-03-05
 DownloadVersion: 1.98.0
 ---
-# February 2025 (version 1.98) {#february-2025-version-198}
+# 2025 年 2 月 (バージョン 1.98) {#february-2025}
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the February 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2025 年 2 月リリースへようこそ。今回のリリースでは、多くのアップデートがあり、きっと気に入っていただけると思います。主なハイライトは以下のとおりです。
 
-* [Next Edit Suggestions (preview)](#collapsed-mode-for-next-edit-suggestions-preview) - Copilot predicts the next edit you are likely to make.
-* [Agent mode (preview)](#agent-mode-improvements-experimental) - Copilot autonomously completes tasks.
-* [Copilot Edits for notebooks](#notebook-support-in-copilot-edits-preview) - Iterate quickly on edits for your notebooks.
-* [Code search](#more-advanced-codebase-search-in-copilot-chat) - Let Copilot find relevant files for your chat prompt.
-* [Terminal IntelliSense (preview)](#terminal-intellisense-preview) - Rich completion support for your terminal.
-* [Drag & drop references](#peek-references-drag-and-drop-support) - Quickly open peek references in a new editor.
-* [Linux custom title bar](#custom-title-bar-on-linux) - Custom title bar support for Linux enabled by default.
-* [Unresolved diagnostics (preview)](#diagnostics-commit-hook-experimental) - Prompt when committing with unresolved diagnostics.
-* [Soft-delete in source control](#discard-untracked-changes-improvements) - Move untracked files to trash instead of deleting them.
-* [Custom instructions GA](#custom-instructions-generally-available) - Use custom instructions to tailor Copilot to your needs.
+* [Next Edit Suggestions (プレビュー)](#collapsed-mode-for-next-edit-suggestions-preview) - Copilot が、次に行う可能性の高い編集を予測します。
+* [エージェントモード (プレビュー)](#agent-mode-improvements-experimental) - Copilot が自律的にタスクを完了します。
+* [Copilot Edits for notebooks](#notebook-support-in-copilot-edits-preview) - notebook の編集を迅速に繰り返します。
+* [コード検索](#more-advanced-codebase-search-in-copilot-chat) - Copilot にチャットプロンプトに関連するファイルを探させます。
+* [ターミナル IntelliSense (プレビュー)](#terminal-intellisense-preview) - ターミナルのリッチな補完サポート。
+* [ドラッグ&ドロップリファレンス](#peek-references-drag-and-drop-support) - ピークリファレンスを新しいエディタですばやく開きます。
+* [Linux カスタムタイトルバー](#custom-title-bar-on-linux) - Linux のカスタムタイトルバーサポートがデフォルトで有効になりました。
+* [未解決の診断 (プレビュー)](#diagnostics-commit-hook-experimental) - 未解決の診断でコミットするときにプロンプ​​トを表示します。
+* [ソース管理でのソフトデリート](#discard-untracked-changes-improvements) - 追跡されていないファイルを削除する代わりに、ゴミ箱に移動します。
+* [カスタム指示の GA](#custom-instructions-generally-available) - カスタム指示を使用して、Copilot をニーズに合わせて調整します。
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+> これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** 新機能をいち早く試したいですか？ナイトリー [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新のアップデートをいち早く試すことができます。
 
 ## GitHub Copilot {#github-copilot}
 
-Copilot features might go through different early access stages, which are typically enabled and configured through settings.
+Copilot の機能は、さまざまな早期アクセス段階を経る可能性があり、通常は設定によって有効化および構成されます。
 
 | Stage | Description |
 |-------|-------------|
-| **Experimental** | The feature is still in development and not yet ready for general use.<br/>View the [experimental features](command:workbench.action.openSettings?%5B%22%40tag%3Aexperimental%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:experimental`). |
-| **Preview** | The feature is still under refinement, yet ready to use. Feedback is welcome.<br/>View the [preview features](command:workbench.action.openSettings?%5B%22%40tag%3Apreview%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:preview`). |
-| **Stable** | The feature is ready for general use. |
+| **Experimental** | この機能はまだ開発中であり、まだ一般的に使用できる状態ではありません。<br/>[試験的な機能](command:workbench.action.openSettings?%5B%22%40tag%3Aexperimental%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:experimental`) を表示します。 |
+| **Preview** | この機能はまだ改良中ですが、使用する準備ができています。フィードバックは歓迎します。<br/>[プレビュー機能](command:workbench.action.openSettings?%5B%22%40tag%3Apreview%20%40ext%3Agithub.copilot-chat%22%5D) (`@tag:preview`) を表示します。 |
+| **Stable** | この機能は一般的に使用する準備ができています。 |
 
 ### Copilot Edits {#copilot-edits}
 
-#### Agent mode improvements (Experimental) {#agent-mode-improvements-experimental}
+#### エージェントモードの改善 (試験的) {#agent-mode-improvements-experimental}
 
-Last month, we introduced _agent mode_ for Copilot Edits in [VS Code Insiders](https://code.visualstudio.com/insiders/). In agent mode, Copilot can automatically search your workspace for relevant context, edit files, check them for errors, and run terminal commands (with your permission) to complete a task end-to-end.
+先月、[VS Code Insiders](https://code.visualstudio.com/insiders/) で Copilot Edits の _エージェントモード_ を導入しました。エージェントモードでは、Copilot がワークスペースを自動的に検索して関連するコンテキストを見つけ、ファイルを編集し、エラーをチェックし、ターミナルコマンドを実行して (許可を得て) タスクをエンドツーエンドで完了します。
 
-> **Note**: Agent mode is available today in [VS Code Insiders](https://code.visualstudio.com/insiders/), and we just started rolling it out gradually in **VS Code Stable**. Once agent mode is enabled for you, you will see a mode dropdown in the Copilot Edits view — simply select **Agent**.
+> **注**: エージェントモードは、[VS Code Insiders](https://code.visualstudio.com/insiders/) で利用可能であり、**VS Code Stable** でも段階的に展開を開始しました。エージェントモードが有効になると、Copilot Edits ビューにモードドロップダウンが表示されます。**エージェント** を選択するだけです。
 
-We made several improvements to the UX of tool usages this month:
+今月は、ツール使用の UX にいくつかの改善を行いました。
 
-* Terminal commands are now shown inline, so you can keep track of which commands were run.
-* You can edit the suggested terminal command in the chat response before running it.
-* Confirm a terminal command with the `kb(workbench.action.chat.acceptTool)` shortcut.
+* ターミナルコマンドがインラインで表示されるようになり、実行されたコマンドを追跡できます。
+* チャット応答で提案されたターミナルコマンドを実行する前に編集できます。
+* `kb(workbench.action.chat.acceptTool)` ショートカットでターミナルコマンドを確認します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/edit-terminal.mp4" title="Video that shows editing a suggested terminal command in Chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/edit-terminal.mp4" title="チャットで提案されたターミナルコマンドを編集する様子を示すビデオ。" autoplay loop controls muted></video>
 
-Agent mode autonomously searches your codebase for relevant context. Expand the message to see the results of which searches were done.
+エージェントモードは、関連するコンテキストを検索するためにコードベースを自律的に検索します。メッセージを展開して、どの検索が行われたかの結果を確認します。
 
-![Screenshot that shows the expandable list of search results in Copilot Edits.](https://code.visualstudio.com/assets/updates/1_98/agent-mode-search-results.png)
+![Copilot Edits で検索結果の展開可能なリストを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/agent-mode-search-results.png)
 
-We've also made various improvements to the prompt and behavior of agent mode:
+また、エージェントモードのプロンプトと動作にさまざまな改善を加えました。
 
-* The undo and redo actions in chat now undo or redo the last file edit made in a chat response. This is useful for agent mode, as you can now undo certain steps the model took without rolling back the entire chat response.
-* Agent mode can now run your build [tasks](https://code.visualstudio.com/docs/editor/tasks) automatically or when instructed to do so. Disable this functionality via the `setting(github.copilot.chat.agent.runTasks)` setting, in the event that you see the model running tasks when it should not.
+* チャットでの元に戻すおよびやり直しのアクションは、チャット応答で行われた最後のファイル編集を元に戻すかやり直します。これはエージェントモードに便利で、モデルが行った特定のステップを元に戻すことができ、チャット応答全体をロールバックする必要がありません。
+* エージェントモードは、ビルド [タスク](https://code.visualstudio.com/docs/editor/tasks) を自動的にまたは指示されたときに実行できます。モデルが実行すべきでないときにタスクを実行している場合は、`setting(github.copilot.chat.agent.runTasks)` 設定を無効にします。
 
-Learn more about [Copilot Edits agent mode](https://code.visualstudio.com/docs/copilot/copilot-edits#_use-agent-mode-preview) or read the [agent mode announcement blog post](https://code.visualstudio.com/blogs/2025/02/24/introducing-copilot-agent-mode).
+[Copilot Edits エージェントモード](https://code.visualstudio.com/docs/copilot/copilot-edits#_use-agent-mode-preview) の詳細を学ぶか、[エージェントモードの発表ブログ投稿](https://code.visualstudio.com/blogs/2025/02/24/introducing-copilot-agent-mode) を読んでください。
 
-> **Note**: If you are a Copilot Business or Enterprise user, an administrator of your organization [must opt in](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) to the use of Copilot "Editor Preview Features" for agent mode to be available.
+> **注**: Copilot Business または Enterprise ユーザーの場合、組織の管理者が [組織で Copilot 機能を有効にする](https://docs.github.com/en/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) 必要があります。
 
-#### Notebook support in Copilot Edits (Preview) {#notebook-support-in-copilot-edits-preview}
+#### Copilot Edits での notebook サポート (プレビュー) {#notebook-support-in-copilot-edits-preview}
 
-We are introducing notebook support in Copilot Edits as a preview feature in [VS Code Insiders](https://code.visualstudio.com/insiders). You can now use Copilot to edit notebook files with the same intuitive experience as editing code files. Create new notebooks from scratch, modify content across multiple cells, insert and delete cells, and change cell types. This preview feature provides a seamless workflow when working with data science or documentation notebooks.
+[VS Code Insiders](https://code.visualstudio.com/insiders) で Copilot Edits の notebook サポートをプレビュー機能として導入しています。Copilot を使用して、コードファイルを編集するのと同じ直感的な体験で notebook ファイルを編集できます。新しい notebook をゼロから作成し、複数のセルにわたってコンテンツを変更し、セルを挿入および削除し、セルの種類を変更します。このプレビュー機能は、データサイエンスやドキュメント notebook を操作する際のシームレスなワークフローを提供します。
 
-> **Note**: This feature is currently only available in [VS Code Insiders](https://code.visualstudio.com/insiders/) with the pre-release version of GitHub Copilot Chat. We'll continue to improve the experience before bringing it to VS Code Stable in a future release.
+> **注**: この機能は現在、[VS Code Insiders](https://code.visualstudio.com/insiders/) の GitHub Copilot Chat のプレリリースバージョンでのみ利用可能です。VS Code Stable に導入する前に、引き続きエクスペリエンスを改善していきます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/notebook_copilot_edits.mp4" title="Video that shows using Copilot Edits to modify a notebook." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/notebook_copilot_edits.mp4" title="Copilot Edits を使用して notebook を変更する様子を示すビデオ。" autoplay loop controls muted></video>
 
-#### Refined editor integration {#refined-editor-integration}
+#### 改良されたエディタ統合 {#refined-editor-integration}
 
-We have polished the integration of Copilot Edits with code and notebook editors:
+Copilot Edits とコードおよび notebook エディタの統合を改善しました。
 
-* No more scrolling while changes are being applied. The viewport remains in place, making it easier to focus on what changes.
-* Renamed the edit review actions from "Accept" to "Keep" and "Discard" to "Undo" to better reflect what’s happening. Changes for Copilot Edits are live, they are applied and saved as they are made and users keep or undo them.
-* After keeping or undoing a file, the next file is automatically revealed.
+* 変更が適用されている間にスクロールすることはありません。ビューポートはそのままで、変更内容に集中しやすくなります。
+* 編集レビューアクションの名前を「Accept」から「Keep」、「Discard」から「Undo」に変更し、何が起こっているかをより正確に反映します。Copilot Edits の変更はライブであり、変更が行われるとすぐに適用され保存され、ユーザーはそれを保持するか元に戻すかを選択します。
+* ファイルを保持または元に戻した後、次のファイルが自動的に表示されます。
 
-The video demonstrates how edits are applied and saved as they occur. The live preview updates, and the user decided to "Keep" the changes. Undoing and further tweaking is also still possible.
+ビデオは、変更が発生するとすぐに適用され保存される様子を示しています。ライブプレビューが更新され、ユーザーは変更を「Keep」することを決定しました。元に戻すことやさらに調整することも引き続き可能です。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/edits_editor.mp4" title="Video that shows that changes from Copilot Edits are saved automatically and the user decided to keep them." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/edits_editor.mp4" title="Copilot Edits の変更が自動的に保存され、ユーザーがそれを保持することを決定した様子を示すビデオ。" autoplay loop controls muted></video>
 
-#### Refreshed UI {#refreshed-ui}
+#### リフレッシュされた UI {#refreshed-ui}
 
-In preparation for unifying Copilot Edits with Copilot Chat, we've given Copilot Edits a facelift. Files that are attached and not yet sent, are now rendered as regular chat attachments. Only files that have been modified with AI are added to the changed files list, which is located above the chat input part.
+Copilot Edits を Copilot Chat と統合する準備として、Copilot Edits にフェイスリフトを施しました。添付されてまだ送信されていないファイルは、通常のチャット添付ファイルとしてレンダリングされます。AI で変更されたファイルのみが変更されたファイルリストに追加され、チャット入力部分の上に配置されます。
 
-With the `setting(chat.renderRelatedFiles)` setting, you can enable getting suggestions for related files. Related file suggestions are rendered below the chat attachments.
+`setting(chat.renderRelatedFiles)` 設定を使用して、関連ファイルの提案を取得することができます。関連ファイルの提案は、チャット添付ファイルの下にレンダリングされます。
 
-![Screenshot that shows the updated Copilot Edits attachments and changed files user experience.](https://code.visualstudio.com/assets/updates/1_98/copilot_edits_ui.png)
+![更新された Copilot Edits の添付ファイルと変更されたファイルのユーザーエクスペリエンスを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/copilot_edits_ui.png)
 
-#### Removed Copilot Edits limits {#removed-copilot-edits-limits}
+#### Copilot Edits の制限を削除 {#removed-copilot-edits-limits}
 
-Previously, you were limited to attach 10 files to your prompt in Copilot Edits. With this release, we removed this limit. Additionally, we've removed the client-side rate limit of 14 interactions per 10 minutes.
+以前は、Copilot Edits のプロンプトに添付できるファイルは 10 個に制限されていました。このリリースでは、この制限を削除しました。さらに、10 分間に 14 回のインタラクションというクライアント側のレート制限も削除しました。
 
-> Note that service-side usage rate limits still apply.
+> サービス側の使用レート制限は引き続き適用されます。
 
-### Custom instructions generally available {#custom-instructions-generally-available}
+### カスタム指示の一般提供 {#custom-instructions-generally-available}
 
-**Setting**: `setting(github.copilot.chat.codeGeneration.useInstructionFiles)`
+**設定**: `setting(github.copilot.chat.codeGeneration.useInstructionFiles)`
 
-Custom instructions enable you to tailor GitHub Copilot to provide chat responses and code suggestions to the way you and your team work. Describe your specific requirements Markdown format in a `.github/copilot-instructions.md` file in your workspace.
+カスタム指示を使用すると、GitHub Copilot をカスタマイズして、あなたやチームの作業方法に合わせたチャット応答やコード提案を提供できます。特定の要件を Markdown 形式で記述し、ワークスペース内の `.github/copilot-instructions.md` ファイルに保存します。
 
-This milestone, we are making custom instructions with `.github/copilot-instructions.md` generally available. Make sure that the `setting(github.copilot.chat.codeGeneration.useInstructionFiles)` VS Code setting is enabled, and Copilot will then use these instructions when generating responses.
+このマイルストーンでは、`.github/copilot-instructions.md` を使用したカスタム指示を一般提供します。`setting(github.copilot.chat.codeGeneration.useInstructionFiles)` VS Code 設定が有効になっていることを確認し、Copilot はこれらの指示を使用して応答を生成します。
 
-Learn more about [custom instructions in Copilot](https://code.visualstudio.com/docs/copilot/copilot-customization).
+[Copilot のカスタム指示](https://code.visualstudio.com/docs/copilot/copilot-customization) の詳細を学んでください。
 
-### Smoother authentication flows in chat {#smoother-authentication-flows-in-chat}
+### チャットでのスムーズな認証フロー {#smoother-authentication-flows-in-chat}
 
-If you host your source code in a GitHub repository, you're able to leverage several features, including advanced code searching, the `@github` chat participant, and more!
+ソースコードを GitHub リポジトリにホストしている場合、コード検索、`@github` チャット参加者など、いくつかの機能を活用できます。
 
-However, for private GitHub repositories, VS Code needs to have permission to interact with your repositories on GitHub. For a while, this was presented with our usual VS Code authentication flow, where a modal dialog showed up when you invoked certain functionality (for example, asking `@workspace` or `@github` a question, or using the `#codebase` tool).
+ただし、プライベート GitHub リポジトリの場合、VS Code が GitHub 上のリポジトリと対話するための権限を持っている必要があります。しばらくの間、これは通常の VS Code 認証フローで提示され、特定の機能を呼び出すときにモーダルダイアログが表示されました (たとえば、`@workspace` や `@github` に質問する、または `#codebase` ツールを使用する場合)。
 
-To make this experience smoother, we've introduced this confirmation in chat:
+このエクスペリエンスをスムーズにするために、チャットでこの確認を導入しました。
 
-![Screenshot that shows the authentication confirmation dialog in Chat, showing the three options to continue.](https://code.visualstudio.com/assets/updates/1_98/confirmation-auth-dialog.png)
+![チャットでの認証確認ダイアログを示すスクリーンショット。続行するための 3 つのオプションが表示されています。](https://code.visualstudio.com/assets/updates/1_98/confirmation-auth-dialog.png)
 
-Not only is it not as jarring as a modal dialog, but it also has new functionality:
+モーダルダイアログほど衝撃的ではないだけでなく、新しい機能も備えています。
 
-1. **Grant:** you're taken through the regular authentication flow like before (via the modal).
-1. **Not Now:** VS Code remembers your choice and won't bother you again until your next VS Code window session. The only exception to this is if the feature needs this additional permission to function, like `@github`.
-1. **Never Ask Again:** VS Code remembers your choice and persists it via the `setting(github.copilot.advanced.authPermissions)` setting. Any feature that needs this additional permission will fail.
+1. **Grant:** 通常の認証フローを経て (モーダルを介して) 進みます。
+1. **Not Now:** VS Code は選択を記憶し、次の VS Code ウィンドウセッションまで再度通知しません。唯一の例外は、`@github` のようにこの追加の権限が必要な機能です。
+1. **Never Ask Again:** VS Code は選択を記憶し、`setting(github.copilot.advanced.authPermissions)` 設定を介して永続化します。この追加の権限が必要な機能は失敗します。
 
-It's important to note that this confirmation does not confirm or deny Copilot (the service) access to your repositories. This is only how VS Code's Copilot experience authenticates. To configure what Copilot can access, please read the docs [on content exclusion](https://docs.github.com/en/copilot/managing-copilot/configuring-and-auditing-content-exclusion/excluding-content-from-github-copilot).
+この確認は、Copilot (サービス) がリポジトリにアクセスすることを確認または拒否するものではないことに注意してください。これは、VS Code の Copilot エクスペリエンスがどのように認証されるかに関するものです。Copilot がアクセスできる内容を構成するには、[コンテンツの除外](https://docs.github.com/en/copilot/managing-copilot/configuring-and-auditing-content-exclusion/excluding-content-from-github-copilot) に関するドキュメントを読んでください。
 
-### More advanced codebase search in Copilot Chat {#more-advanced-codebase-search-in-copilot-chat}
+### Copilot Chat でのより高度なコードベース検索 {#more-advanced-codebase-search-in-copilot-chat}
 
-**Setting**: `setting(github.copilot.chat.codesearch.enabled)`
+**設定**: `setting(github.copilot.chat.codesearch.enabled)`
 
-When you add `#codebase` to your Copilot Chat query, Copilot helps you find relevant code in your workspace for your chat prompt. `#codebase` can now run tools like text search and file search to pull in additional context from your workspace.
+Copilot Chat クエリに `#codebase` を追加すると、Copilot がチャットプロンプトに関連するワークスペース内のコードを見つけるのを支援します。`#codebase` は、テキスト検索やファイル検索などのツールを実行して、ワークスペースから追加のコンテキストを取得できるようになりました。
 
-Set `setting(github.copilot.chat.codesearch.enabled)` to enable this behavior. The full list of tools is:
+この動作を有効にするには、`setting(github.copilot.chat.codesearch.enabled)` を設定します。ツールの完全なリストは次のとおりです。
 
-* Embeddings-based semantic search
-* Text search
-* File search
-* Git modified files
-* Project structure
-* Read file
-* Read directory
-* Workspace symbol search
+* 埋め込みベースのセマンティック検索
+* テキスト検索
+* ファイル検索
+* Git 変更ファイル
+* プロジェクト構造
+* ファイルの読み取り
+* ディレクトリの読み取り
+* ワークスペースシンボル検索
 
-### Attach problems as chat context {#attach-problems-as-chat-context}
+### 問題をチャットコンテキストとして添付 {#attach-problems-as-chat-context}
 
-To help with fixing code or other issues in your workspace, you can now attach problems from the Problems panel to your chat as context for your prompt.
+ワークスペース内のコードやその他の問題を修正するのに役立つように、問題パネルからチャットに問題をコンテキストとして添付できるようになりました。
 
-Either drag an item from the Problems panel onto the Chat view, type `#problems` in your prompt, or select the paperclip 📎 button. You can attach specific problems, all problems in a file, or all files in your codebase.
+問題パネルからチャットビューにアイテムをドラッグするか、プロンプトに `#problems` と入力するか、クリップ📎ボタンを選択します。特定の問題、ファイル内のすべての問題、またはコードベース内のすべてのファイルを添付できます。
 
-### Attach folders as context {#attach-folders-as-context}
+### フォルダをコンテキストとして添付 {#attach-folders-as-context}
 
-Previously, you could attach folders as context by using drag and drop from the Explorer view. Now, you can also attach a folder by selecting the paperclip 📎 icon or by typing `#folder:` followed by the folder name in your chat prompt.
+以前は、エクスプローラービューからドラッグアンドドロップを使用してフォルダをコンテキストとして添付できました。今では、クリップ📎アイコンを選択するか、チャットプロンプトに `#folder:` とフォルダ名を入力することで、フォルダを添付することもできます。
 
-### Collapsed mode for Next Edit Suggestions (Preview) {#collapsed-mode-for-next-edit-suggestions-preview}
+### Next Edit Suggestions の折りたたみモード (プレビュー) {#collapsed-mode-for-next-edit-suggestions-preview}
 
-**Settings**:
+**設定**:
 
 * `setting(github.copilot.nextEditSuggestions.enabled)`
 * `setting(editor.inlineSuggest.edits.showCollapsed:true)`
 
-We've added a collapsed mode for NES. When you enable this mode, only the NES suggestion indicator is shown in the left editor margin. The code suggestion itself is revealed only when you navigate to it by pressing `kb(editor.action.inlineSuggest.jump)`. Consecutive suggestions are shown immediately until a suggestion is not accepted.
+NES の折りたたみモードを追加しました。このモードを有効にすると、左側のエディターマージンに NES 提案インジケーターのみが表示されます。コード提案自体は、`kb(editor.action.inlineSuggest.jump)` を押してナビゲートすると表示されます。連続する提案は、提案が受け入れられるまで直ちに表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/NEScollapsedMode.mp4" title="Video that shows Next Edit Suggestions collapsed mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/NEScollapsedMode.mp4" title="Next Edit Suggestions の折りたたみモードを示すビデオ。" autoplay loop controls muted></video>
 
-The collapsed mode is disabled by default and can be enabled by configuring `setting(editor.inlineSuggest.edits.showCollapsed:true)`, or you can enable or disable it in the NES gutter indicator menu.
+折りたたみモードはデフォルトでは無効になっており、`setting(editor.inlineSuggest.edits.showCollapsed:true)` を設定することで有効にできます。または、NES ガターインジケーターメニューで有効または無効にすることもできます。
 
-![Screenshot that shows the Next Edit Suggestions context menu in the editor left margin, highlighting the Show Collapsed option.](https://code.visualstudio.com/assets/updates/1_98/NESgutterMenu.png)
+![エディター左マージンの Next Edit Suggestions コンテキストメニューを示すスクリーンショット。Show Collapsed オプションが強調表示されています。](https://code.visualstudio.com/assets/updates/1_98/NESgutterMenu.png)
 
-### Change completions model {#change-completions-model}
+### 補完モデルの変更 {#change-completions-model}
 
-You could already change the language model for Copilot Chat and Copilot Edits, and now you can also change the model for inline suggestions.
+Copilot Chat および Copilot Edits の言語モデルを変更できるようになりましたが、インライン提案のモデルも変更できるようになりました。
 
-Alternatively, you can change the model that is used for code completions via **Change Completions Model** command in the Command Palette or the **Configure Code Completions** item in the Copilot menu in the title bar.
+代わりに、コマンドパレットの **Change Completions Model** コマンドまたはタイトルバーの Copilot メニューの **Configure Code Completions** アイテムを使用して、コード補完に使用されるモデルを変更できます。
 
-> **Note:** the list of available models might vary and change over time. If you are a Copilot Business or Enterprise user, your Administrator needs to enable certain models for your organization by opting in to `Editor Preview Features` in the [Copilot policy settings](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) on GitHub.com.
+> **注**: 利用可能なモデルのリストは時間とともに変わる可能性があります。Copilot Business または Enterprise ユーザーの場合、管理者が GitHub.com の [Copilot ポリシー設定](https://docs.github.com/en/enterprise-cloud@latest/copilot/managing-copilot/managing-github-copilot-in-your-organization/managing-policies-for-copilot-in-your-organization#enabling-copilot-features-in-your-organization) で `Editor Preview Features` にオプトインすることで、特定のモデルを組織に対して有効にする必要があります。
 
-### Model availability {#model-availability}
+### モデルの利用可能性 {#model-availability}
 
-This release, we added more models to choose from when using Copilot. The following models are now available in the model picker in Visual Studio Code and github.com chat:
+このリリースでは、Copilot を使用する際に選択できるモデルが増えました。次のモデルが Visual Studio Code および github.com チャットのモデルピッカーで利用可能になりました。
 
-* **GPT 4.5 (Preview)**: OpenAI’s latest model, GPT-4.5, is now available in GitHub Copilot Chat to Copilot Enterprise users. GPT-4.5 is a large language model designed with advanced capabilities in intuition, writing style, and broad knowledge. Learn more about the GPT-4.5 model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-27-openai-gpt-4-5-in-github-copilot-now-available-in-public-preview).
+* **GPT 4.5 (プレビュー)**: OpenAI の最新モデル GPT-4.5 が、Copilot Enterprise ユーザー向けに GitHub Copilot Chat で利用可能になりました。GPT-4.5 は、直感、文体、および広範な知識において高度な能力を備えた大規模な言語モデルです。[GitHub ブログ投稿](https://github.blog/changelog/2025-02-27-openai-gpt-4-5-in-github-copilot-now-available-in-public-preview) で GPT-4.5 モデルの利用可能性について詳しく学んでください。
 
-* **Claude 3.7 Sonnet (Preview)**: Claude 3.7 Sonnet is now available to all customers on paid Copilot plans. This new Sonnet model supports both thinking and non-thinking modes in Copilot. In initial testing, we’ve seen particularly strong improvements in agentic scenarios. Learn more about the Claude 3.7 Sonnet model availability in the [GitHub blog post](https://github.blog/changelog/2025-02-24-claude-3-7-sonnet-is-now-available-in-github-copilot-in-public-preview/).
+* **Claude 3.7 Sonnet (プレビュー)**: Claude 3.7 Sonnet は、有料の Copilot プランのすべての顧客に利用可能になりました。この新しい Sonnet モデルは、Copilot の思考モードと非思考モードの両方をサポートします。初期テストでは、特にエージェントシナリオでの大幅な改善が見られました。[GitHub ブログ投稿](https://github.blog/changelog/2025-02-24-claude-3-7-sonnet-is-now-available-in-github-copilot-in-public-preview/) で Claude 3.7 Sonnet モデルの利用可能性について詳しく学んでください。
 
-### Copilot Vision (Preview) {#copilot-vision-preview}
+### Copilot Vision (プレビュー) {#copilot-vision-preview}
 
-We're quickly rolling out end-to-end vision support in this version of Copilot Chat. This lets you attach images and interact with images in chat prompts. For example, if you encounter an error while debugging, attach a screenshot of VS Code, and ask Copilot to help you resolve the issue. You might also use it to attach some UI mockup and let Copilot provide some HTML and CSS to implement the mockup.
+このバージョンの Copilot Chat では、エンドツーエンドのビジョンサポートを迅速に展開しています。これにより、画像を添付し、チャットプロンプトで画像と対話できるようになります。たとえば、デバッグ中にエラーが発生した場合、VS Code のスクリーンショットを添付し、Copilot に問題の解決を依頼できます。また、UI モックアップを添付し、Copilot に HTML および CSS を提供してモックアップを実装させることもできます。
 
-![Animation that shows an attached image in a Copilot Chat prompt. Hovering over the image shows a preview of it.](https://code.visualstudio.com/assets/updates/1_97/image-attachments.gif)
+![Copilot Chat プロンプトに添付された画像を示すアニメーション。画像の上にカーソルを合わせるとプレビューが表示されます。](https://code.visualstudio.com/assets/updates/1_97/image-attachments.gif)
 
-You can attach images in multiple ways:
+画像を添付する方法は複数あります。
 
-* Drag and drop images from your OS or from the Explorer view
-* Paste an image from your clipboard
-* Attach a screenshot of the VS Code window (select the **paperclip 📎 button** > **Screenshot Window**)
+* OS またはエクスプローラービューから画像をドラッグアンドドロップ
+* クリップボードから画像を貼り付ける
+* VS Code ウィンドウのスクリーンショットを添付する (クリップ📎ボタン > **Screenshot Window** を選択)
 
-A warning is shown if the selected model currently does not have the capability to handle the file type. The only supported model at the moment will be `GPT 4o`, but support for image attachments with `Claude 3.5 Sonnet` and `Gemini 2.0 Flash` will be rolling out soon as well. Currently, the supported image types are `JPEG/JPG`, `PNG`, `GIF`, and `WEBP`.
+選択したモデルが現在ファイルタイプを処理できない場合、警告が表示されます。現在サポートされている唯一のモデルは `GPT 4o` ですが、`Claude 3.5 Sonnet` および `Gemini 2.0 Flash` での画像添付のサポートも近日中に展開される予定です。現在サポートされている画像タイプは `JPEG/JPG`、`PNG`、`GIF`、および `WEBP` です。
 
-### Copilot status overview (Experimental) {#copilot-status-overview-experimental}
+### Copilot ステータス概要 (試験的) {#copilot-status-overview-experimental}
 
-**Setting**: `setting(chat.experimental.statusIndicator.enabled)`
+**設定**: `setting(chat.experimental.statusIndicator.enabled)`
 
-We are experimenting with a new centralized Copilot status overview that provides a quick overview of your Copilot status and key editor settings:
+Copilot ステータスと主要なエディター設定の概要をすばやく提供する新しい集中化された Copilot ステータス概要を試験的に導入しています。
 
-* Quota information if you are a [Copilot Free](https://code.visualstudio.com/blogs/2024/12/18/free-github-copilot) user
-* Editor related settings such as Code Completions
-* Useful keyboard shortcuts to use other Copilot features
+* [Copilot Free](https://code.visualstudio.com/blogs/2024/12/18/free-github-copilot) ユーザーの場合、クォータ情報
+* コード補完などのエディター関連設定
+* 他の Copilot 機能を使用するための便利なキーボードショートカット
 
-This Copilot status overview is accessible via the Copilot icon in the Status Bar.
+この Copilot ステータス概要は、ステータスバーの Copilot アイコンからアクセスできます。
 
-![Screenshot that shows the Copilot status overview in the Status Bar.](https://code.visualstudio.com/assets/updates/1_98/copilot-status.png)
+![ステータスバーの Copilot ステータス概要を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/copilot-status.png)
 
-Enable the Copilot status overview with the `setting(chat.experimental.statusIndicator.enabled)` setting.
+`setting(chat.experimental.statusIndicator.enabled)` 設定を使用して Copilot ステータス概要を有効にします。
 
-### TypeScript context for inline completions (Experimental) {#typescript-context-for-inline-completions-experimental}
+### インライン補完の TypeScript コンテキスト (試験的) {#typescript-context-for-inline-completions-experimental}
 
-**Setting**: `setting(chat.languageContext.typescript.enabled)`
+**設定**: `setting(chat.languageContext.typescript.enabled)`
 
-We are experimenting with enhanced context for inline completions and `/fix` commands for TypeScript files. The experiment is currently scoped to Insider releases and can be enabled with the `setting(chat.languageContext.typescript.enabled)` setting.
+TypeScript ファイルのインライン補完および `/fix` コマンドのコンテキストを強化する実験を行っています。この実験は現在 Insider リリースに限定されており、`setting(chat.languageContext.typescript.enabled)` 設定を有効にすることで有効にできます。
 
-### Custom instructions for pull request title and description {#custom-instructions-for-pull-request-title-and-description}
+### プルリクエストのタイトルと説明のカスタム指示 {#custom-instructions-for-pull-request-title-and-description}
 
-You can provide custom instructions for generating pull request title and description with the setting `setting(github.copilot.chat.pullRequestDescriptionGeneration.instructions)`.  You can point the setting to a file in your workspace, or you can provide instructions inline in your settings. Get more details about using [customizing Copilot in VS Code](https://code.visualstudio.com/docs/copilot/copilot-customization).
+`setting(github.copilot.chat.pullRequestDescriptionGeneration.instructions)` 設定を使用して、プルリクエストのタイトルと説明を生成するためのカスタム指示を提供できます。この設定をワークスペース内のファイルにポイントするか、設定内にインラインで指示を提供できます。[VS Code で Copilot をカスタマイズする](https://code.visualstudio.com/docs/copilot/copilot-customization) についての詳細を取得してください。
 
-The following sample shows how to provide a custom instruction inline in settings.
+次のサンプルは、設定内にインラインでカスタム指示を提供する方法を示しています。
 
 ```json
 {
   "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
     {
-      "text": "Prefix every PR title with an emoji."
+      "text": "すべての PR タイトルの前に絵文字を付けます。"
     }
   ]
 }
 ```
 
-Generating a title and description requires the GitHub Pull Requests extension to be installed.
+タイトルと説明を生成するには、GitHub Pull Requests 拡張機能がインストールされている必要があります。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Copilot Edits accessibility {#copilot-edits-accessibility}
+### Copilot Edits のアクセシビリティ {#copilot-edits-accessibility}
 
-We made Copilot Edits much more accessible.
+Copilot Edits のアクセシビリティを大幅に向上させました。
 
-* There are now audio signals for files with modifications and for changed regions (insertions, modifications, and deletions).
-* The accessible diff viewer is now available for modified files. Just like in diff editors, select `kb(chatEditor.action.showAccessibleDiffView)` to enable it.
+* 変更されたファイルや変更された領域 (挿入、変更、削除) に対してオーディオ信号が追加されました。
+* 変更されたファイルのアクセシブルな差分ビューアーが利用可能になりました。差分エディターと同様に、`kb(chatEditor.action.showAccessibleDiffView)` を選択して有効にします。
 
-### `activeEditorState` window title variable {#activeeditorstate-window-title-variable}
+### `activeEditorState` ウィンドウタイトル変数 {#activeeditorstate-window-title-variable}
 
-We have a new `setting(window.title)` variable, `activeEditorState`, to indicate editor information such as modified state, the number of problems, and when a file has pending Copilot Edits to screen reader users. When in Screen Reader Optimized mode, this is appended by default and can be disabled with `setting(accessibility.windowTitleOptimized:false)`.
+エディター情報 (変更状態、問題の数、保留中の Copilot Edits がある場合など) を示す新しい `setting(window.title)` 変数 `activeEditorState` を追加しました。スクリーンリーダーユーザー向けに、スクリーンリーダー最適化モードではデフォルトで追加され、`setting(accessibility.windowTitleOptimized:false)` を設定して無効にできます。
 
-## Workbench {#workbench}
+## ワークベンチ {#workbench}
 
-### Custom title bar on Linux {#custom-title-bar-on-linux}
+### Linux のカスタムタイトルバー {#custom-title-bar-on-linux}
 
-The custom title bar is now enabled by default on Linux. The custom title bar gives you access to layout controls, the Copilot menu, and more.
+カスタムタイトルバーが Linux でデフォルトで有効になりました。カスタムタイトルバーにより、レイアウトコントロール、Copilot メニューなどにアクセスできます。
 
-![Screenshot that shows the custom VS Code title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/custom-title.png)
+![Linux 上のカスタム VS Code タイトルバーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/custom-title.png)
 
-You can always revert back to the native title decorations, either from the custom title context menu or by configuring `setting(window.titleBarStyle)` to `native`.
+カスタムタイトルのコンテキストメニューから、または `setting(window.titleBarStyle)` を `native` に設定することで、ネイティブタイトルの装飾に戻すことができます。
 
-![Screenshot that shows the content menu option to disable the custom title bar on Linux.](https://code.visualstudio.com/assets/updates/1_97/restore-title.png)
+![Linux でカスタムタイトルバーを無効にするコンテンツメニューオプションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_97/restore-title.png)
 
-We are happy for continued feedback on this experience and are already working on improving this for future milestones based on existing feedback.
+このエクスペリエンスに関するフィードバックを引き続きお待ちしており、既存のフィードバックに基づいて将来のマイルストーンでこれを改善するためにすでに取り組んでいます。
 
-### Use labels for Secondary Side Bar views {#use-labels-for-secondary-side-bar-views}
+### セカンダリサイドバーのビューにラベルを使用 {#use-labels-for-secondary-side-bar-views}
 
-We decided to change the appearance of views in the Secondary Side Bar to show labels instead of icons, similar to what we have in the Panel area. This makes it easier to distinguish between different views, for example the **Copilot Edits** and **Copilot Chat** views. You can switch back to showing icons at any time by configuring `setting(workbench.secondarySideBar.showLabels)`.
+セカンダリサイドバーのビューの外観を変更し、アイコンの代わりにラベルを表示することにしました。これにより、パネル領域と同様に、異なるビュー (たとえば **Copilot Edits** と **Copilot Chat**) を区別しやすくなります。`setting(workbench.secondarySideBar.showLabels)` を設定することで、いつでもアイコンの表示に戻すことができます。
 
-![Screenshot that shows Secondary Side Bar with labels instead of icons.](https://code.visualstudio.com/assets/updates/1_98/aux-sidebar.png)
+![アイコンの代わりにラベルを表示するセカンダリサイドバーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/aux-sidebar.png)
 
-### New Settings editor key-matching algorithm (Preview) {#new-settings-editor-key-matching-algorithm-preview}
+### 新しい設定エディターのキー一致アルゴリズム (プレビュー) {#new-settings-editor-key-matching-algorithm-preview}
 
-**Setting**: `setting(workbench.settings.useWeightedKeySearch:true)`
+**設定**: `setting(workbench.settings.useWeightedKeySearch:true)`
 
-We have added a new Settings editor search algorithm that prioritizes more relevant key matches. The search algorithm attempts to match the setting ID and labels in more ways than before, but it also filters down the results more so that only the best match types are shown.
+設定エディターの新しい検索アルゴリズムを追加し、より関連性の高いキー一致を優先します。検索アルゴリズムは、設定 ID とラベルを以前よりも多くの方法で一致させようとしますが、最も適切な一致タイプのみを表示するように結果を絞り込みます。
 
-You can try out the preview feature by enabling the `setting(workbench.settings.useWeightedKeySearch:true)` setting.
+`setting(workbench.settings.useWeightedKeySearch:true)` 設定を有効にしてプレビュー機能を試してみてください。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/new-settings-search.mp4" title="Video that shows searching for tab and font before and after. After shows more relevant settings at the top of the search results." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/new-settings-search.mp4" title="タブとフォントの検索を前後で示すビデオ。後者は、検索結果の上位により関連性の高い設定を表示します。" autoplay loop controls muted></video>
 
-_Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
+_テーマ: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (プレビュー [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
 
-### Option to hide dot files in simple file picker {#option-to-hide-dot-files-in-simple-file-picker}
+### シンプルなファイルピッカーでドットファイルを非表示にするオプション {#option-to-hide-dot-files-in-simple-file-picker}
 
-When using the [simple file picker](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) (either when connected to a remote or when using `setting(files.simpleDialog.enable:true)`, you can now hide dot files by using the **Show/Hide dot files** button.
+[シンプルなファイルピッカー](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_simple-file-dialog) を使用する場合 (リモートに接続している場合や `setting(files.simpleDialog.enable:true)` を使用している場合)、**Show/Hide dot files** ボタンを使用してドットファイルを非表示にできるようになりました。
 
-![Screenshot that shows the simple file picker, highlighting the button to show or hide dot files.](https://code.visualstudio.com/assets/updates/1_98/hide-dot-file.png)
+![ドットファイルを表示または非表示にするボタンを強調表示したシンプルなファイルピッカーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/hide-dot-file.png)
 
-## Editor {#editor}
+## エディター {#editor}
 
-### Peek references drag and drop support {#peek-references-drag-and-drop-support}
+### ピークリファレンスのドラッグアンドドロップサポート {#peek-references-drag-and-drop-support}
 
-The [peek](https://code.visualstudio.com/docs/editor/editingevolved#_peek) view now supports drag & drop. Invoke **Peek References**, **Peek Implementation**, or any of the other peek commands, and drag entries from its tree to open them as separate editors.
+[ピーク](https://code.visualstudio.com/docs/editor/editingevolved#_peek) ビューがドラッグアンドドロップをサポートするようになりました。**Peek References**、**Peek Implementation**、または他のピークコマンドを呼び出し、そのツリーからエントリをドラッグして別のエディターとして開きます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/peek_dnd.mp4" title="Video that shows drag and drop of a peek reference as new editor group." autoplay loop controls muted></video>
-_Theme: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
+<video src="https://code.visualstudio.com/assets/updates/1_98/peek_dnd.mp4" title="ピークリファレンスを新しいエディターグループとしてドラッグアンドドロップする様子を示すビデオ。" autoplay loop controls muted></video>
+_テーマ: [GitHub Light Colorblind (Beta)](https://marketplace.visualstudio.com/items?itemName=GitHub.github-vscode-theme) (プレビュー [vscode.dev](https://vscode.dev/editor/theme/GitHub.github-vscode-theme/GitHub%20Light%20Colorblind%20(Beta)))_
 
-### Occurrences highlight delay {#occurrences-highlight-delay}
+### 出現ハイライトの遅延 {#occurrences-highlight-delay}
 
-The delay for occurrence highlighting within the editor is now set to 0 by default. This results in an overall more responsive editor feel. You can still control the delay with the `setting(editor.occurrencesHighlightDelay)` setting.
+エディター内の出現ハイライトの遅延がデフォルトで 0 に設定されました。これにより、全体的により応答性の高いエディターの感触が得られます。`setting(editor.occurrencesHighlightDelay)` 設定を使用して遅延を制御できます。
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Updated view titles {#updated-view-titles}
+### 更新されたビュータイトル {#updated-view-titles}
 
-When we added the **Source Control Graph** view to the Source Control view, it emphasized the duplication of section titles in the Source Control view: "Source Control Repositories", "Source Control", and "Source Control Graph". This milestone we have revisited the titles of the views, so that they are shorter and no longer duplicate the view title: "Repositories", "Changes", and "Graph".
+ソース管理ビューに **Source Control Graph** ビューを追加したとき、ソース管理ビューのセクションタイトルの重複が強調されました: "Source Control Repositories"、"Source Control"、および "Source Control Graph"。このマイルストーンでは、ビューのタイトルを見直し、短くし、ビュータイトルを重複させないようにしました: "Repositories"、"Changes"、および "Graph"。
 
-### Discard untracked changes improvements {#discard-untracked-changes-improvements}
+### 追跡されていない変更の破棄の改善 {#discard-untracked-changes-improvements}
 
-**Setting**: `setting(git.discardUntrackedChangesToTrash)`
+**設定**: `setting(git.discardUntrackedChangesToTrash)`
 
-Over the years we have received multiple reports about data loss because discarding an untracked file would permanently delete the file, even though VS Code shows a modal dialog making it clear that the file will be deleted permanently.
+長年にわたり、追跡されていないファイルを破棄するとファイルが完全に削除されるため、データ損失に関する複数の報告がありました。VS Code はファイルが完全に削除されることを明確に示すモーダルダイアログを表示しますが、それでも問題が発生していました。
 
-Starting this milestone, discarding an untracked file will move the file to the Recycle Bin/Trash when possible, so that the file can be easily recovered. You can disable this functionality using the `setting(git.discardUntrackedChangesToTrash)` setting.
+このマイルストーンから、追跡されていないファイルを破棄すると、可能な場合はファイルがリサイクルビン/ゴミ箱に移動されるため、ファイルを簡単に回復できます。この機能は `setting(git.discardUntrackedChangesToTrash)` 設定を使用して無効にできます。
 
-![Screenshot of the modal dialog shown when discarding an untracked file.](https://code.visualstudio.com/assets/updates/1_98/scm-move-to-trash.png)
+![追跡されていないファイルを破棄するときに表示されるモーダルダイアログのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/scm-move-to-trash.png)
 
-### Diagnostics commit hook (Experimental) {#diagnostics-commit-hook-experimental}
+### 診断コミットフック (試験的) {#diagnostics-commit-hook-experimental}
 
-**Settings**:
+**設定**:
 
 * `setting(git.diagnosticsCommitHook.Enabled:true)`
 * `setting(git.diagnosticsCommitHook.Sources)`
 
-This milestone, we introduced a new commit hook that prompts you if there are any unresolved diagnostics for the changed files. This is currently an experimental feature that can be enabled using the `setting(git.diagnosticsCommitHook.Enabled:true)` setting.
+このマイルストーンでは、変更されたファイルに未解決の診断がある場合にプロンプトを表示する新しいコミットフックを導入しました。これは現在試験的な機能であり、`setting(git.diagnosticsCommitHook.Enabled:true)` 設定を使用して有効にできます。
 
-By default, the commit hook prompts for any error level diagnostics, but the diagnostics sources and levels can be customized using the `setting(git.diagnosticsCommitHook.Sources)` setting. Give it a try and let us know your feedback.
+デフォルトでは、エラーレベルの診断に対してプロンプトが表示されますが、診断ソースとレベルは `setting(git.diagnosticsCommitHook.Sources)` 設定を使用してカスタマイズできます。試してみて、フィードバックをお聞かせください。
 
-![Screenshot of the modal dialog shown when there are unresolved diagnostics for the changed files.](https://code.visualstudio.com/assets/updates/1_98/scm-diagnostics-commit-hook.png)
+![変更されたファイルに未解決の診断がある場合に表示されるモーダルダイアログのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/scm-diagnostics-commit-hook.png)
 
-## Notebooks {#notebooks}
+## ノートブック {#notebooks}
 
-### Inline notebook diff view (Experimental) {#inline-notebook-diff-view-experimental}
+### インラインノートブック差分ビュー (試験的) {#inline-notebook-diff-view-experimental}
 
-**Setting**: `setting(notebook.diff.experimental.toggleInline:true)`
+**設定**: `setting(notebook.diff.experimental.toggleInline:true)`
 
-You can now enable an inline diff view for notebooks. This feature enables you to view changes within notebook cells in a single inline view, rather than the traditional side-by-side comparison.
+ノートブックのインライン差分ビューを有効にできるようになりました。この機能により、ノートブックセル内の変更を従来のサイドバイサイド比較ではなく、単一のインラインビューで表示できます。
 
-Enable this feature by setting `setting(notebook.diff.experimental.toggleInline:true)` to `true`. You can then toggle the diff view to inline using the editor menu in the top right corner.
+この機能を有効にするには、`setting(notebook.diff.experimental.toggleInline:true)` を `true` に設定します。エディターメニューの右上隅を使用して差分ビューをインラインに切り替えることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/inline_notebook_diff.mp4" title="Video that shows toggling an edit suggestion from side-by-side to an inline diff for notebooks." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/inline_notebook_diff.mp4" title="ノートブックの編集提案をサイドバイサイドからインライン差分に切り替える様子を示すビデオ。" autoplay loop controls muted></video>
 
-### Notebook inline values hover {#notebook-inline-values-hover}
+### ノートブックインライン値ホバー {#notebook-inline-values-hover}
 
-Notebook inline values now have their decoration truncated to fit the width of the viewport and have a rich hover to show the full value, maintaining whitespace formatting. This maintains the shape of variables like dataframes, making values easier to read at a glance.
+ノートブックのインライン値は、ビューポートの幅に合わせて装飾が切り詰められ、完全な値を表示するリッチホバーが追加されました。これにより、データフレームなどの変数の形状が維持され、一目で値を読みやすくなります。
 
-![Screenshot that shows the cursor hovering above a dataframe object's inline decoration. A rich value hover is shown.](https://code.visualstudio.com/assets/updates/1_98/nb-inline-values-rich-hover.png)
+![データフレームオブジェクトのインライン装飾の上にカーソルを合わせたスクリーンショット。リッチ値ホバーが表示されます。](https://code.visualstudio.com/assets/updates/1_98/nb-inline-values-rich-hover.png)
 
-## Terminal IntelliSense (Preview) {#terminal-intellisense-preview}
+## ターミナル IntelliSense (プレビュー) {#terminal-intellisense-preview}
 
-**Setting**: `setting(terminal.integrated.suggest.enabled:true)`
+**設定**: `setting(terminal.integrated.suggest.enabled:true)`
 
-We've significantly improved terminal shell completions across bash, zsh, fish, and PowerShell by adding completion specs (`git` for example), refining command-line parsing for better suggestions, and enhancing file and folder completions. Enable this feature with `setting(terminal.integrated.suggest.enabled:true)`.
+bash、zsh、fish、および PowerShell のターミナルシェル補完を大幅に改善し、補完スペック (`git` など) を追加し、コマンドライン解析を改善してより良い提案を提供し、ファイルおよびフォルダの補完を強化しました。この機能を有効にするには、`setting(terminal.integrated.suggest.enabled:true)` を設定します。
 
-### Enhanced Fig completion support {#enhanced-fig-completion-support}
+### 強化された Fig 補完サポート {#enhanced-fig-completion-support}
 
-We leverage [Fig completion specs](https://github.com/withfig/autocomplete) to power intelligent completions for specific CLIs. We only had a small number of these before, but this iteration we added the following CLIs to the list we ship with VS Code:
+[Fig 補完スペック](https://github.com/withfig/autocomplete) を活用して、特定の CLI のインテリジェントな補完を提供します。以前は少数のスペックしかありませんでしたが、このイテレーションでは次の CLI を VS Code に追加しました。
 
-* Basic tools: `cat`, `chmod`, `chown`, `cp`, `curl`, `df`, `du`, `echo`, `find`, `grep`, `head`, `less`, `ls`, `mkdir`, `more`, `mv`, `pwd`, `rm`, `rmdir`, `tail`, `top`, `touch`, `uname`
-* Process tools: `kill`, `killall`, `ps`
-* Package managers: `apt`, `brew`
-* Node.js ecosystem: `node`, `npm`, `npx`, `nvm`, `pnpm`, `yarn`
-* SCM, languages, editors: `git`, `nano`, `python`, `python3`, `vim`
-* Network: `scp`, `ssh`, `wget`
+* 基本ツール: `cat`、`chmod`、`chown`、`cp`、`curl`、`df`、`du`、`echo`、`find`、`grep`、`head`、`less`、`ls`、`mkdir`、`more`、`mv`、`pwd`、`rm`、`rmdir`、`tail`、`top`、`touch`、`uname`
+* プロセスツール: `kill`、`killall`、`ps`
+* パッケージマネージャー: `apt`、`brew`
+* Node.js エコシステム: `node`、`npm`、`npx`、`nvm`、`pnpm`、`yarn`
+* SCM、言語、エディター: `git`、`nano`、`python`、`python3`、`vim`
+* ネットワーク: `scp`、`ssh`、`wget`
 
-In addition to the new specs, we now also support _generators_, which dynamically generate completions by running commands when they're requested. One example of this in action is presenting all branches for `git checkout`:
+新しいスペックに加えて、_ジェネレーター_ もサポートしており、リクエストされたときにコマンドを実行して動的に補完を生成します。これの一例として、`git checkout` のすべてのブランチを表示することが挙げられます。
 
-![Screenshot that shows completions for "git checkout tyriar/xterm", showing several results, including fuzzy results that don't match the query exactly.](https://code.visualstudio.com/assets/updates/1_98/terminal-git-checkout.png)
-_Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire/Sapphire))_
+![「git checkout tyriar/xterm」の補完を示すスクリーンショット。いくつかの結果が表示され、クエリと完全に一致しないファジー結果も含まれています。](https://code.visualstudio.com/assets/updates/1_98/terminal-git-checkout.png)
+_テーマ: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (プレビュー [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire/Sapphire))_
 
-Behind the scenes, this runs `git --no-optional-locks branch -a --no-color --sort=-committerdate` to get the list of branches before processing them into completions. A similar approach is used to also fetch tags.
+舞台裏では、これが `git --no-optional-locks branch -a --no-color --sort=-committerdate` を実行してブランチのリストを取得し、それを補完に処理します。同様のアプローチを使用してタグも取得します。
 
-### Configurable quick suggestions {#configurable-quick-suggestions}
+### 設定可能なクイック提案 {#configurable-quick-suggestions}
 
-**Setting**: `setting(terminal.integrated.suggest.quickSuggestions)`
+**設定**: `setting(terminal.integrated.suggest.quickSuggestions)`
 
-Similar to the editor, _quick suggestions_ are what automatically shows IntelliSense when typing _anything_, as opposed to _trigger characters_, which show when certain characters like `\` or `-` are used. The new `setting(terminal.integrated.suggest.quickSuggestions)` setting allows precise control over when quick suggestions should be presented.
+エディターと同様に、_クイック提案_ は、特定の文字 (たとえば `\` や `-`) を使用する代わりに、_何か_ を入力すると自動的に IntelliSense を表示します。新しい `setting(terminal.integrated.suggest.quickSuggestions)` 設定を使用して、クイック提案を表示するタイミングを正確に制御できます。
 
-The default value enables quick suggestions for commands and arguments, and now disabled by default falling back to paths which we heard could get noisy and frustrating as they often weren't applicable. This is the default:
+デフォルト値は、コマンドと引数に対してクイック提案を有効にし、パスに対しては無効にします。これはデフォルトです。
 
 ```js
 "terminal.integrated.suggest.quickSuggestions": {
@@ -393,215 +393,214 @@ The default value enables quick suggestions for commands and arguments, and now 
 }
 ```
 
-### Inline suggestion detection {#inline-suggestion-detection}
+### インライン提案の検出 {#inline-suggestion-detection}
 
-**Setting**: `setting(terminal.integrated.suggest.inlineSuggestion)`
+**設定**: `setting(terminal.integrated.suggest.inlineSuggestion)`
 
-One problem inline suggestion detection has had to date, has been confusion introduced by competing with suggestions from different sources. Specifically, the inline suggestion that often appears when typing in shells:
+これまでのインライン提案検出の問題の 1 つは、異なるソースからの提案と競合することによって引き起こされる混乱でした。具体的には、シェルで入力するときに表示されるインライン提案です。
 
-![Screenshot that shows fish shell showing suggestions, such as previous git commit commands when typing a prefix.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-autosuggest.png)
+![fish シェルが提案を表示する様子を示すスクリーンショット。以前の git コミットコマンドの提案が表示されています。](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-autosuggest.png)
 
-These suggestions are actually shell-level features (auto suggestions in fish/zsh, predictions in pwsh, etc.), which might not be obvious to the user, especially when presented alongside IntelliSense.
+これらの提案は実際にはシェルレベルの機能です (fish/zsh の自動提案、pwsh の予測など)。特に IntelliSense と一緒に表示される場合、ユーザーには明らかではないかもしれません。
 
-The IntelliSense feature requires that we detect this inline suggestion, which previously used a naive implementation that only checked whether the text was styled with _faint_ or _italics_ SGR attributes. It turns out that this was insufficient, not only when the user customized the styles, but also fish shell did not use either of these styles by default. We now detect the majority of cases by analyzing the command line context and cursor position.
+IntelliSense 機能は、このインライン提案を検出する必要がありますが、以前は _faint_ または _italics_ SGR 属性でスタイル設定されたテキストをチェックするだけの単純な実装を使用していました。これでは不十分であり、特にユーザーがスタイルをカスタマイズした場合や、fish シェルがデフォルトでこれらのスタイルを使用しない場合に問題が発生しました。現在では、コマンドラインコンテキストとカーソル位置を分析することで、ほとんどのケースを検出しています。
 
-Building upon this new and improved detection, the inline suggestion is now presented as the top option with a star icon to both align closer with how the editor behaves and to make it more clear what `kstyle(Tab)` will do in this case.
+この新しく改善された検出に基づいて、インライン提案はトップオプションとして表示され、星アイコンが付いており、エディターの動作により近づけ、`kstyle(Tab)` がこの場合に何を行うかをより明確にします。
 
-![Screenshot that shows when an inline suggestion shows up, it will be detected and put beside a star icon at the top of IntelliSense.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-inline-suggest.png)
+![インライン提案が表示されると、検出され、IntelliSense のトップに星アイコンと一緒に表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-inline-suggest.png)
 
-The default is to always show this suggestion as the top suggestions, but can be configured with `setting(terminal.integrated.suggest.inlineSuggestion)`.
+デフォルトでは、この提案は常にトップ提案として表示されますが、`setting(terminal.integrated.suggest.inlineSuggestion)` を使用して構成できます。
 
-### Detailed command completions {#detailed-command-completions}
+### 詳細なコマンド補完 {#detailed-command-completions}
 
-Completions for bash and zsh built-in commands and PowerShell commands are now more detailed, providing details on available arguments. This information is sourced from the shell's documentation or help commands.
+bash および zsh の組み込みコマンドおよび PowerShell コマンドの補完が詳細になり、利用可能な引数に関する詳細情報が提供されます。この情報は、シェルのドキュメントまたはヘルプコマンドから取得されます。
 
-For bash, `help <command>` is used to get a basic description:
+bash では、`help <command>` を使用して基本的な説明を取得します。
 
-![Screenshot that shows the history completion in bash, showing usage information and description.](https://code.visualstudio.com/assets/updates/1_98/terminal-bash-builtin-completions.png)
+![履歴補完を示す bash のスクリーンショット。使用方法情報と説明が表示されています。](https://code.visualstudio.com/assets/updates/1_98/terminal-bash-builtin-completions.png)
 
-For zsh, `man zshbuiltins` is used to get a detailed description:
+zsh では、`man zshbuiltins` を使用して詳細な説明を取得します。
 
-![Screenshot that shows completions in zsh, displaying detailed information from the manpage.](https://code.visualstudio.com/assets/updates/1_98/terminal-zsh-builtin-completions.png)
+![補完を示す zsh のスクリーンショット。man ページからの詳細情報が表示されています。](https://code.visualstudio.com/assets/updates/1_98/terminal-zsh-builtin-completions.png)
 
-For PowerShell, more properties of `Get-Command` are shown in the completion:
+PowerShell では、`Get-Command` のプロパティの詳細が補完に表示されます。
 
-![Screenshot that shows the completion for Get-ChildItem, showing the module Microsoft.PowerShell.Management and its version.](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-module.png)
+![Get-ChildItem の補完を示すスクリーンショット。モジュール Microsoft.PowerShell.Management とそのバージョンが表示されています。](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-module.png)
 
-![Screenshot that shows the completion for ConvertTo-Json, showing the signature of the command.](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-signature.png)
+![ConvertTo-Json の補完を示すスクリーンショット。コマンドのシグネチャが表示されています。](https://code.visualstudio.com/assets/updates/1_98/terminal-pwsh-signature.png)
 
-### Improved sorting {#improved-sorting}
+### 改善されたソート {#improved-sorting}
 
-Command completions now feature improved sorting, specifically:
+コマンド補完には、特に次の点で改善されたソートが特徴です。
 
-* Completions with more details generally appear above less detailed completions
-* Builtin commands take precedence over paths from `$PATH`
+* より詳細な補完は、一般的に詳細の少ない補完の上に表示されます
+* 組み込みコマンドは `$PATH` からのパスよりも優先されます
 
-![Screenshot that shows the more useful alias and autoload commands showing before others in zsh.](https://code.visualstudio.com/assets/updates/1_98/terminal-zsh-order.png)
+![zsh でより有用なエイリアスおよび自動ロードコマンドが他のコマンドの前に表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-zsh-order.png)
 
-For paths, the following improvements were made:
+パスについては、次の改善が行われました。
 
-* Paths starting with `_` get a penalty as this is often an indicator that they are special and generally shouldn't be changed much (for example, `__init__.py`).
-* Punctuation is ignored when sorting, so files starting with `.` will be mixed in with others.
+* `_` で始まるパスはペナルティを受けます。これは通常、特別であり、あまり変更されるべきではないことを示す指標です (たとえば、`__init__.py`)。
+* ソート時に句読点が無視されるため、`.` で始まるファイルは他のファイルと混在します。
 
-![Screenshot that shows __init__.py will show below other files, while a .build dir will show immediately above a build file.](https://code.visualstudio.com/assets/updates/1_98/terminal-underscore-punc.png)
+![__init__.py が他のファイルの下に表示され、.build ディレクトリが build ファイルのすぐ上に表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-underscore-punc.png)
 
-### CDPATH support {#cdpath-support}
+### CDPATH サポート {#cdpath-support}
 
-**Setting**: `setting(terminal.integrated.suggest.cdPath)`
+**設定**: `setting(terminal.integrated.suggest.cdPath)`
 
-The `$CDPATH` environment variable is a common shell feature that contains a colon-separated list of paths, similar to `$PATH`, and allows navigating to them as if they were relative regardless of the current working directory. Fish actually shows CDPATH entries in `cd` tab completion:
+`$CDPATH` 環境変数は、`$PATH` と同様にコロン区切りのパスのリストを含む一般的なシェル機能であり、現在の作業ディレクトリに関係なく相対的にナビゲートできます。fish は実際に `cd` タブ補完で CDPATH エントリを表示します。
 
-![Screenshot that shows tab completion in fish, displaying entries from CDPATH.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-cdpath.png)
+![fish でのタブ補完を示すスクリーンショット。CDPATH からのエントリが表示されています。](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-cdpath.png)
 
-We now support showing `$CDPATH` entries as completions when using `cd`:
+`cd` を使用する際に `$CDPATH` エントリを補完として表示することができるようになりました。
 
-![Screenshot that shows CDPATH entries now show up in IntelliSense.](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-cdpath-completions.png)
+![CDPATH エントリが IntelliSense に表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-fish-cdpath-completions.png)
 
-This feature also works on Windows (`;` separators) and doesn't need the shell to natively support the feature, since the default is using the absolute path.
+この機能は Windows (`;` セパレータ) でも動作し、シェルがネイティブにサポートしていなくても、デフォルトで絶対パスを使用します。
 
-![Screenshot that shows a CDPATH containing 2 paths separated by a semi-colon, including all sub-directories even on PowerShell which does not support CDPATH natively.](https://code.visualstudio.com/assets/updates/1_98/terminal-cdpath-pwsh.png)
+![CDPATH に 2 つのパスがセミコロンで区切られて含まれている様子を示すスクリーンショット。PowerShell でも CDPATH がネイティブにサポートされていない場合でも、すべてのサブディレクトリが表示されます。](https://code.visualstudio.com/assets/updates/1_98/terminal-cdpath-pwsh.png)
 
-Configure this with `setting(terminal.integrated.suggest.cdPath)`.
+`setting(terminal.integrated.suggest.cdPath)` を使用してこの機能を構成します。
 
-#### Absolute paths {#absolute-paths}
+#### 絶対パス {#absolute-paths}
 
-Absolute paths are now supported.
+絶対パスがサポートされるようになりました。
 
-![Screenshot that shows "cd c:\Github\mi" will show results for all absolute folders matching that term.](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-windows.png)
+![「cd c:\Github\mi」と入力すると、絶対パスに一致するすべてのフォルダが表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-windows.png)
 
-![Screenshot that shows cd to absolute paths also works with Unix-style paths.](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-mac.png)
+![cd を使用して絶対パスに移動することも Unix スタイルのパスで動作する様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-absolute-mac.png)
 
-### Alias support {#alias-support}
+### エイリアスサポート {#alias-support}
 
-Command aliases are now also detected for bash, zsh and fish and feature a new distinct icon:
+bash、zsh、および fish のコマンドエイリアスが検出され、新しい独自のアイコンが表示されるようになりました。
 
-![Screenshot that shows the alias c->code-insiders will now be detected and show with the command icon with a little arrow in the corner.](https://code.visualstudio.com/assets/updates/1_98/terminal-alias.png)
+![エイリアス c->code-insiders が検出され、コマンドアイコンの隅に小さな矢印が表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-alias.png)
 
-### Differentiated options and flags {#differentiated-options-and-flags}
+### オプションとフラグの区別 {#differentiated-options-and-flags}
 
-CLI options (that have a value) and flags (that don't) are now differentiated in the UI via a different icon:
+CLI オプション (値を持つもの) とフラグ (値を持たないもの) が UI で区別され、異なるアイコンが表示されるようになりました。
 
-![Screenshot that shows flags like --help will show a flag icon, options like --diff will show a different icon.](https://code.visualstudio.com/assets/updates/1_98/terminal-flags-options.png)
+![--help のようなフラグがフラグアイコンで表示され、--diff のようなオプションが異なるアイコンで表示される様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_98/terminal-flags-options.png)
 
-## Tasks {#tasks}
+## タスク {#tasks}
 
-### Task rerun action {#task-rerun-action}
+### タスク再実行アクション {#task-rerun-action}
 
-We have a new **rerun** task action for terminals, `kb(workbench.action.tasks.rerunForActiveTerminal)`. The action appears on the terminal tab's inline toolbar and in the terminal's context menu.
+ターミナル用の新しい **再実行** タスクアクション `kb(workbench.action.tasks.rerunForActiveTerminal)` を追加しました。このアクションは、ターミナルタブのインラインツールバーおよびターミナルのコンテキストメニューに表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_98/terminal-rerun-task.mp4" title="Video that shows the terminal rerun task." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_98/terminal-rerun-task.mp4" title="ターミナルのタスク再実行を示すビデオ。" autoplay loop controls muted></video>
 
-## Debug {#debug}
+## デバッグ {#debug}
 
-### Debug inline values hover {#debug-inline-values-hover}
+### デバッグインライン値ホバー {#debug-inline-values-hover}
 
-If the setting `setting(debug.inlineValues)` is enabled, the inline value decorations now have an inline hover, making it easier to read longer values at a glance.
+`setting(debug.inlineValues)` 設定が有効になっている場合、インライン値の装飾にインラインホバーが追加され、長い値を一目で読みやすくなります。
 
-![Screenshot that shows the cursor hovering above a dataframe object's inline decoration in an active debugging session. Rich value hover is shown.](https://code.visualstudio.com/assets/updates/1_98/debug-inline-values-rich-hover.png)
+![アクティブなデバッグセッションでデータフレームオブジェクトのインライン装飾の上にカーソルを合わせたスクリーンショット。リッチ値ホバーが表示されます。](https://code.visualstudio.com/assets/updates/1_98/debug-inline-values-rich-hover.png)
 
-## Languages {#languages}
+## 言語 {#languages}
 
 ### TypeScript 5.8 {#typescript-58}
 
-VS Code now includes TypeScript 5.8.2. This major update brings new language improvements, including [improved checking of types from conditional expressions](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) and [support for write code that confirms to Node's new --experimental-strip-types option](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#the---erasablesyntaxonly-option). It also included a number of tooling improvements and bug fixes.
+VS Code には TypeScript 5.8.2 が含まれています。この主要なアップデートには、[条件式からの型のチェックの改善](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) や [Node の新しい --experimental-strip-types オプションに準拠するコードの記述サポート](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/#the---erasablesyntaxonly-option) などの新しい言語の改善が含まれています。また、多くのツールの改善やバグ修正も含まれています。
 
-Check out the [TypeScript 5.8 release blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) for more details on this update.
+このアップデートの詳細については、[TypeScript 5.8 リリースブログ](https://devblogs.microsoft.com/typescript/announcing-typescript-5-8/) をご覧ください。
 
-## Remote Development {#remote-development}
+## リモート開発 {#remote-development}
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[リモート開発拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) を使用すると、[Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)、SSH 経由のリモートマシンまたは [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels)、または [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) をフル機能の開発環境として使用できます。
 
-Highlights include:
+ハイライトには次のものが含まれます。
 
-* EOL for Linux legacy server
-* Expanded proxy configurability
+* Linux レガシーサーバーの EOL
+* プロキシ構成の拡張
 
-You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_98.md).
+これらの機能の詳細については、[リモート開発リリースノート](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_98.md) をご覧ください。
 
-## Enterprise support {#enterprise-support}
+## エンタープライズサポート {#enterprise-support}
 
-### Multi-line support for allowed extensions {#multi-line-support-for-allowed-extensions}
+### 許可された拡張機能の複数行サポート {#multi-line-support-for-allowed-extensions}
 
-You can now configure allowed extensions in the group policy on Windows using a multi-line string. This allows for more flexible and extensive configuration of allowed extensions. Learn more about [configuring allowed extensions](https://code.visualstudio.com/docs/setup/enterprise#_configure-allowed-extensions).
+許可された拡張機能を Windows のグループポリシーで構成する際に、複数行の文字列を使用できるようになりました。これにより、許可された拡張機能の構成がより柔軟で広範になります。[許可された拡張機能の構成](https://code.visualstudio.com/docs/setup/enterprise#_configure-allowed-extensions) について詳しく学んでください。
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### Python {#python}
 
-#### Automatic quotation insertion when breaking long strings {#automatic-quotation-insertion-when-breaking-long-strings}
+#### 長い文字列を分割する際の自動引用符挿入 {#automatic-quotation-insertion-when-breaking-long-strings}
 
-[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now supports automatic insertion of quotation marks to enable a seamless experience when breaking long strings.
+[Pylance](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) は、長い文字列を分割する際に引用符を自動挿入する機能をサポートするようになりました。
 
-#### Pylance memory consumption improvements {#pylance-memory-consumption-improvements}
+#### Pylance のメモリ消費の改善 {#pylance-memory-consumption-improvements}
 
-Some optimizations were made to improve Pylance's memory consumption, particularly when working with large workspaces. [This enhancement](https://github.com/microsoft/pyright/pull/9993) was made to Pyright, the static type checker that powers Pylance's language server features.
+特に大規模なワークスペースで作業する際に、Pylance のメモリ消費を改善するための最適化が行われました。[この改善](https://github.com/microsoft/pyright/pull/9993) は、Pylance の言語サーバー機能を支える静的型チェッカー Pyright に対して行われました。
 
-#### Improvements to Python shell integration {#improvements-to-python-shell-integration}
+#### Python シェル統合の改善 {#improvements-to-python-shell-integration}
 
-After modifying `setting(python.terminal.shellIntegration.enabled)`, you will no longer have to reload in order for changes to take effect. Simply create a new terminal to see desired changes on your Python REPL in terminal.
+`setting(python.terminal.shellIntegration.enabled)` を変更した後、変更が反映されるまでにリロードする必要がなくなりました。新しいターミナルを作成するだけで、ターミナル内の Python REPL に希望の変更が反映されます。
 
-#### Correct workspace prompt for Windows Git Bash {#correct-workspace-prompt-for-windows-git-bash}
+#### Windows Git Bash の正しいワークスペースプロンプト {#correct-workspace-prompt-for-windows-git-bash}
 
-Python users on Windows using Git Bash will now see correct working directory in their terminal prompt.
-These changes apply to those opted into the `pythonTerminalEnvVarActivation` experiment.
+Windows で Git Bash を使用する Python ユーザーは、ターミナルプロンプトに正しい作業ディレクトリが表示されるようになりました。
+これらの変更は、`pythonTerminalEnvVarActivation` 実験にオプトインしているユーザーに適用されます。
 
-#### New setting for auto test discovery file pattern {#new-setting-for-auto-test-discovery-file-pattern}
+#### 自動テスト検出ファイルパターンの新しい設定 {#new-setting-for-auto-test-discovery-file-pattern}
 
-You can now refine which files auto test discovery occurs by specifying a glob pattern in the `setting(python.testing.autoTestDiscoverOnSavePattern)` setting. Its default value is set to `**/*.py`.
+`setting(python.testing.autoTestDiscoverOnSavePattern)` 設定でグロブパターンを指定することで、自動テスト検出が行われるファイルを絞り込むことができます。デフォルト値は `**/*.py` に設定されています。
 
-#### Read test debug config from settings.json as fallback {#read-test-debug-config-from-settings.json-as-fallback}
+#### 設定.json からのテストデバッグ構成の読み取り {#read-test-debug-config-from-settings.json-as-fallback}
 
-We now look for test debug configurations in both `settings.json` and `launch.json` files, expanding where you can define these configurations.
+テストデバッグ構成を `settings.json` および `launch.json` ファイルの両方で検索するようになり、これらの構成を定義できる場所が拡張されました。
 
-### GitHub authentication {#github-authentication}
+### GitHub 認証 {#github-authentication}
 
-#### Improved proxy support with Electron `fetch` adoption {#improved-proxy-support-with-electron-fetch-adoption}
+#### Electron `fetch` 採用によるプロキシサポートの改善 {#improved-proxy-support-with-electron-fetch-adoption}
 
-The GitHub Authentication extension now leverages Electron's version of `fetch` in order to make web requests. This has helped users with certain proxy & firewall settings. If you know you run in an environment that has a proxy setup and you are unable to authenticate to GitHub inside of VS Code, don't hesitate to create an issue!
+GitHub 認証拡張機能は、Web リクエストを行うために Electron のバージョンの `fetch` を活用するようになりました。これにより、特定のプロキシおよびファイアウォール設定を持つユーザーが支援されました。プロキシ設定がある環境で GitHub に認証できない場合は、問題を作成することを躊躇しないでください。
 
-## Extension authoring {#extension-authoring}
+## 拡張機能の作成 {#extension-authoring}
 
-### Authentication {#authentication}
+### 認証 {#authentication}
 
-> **Important**:
-> We are renaming `AuthenticationForceNewSessionOptions` to `AuthenticationGetSessionPresentationOptions` and leaving a deprecated `AuthenticationForceNewSessionOptions` for now. There is no functional difference, so this is not a breaking change in the runtime, but you should update your code to use `AuthenticationGetSessionPresentationOptions` instead of `AuthenticationForceNewSessionOptions` since it will be removed in the future.
+> **重要**:
+> `AuthenticationForceNewSessionOptions` を `AuthenticationGetSessionPresentationOptions` に名前を変更し、現在のところ `AuthenticationForceNewSessionOptions` を非推奨として残します。機能的な違いはないため、ランタイムでの破壊的変更ではありませんが、将来的に削除されるため、`AuthenticationForceNewSessionOptions` の代わりに `AuthenticationGetSessionPresentationOptions` を使用するようにコードを更新する必要があります。
 
-Looking at these two authentication calls:
+次の 2 つの認証呼び出しを見てみましょう。
 ```ts
 vscode.authentication.getSession(provider, scopes, { createIfNone: options });
 vscode.authentication.getSession(provider, scopes, { forceNewSession: options });
 ```
 
-`createIfNone` and `forceNewSession` will now take in either a `boolean` or a `AuthenticationGetSessionPresentationOptions`:
+`createIfNone` および `forceNewSession` は、`boolean` または `AuthenticationGetSessionPresentationOptions` のいずれかを受け取るようになります。
 ```ts
 /**
- * Optional options to be used when calling {@link authentication.getSession} with interactive options `forceNewSession` & `createIfNone`.
+ * インタラクティブなオプション `forceNewSession` および `createIfNone` を使用して {@link authentication.getSession} を呼び出す際に使用されるオプション。
  */
 export interface AuthenticationGetSessionPresentationOptions {
 	/**
-	 * An optional message that will be displayed to the user when we ask to re-authenticate. Providing additional context
-	 * as to why you are asking a user to re-authenticate can help increase the odds that they will accept.
+	 * 再認証を求める際にユーザーに表示されるオプションのメッセージ。再認証を求める理由を追加のコンテキストとして提供することで、ユーザーが受け入れる可能性が高まります。
 	 */
 	detail?: string;
 }
 ```
-_[full typings can be found here](https://github.com/microsoft/vscode/blob/release/1.98/src/vscode-dts/vscode.d.ts#L17520-L17551)_...
+_[完全な型定義はこちら](https://github.com/microsoft/vscode/blob/release/1.98/src/vscode-dts/vscode.d.ts#L17520-L17551)_...
 
-This is a new addition for `createIfNone`, but it's a modification for `forceNewSession`, which used to take in a `AuthenticationForceNewSessionOptions` that had the same signature as the new `AuthenticationGetSessionPresentationOptions`.
+これは `createIfNone` にとって新しい追加ですが、`forceNewSession` にとっては `AuthenticationForceNewSessionOptions` を受け取るように変更されたものであり、これは `AuthenticationGetSessionPresentationOptions` と同じシグネチャを持っています。
 
-If you are explicitly using `AuthenticationForceNewSessionOptions`, you will see it is marked as deprecated and you should replace it with `AuthenticationGetSessionPresentationOptions`, as `AuthenticationForceNewSessionOptions` will be removed in a future version.
+`AuthenticationForceNewSessionOptions` を明示的に使用している場合、それが非推奨としてマークされていることがわかり、`AuthenticationForceNewSessionOptions` が将来のバージョンで削除されるため、`AuthenticationGetSessionPresentationOptions` に置き換える必要があります。
 
-It's important to note that the only thing that is changing here are the types. **There is no runtime change, so this is not a breaking change from that perspective.**
+ここで重要なのは、変更されるのは型だけであり、ランタイムの変更はないため、ランタイムの観点からは破壊的変更ではないということです。
 
-Additionally, the `authLearnMore` [proposed API](https://github.com/microsoft/vscode/blob/release/1.98/src/vscode-dts/vscode.proposed.authLearnMore.d.ts) has been updated from `AuthenticationForceNewSessionOptions` to `AuthenticationGetSessionPresentationOptions`.
+さらに、`authLearnMore` [提案 API](https://github.com/microsoft/vscode/blob/release/1.98/src/vscode-dts/vscode.proposed.authLearnMore.d.ts) が `AuthenticationForceNewSessionOptions` から `AuthenticationGetSessionPresentationOptions` に更新されました。
 
-Here's an example that leverages `detail` and the `learnMore` proposal:
+`detail` と `learnMore` 提案を活用する例を次に示します。
 
-![Screenshot that shows the authentication modal dialog, featuring a message that says 'To get more relevant Copilot Chat results, we need permission to read the contents of your repository on GitHub.' and a button to learn more.](https://code.visualstudio.com/assets/updates/1_98/auth-presentation.png)
+![認証モーダルダイアログを示すスクリーンショット。「より関連性の高い Copilot Chat の結果を得るために、GitHub 上のリポジトリの内容を読み取る権限が必要です。」というメッセージと、詳細を学ぶためのボタンが表示されています。](https://code.visualstudio.com/assets/updates/1_98/auth-presentation.png)
 
-### Refined Snippet API {#refined-snippet-api}
+### 改良されたスニペット API {#refined-snippet-api}
 
-You can now control the whitespace normalization when inserting snippets. This applies to the [`insertSnippet`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L1306)-API and to the [`SnippetTextEdit`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L3753)-API and control is the indentation of additional lines of snippets are adjusted or not
+スニペットを挿入する際の空白の正規化を制御できるようになりました。これは [`insertSnippet`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L1306)-API および [`SnippetTextEdit`](https://github.com/microsoft/vscode/blob/c202fb0bcfc7ac863f90756bdf668e801b96901d/src/vscode-dts/vscode.d.ts#L3753)-API に適用され、スニペットの追加行のインデントが調整されるかどうかを制御します。
 
 ```js
 const snippet = `This is an indented
@@ -610,74 +609,74 @@ const snippet = `This is an indented
 // keepWhitespace: false, undefined
 function indentedFunctionWithSnippet() {
     return `This is an indented
-        snippet`; // adjusted indentation
+        snippet`; // 調整されたインデント
 }
 
 // keepWhitespace: true
 function indentedFunctionWithSnippet() {
     return `This is an indented
-    snippet`; // original indentation
+    snippet`; // 元のインデント
 }
 
 ```
 
-## Proposed APIs {#proposed-apis}
+## 提案された API {#proposed-apis}
 
-### Text Encodings {#text-encodings}
+### テキストエンコーディング {#text-encodings}
 
-We added new proposed API to work with [text encodings](https://github.com/microsoft/vscode/blob/501ee833b16b8e83ba656c46e0888aadd9d2db04/src/vscode-dts/vscode.proposed.textDocumentEncoding.d.ts#L1) in VS Code.
+VS Code で [テキストエンコーディング](https://github.com/microsoft/vscode/blob/501ee833b16b8e83ba656c46e0888aadd9d2db04/src/vscode-dts/vscode.proposed.textDocumentEncoding.d.ts#L1) を操作するための新しい提案 API を追加しました。
 
-Specifically, this new API allows to:
+具体的には、この新しい API により次のことが可能になります。
 
-* Get the current `encoding` of a `TextDocument`
-* Open a `TextDocument` with a specific `encoding`
-* Encode a `string` to a `Uint8Array` with a specific `encoding`
-* Decode a `Uint8Array` to a `string` using a specific `encoding`
+* `TextDocument` の現在の `encoding` を取得する
+* 特定の `encoding` で `TextDocument` を開く
+* 特定の `encoding` で `string` を `Uint8Array` にエンコードする
+* 特定の `encoding` を使用して `Uint8Array` を `string` にデコードする
 
-Try it out and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/241449).
+試してみて、[この GitHub issue](https://github.com/microsoft/vscode/issues/241449) でフィードバックをお聞かせください。
 
-### Shell environment {#shell-environment}
+### シェル環境 {#shell-environment}
 
-Extensions are able to access the user's currently active shell environment information for pwsh, zsh, bash, and fish shell that are opened from the VS Code integrated terminal. This is only available when `setting(terminal.integrated.shellIntegration.enabled)` is enabled.
+拡張機能は、VS Code 統合ターミナルから開かれた pwsh、zsh、bash、および fish シェルの現在アクティブなシェル環境情報にアクセスできます。これは `setting(terminal.integrated.shellIntegration.enabled)` が有効な場合にのみ利用可能です。
 
-The user can decide whether or not to report their shell environment information with `setting(terminal.integrated.shellIntegration.environmentReporting)`.
+ユーザーは `setting(terminal.integrated.shellIntegration.environmentReporting)` を使用して、シェル環境情報を報告するかどうかを決定できます。
 
-Give it a try and let us know what you think [in this GitHub issue](https://github.com/microsoft/vscode/issues/227467).
+試してみて、[この GitHub issue](https://github.com/microsoft/vscode/issues/227467) でフィードバックをお聞かせください。
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### Electron 34 update {#electron-34-update}
+### Electron 34 アップデート {#electron-34-update}
 
-In this milestone, we are promoting the Electron 34 update to users on our stable release. This update comes with Chromium 132.0.6834.196 and Node.js 20.18.2. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+このマイルストーンでは、Electron 34 アップデートを安定版リリースのユーザーに提供しています。このアップデートには、Chromium 132.0.6834.196 および Node.js 20.18.2 が含まれています。Insiders ビルドを自己ホストし、早期フィードバックを提供してくれたすべての人に感謝します。
 
-### macOS 10.15 support has ended {#macos-1015-support-has-ended}
+### macOS 10.15 のサポート終了 {#macos-1015-support-has-ended}
 
-VS Code `1.97` is the last release that supports macOS 10.15 (macOS Catalina). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
+VS Code `1.97` は macOS 10.15 (macOS Catalina) をサポートする最後のリリースです。追加情報については、[FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) を参照してください。
 
-### Dev-time tracking of leaked disposables {#dev-time-tracking-of-leaked-disposables}
+### リークされたディスポーザブルの開発時追跡 {#dev-time-tracking-of-leaked-disposables}
 
-VS Code uses the disposable pattern for explicit resource management, for example to close files, clean up DOM elements, or remove event listeners. Not disposing of resources means memory is wasted and memory usage accumulates over time.
+VS Code は、ファイルを閉じる、DOM 要素をクリーンアップする、イベントリスナーを削除するなどの明示的なリソース管理のためにディスポーザブルパターンを使用します。リソースを破棄しないと、メモリが無駄になり、時間とともにメモリ使用量が蓄積されます。
 
-We are constantly on the hunt for such leaks and have added another tool for detecting this. We utilize the [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) API as it informs us when an object has been garbage collected. If such an object represented a `disposable`, which has not been disposed of, this means we have a leak. These are collected and shown to the developers of VS Code, so that we can clean things up as we go.
+私たちは常にこのようなリークを追跡しており、これを検出するための新しいツールを追加しました。[`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry) API を利用して、オブジェクトがガベージコレクトされたときに通知を受け取ります。このようなオブジェクトが破棄されていないディスポーザブルを表している場合、これはリークを意味します。これらは収集され、VS Code の開発者に表示されるため、進行中にクリーンアップできます。
 
-## Notable fixes {#notable-fixes}
+## 注目の修正 {#notable-fixes}
 
-## Thank you {#thank-you}
+## ありがとう {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆さんに大きな _**ありがとう**_ を伝えたいと思います。
 
-### Issue tracking {#issue-tracking}
+### 問題追跡 {#issue-tracking}
 
-Contributions to our issue tracking:
+問題追跡への貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 
-### Pull requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
 * [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Diff selection indicator line should use menu.separatorBackground instead of menu.border [PR #228825](https://github.com/microsoft/vscode/pull/228825)
 * [@bchu1 (Bryan Chu)](https://github.com/bchu1): Fix to header misplacement in minimap [PR #217581](https://github.com/microsoft/vscode/pull/217581)
@@ -725,24 +724,24 @@ Contributions to `vscode`:
   * Add node as npm script runner (2nd) [PR #240527](https://github.com/microsoft/vscode/pull/240527)
 * [@zardoy (Vitaly)](https://github.com/zardoy): [Git] Migrate to git autostash when pulling for better performance [PR #187850](https://github.com/microsoft/vscode/pull/187850)
 
-Contributions to `vscode-css-languageservice`:
+`vscode-css-languageservice` への貢献:
 
 * [@GauravB159 (Gaurav Bhagchandani)](https://github.com/GauravB159): lab() and lch() color previews added [PR #306](https://github.com/microsoft/vscode-css-languageservice/pull/306)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献:
 
 * [@edemaine (Erik Demaine)](https://github.com/edemaine): Probing support for Civet [PR #1965](https://github.com/microsoft/vscode-eslint/pull/1965)
 * [@mustevenplay (mustevenplay)](https://github.com/mustevenplay): Add Typescript configuration files detection [PR #1968](https://github.com/microsoft/vscode-eslint/pull/1968)
 
-Contributions to `vscode-hexeditor`:
+`vscode-hexeditor` への貢献:
 
 * [@tomilho (Tomás Silva)](https://github.com/tomilho): Moved Hex Compare Selected below Compare Selected [PR #561](https://github.com/microsoft/vscode-hexeditor/pull/561)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献:
 
 * [@thesuperzapper (Mathew Wicks)](https://github.com/thesuperzapper): Fix reading `JUPYTER_RUNTIME_DIR` and `XDG_RUNTIME_DIR` [PR #16451](https://github.com/microsoft/vscode-jupyter/pull/16451)
 
-Contributions to `vscode-languageserver-node`:
+`vscode-languageserver-node` への貢献:
 
 * [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs)
   * Add capability information to the metamodel [PR #1591](https://github.com/microsoft/vscode-languageserver-node/pull/1591)
@@ -751,7 +750,7 @@ Contributions to `vscode-languageserver-node`:
 * [@mciccale (Marco Ciccalè Baztán)](https://github.com/mciccale): minor typo semaphore.ts [PR #1618](https://github.com/microsoft/vscode-languageserver-node/pull/1618)
 * [@yf-yang](https://github.com/yf-yang): fix: avoid dispose unmatched handlers [PR #1614](https://github.com/microsoft/vscode-languageserver-node/pull/1614)
 
-Contributions to `vscode-mypy`:
+`vscode-mypy` への貢献:
 
 * [@DetachHead](https://github.com/DetachHead)
   * use correct capitalization of file paths to work around mypy issue [PR #342](https://github.com/microsoft/vscode-mypy/pull/342)
@@ -759,20 +758,20 @@ Contributions to `vscode-mypy`:
 * [@hamirmahal (Hamir Mahal)](https://github.com/hamirmahal): fix: usage of `node12 which is deprecated` in CI [PR #336](https://github.com/microsoft/vscode-mypy/pull/336)
 * [@ivirabyan (Ivan Virabyan)](https://github.com/ivirabyan): Add dmypy status file setting [PR #347](https://github.com/microsoft/vscode-mypy/pull/347)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
 * [@christianvuerings (Christian Vuerings)](https://github.com/christianvuerings): Fix Copy GitHub Permalink with custom SSH [PR #6669](https://github.com/microsoft/vscode-pull-request-github/pull/6669)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
 * [@TCPsoftware (tcpsoft)](https://github.com/TCPsoftware): Make "args": "${command:pickArgs}" as default debug configuration [PR #548](https://github.com/microsoft/vscode-python-debugger/pull/548)
 
-Contributions to `vscode-vsce`:
+`vscode-vsce` への貢献:
 
 * [@mohankumarelec (mohanram)](https://github.com/mohankumarelec): Updated the semver comparison [PR #1078](https://github.com/microsoft/vscode-vsce/pull/1078)
 * [@stevedlawrence (Steve Lawrence)](https://github.com/stevedlawrence): Allow for reproducible .vsix packages [PR #1100](https://github.com/microsoft/vscode-vsce/pull/1100)
 
-Contributions to `debug-adapter-protocol`:
+`debug-adapter-protocol` への貢献:
 
 * [@angelozerr (Angelo)](https://github.com/angelozerr): Add IntelliJ / LSP4IJ DAP support [PR #529](https://github.com/microsoft/debug-adapter-protocol/pull/529)
 * [@samisalreadytaken](https://github.com/samisalreadytaken): Add Squirrel Debugger to adapters.md [PR #530](https://github.com/microsoft/debug-adapter-protocol/pull/530)
@@ -780,7 +779,7 @@ Contributions to `debug-adapter-protocol`:
 * [@sssooonnnggg (Song)](https://github.com/sssooonnnggg): chore: add luau debugger [PR #516](https://github.com/microsoft/debug-adapter-protocol/pull/516)
 * [@theIDinside (Simon Farre)](https://github.com/theIDinside): Add Midas to Debug Adapter list, w/ VSCode [PR #528](https://github.com/microsoft/debug-adapter-protocol/pull/528)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
 * [@ind1go (Ben Cox)](https://github.com/ind1go): Typo in workspace diagnostics [PR #2086](https://github.com/microsoft/language-server-protocol/pull/2086)
 * [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs)
@@ -791,7 +790,7 @@ Contributions to `language-server-protocol`:
 * [@the-mikedavis (Michael Davis)](https://github.com/the-mikedavis): Clarify that `$0` should not use any other snippet syntax [PR #2087](https://github.com/microsoft/language-server-protocol/pull/2087)
 * [@yassun7010 (yassun7010)](https://github.com/yassun7010): add Tombi to LSP list. [PR #2089](https://github.com/microsoft/language-server-protocol/pull/2089)
 
-Contributions to `python-environment-tools`:
+`python-environment-tools` への貢献:
 
 * [@pantheraleo-7](https://github.com/pantheraleo-7): Add support for detecting `$VIRTUAL_ENV` [PR #181](https://github.com/microsoft/python-environment-tools/pull/181)
 


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/09d5583761e3e0ec3bd76e683033513bdf282fde

For future reference ...

1. Checkout original file (CLI command)
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```