### PR TITLE
Translate March 2025 (version 1.99)

### DIFF
--- a/docs/release-notes/v1_99.md
+++ b/docs/release-notes/v1_99.md
@@ -1,586 +1,586 @@
 ---
 Order: 108
-TOCTitle: March 2025
-PageTitle: Visual Studio Code March 2025
-MetaDescription: Learn what is new in the Visual Studio Code March 2025 Release (1.99)
+TOCTitle: 2025 年 3 月
+PageTitle: Visual Studio Code 2025 年 3 月リリース
+MetaDescription: Visual Studio Code 2025 年 3 月リリース (1.99) の新機能をご紹介します。
 MetaSocialImage: 1_99/release-highlights.png
 Date: 2025-04-03
 DownloadVersion: 1.99.0
 ---
-# March 2025 (version 1.99) {#march-2025}
+# 2025 年 3 月 (バージョン 1.99) {#march-2025}
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the March 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2025 年 3 月リリースへようこそ。このバージョンでは多くのアップデートがあり、きっと気に入っていただけると思います。主なハイライトは次のとおりです。
 
-* **Agent mode**
-  * Agent mode is available in VS Code Stable. Enable it by setting `setting(chat.agent.enabled:true)` ([more...](#agent-mode-is-available-in-vs-code-stable)).
-  * Extend agent mode with Model Context Protocol (MCP) server tools ([more...](#model-context-protocol-server-support)).
-  * Try the new built-in tools in agent mode for fetching web content, finding symbol references, and deep thinking ([more...](#agent-mode-tools)).
+* **エージェント モード**
+  * エージェント モードが VS Code Stable で利用可能になりました。`setting(chat.agent.enabled:true)` を設定して有効にします ([詳細...](#agent-mode-is-available-in-vs-code-stable))。
+  * Model Context Protocol (MCP) サーバー ツールでエージェント モードを拡張します ([詳細...](#model-context-protocol-server-support))。
+  * Web コンテンツの取得、シンボル リファレンスの検索、および深い思考のためのエージェント モードの新しい組み込みツールをお試しください ([詳細...](#agent-mode-tools))。
 
-* **Code editing**
-  * Next Edit Suggestions is now generally available ([more...](#next-edit-suggestions-general-availability)).
-  * Benefit from fewer distractions such as diagnostics events while AI edits are applied in the editor ([more...](#ai-edits-improvements)).
+* **コード編集**
+  * Next Edit Suggestions が一般提供になりました ([詳細...](#next-edit-suggestions-general-availability))。
+  * エディターで AI 編集が適用されている間、診断イベントなどの気を散らすものを減らすことができます ([詳細...](#ai-edits-improvements))。
 
-* **Chat**
-  * Use your own API keys to access more language models in chat (preview) ([more...](#bring-your-own-key-byok-preview)).
-  * Easily switch between ask, edit, and agent mode from the unified chat experience ([more...](#unified-chat-experience)).
-  * Experience improved workspace search speed and accuracy with instant remote workspace indexing ([more...](#faster-workspace-searches-with-instant-indexing)).
+* **チャット**
+  * 独自の API キーを使用して、チャットでより多くの言語モデルにアクセスできます (プレビュー) ([詳細...](#bring-your-own-key-byok-preview))。
+  * 統合されたチャット エクスペリエンスから、ask、edit、およびエージェント モードを簡単に切り替えることができます ([詳細...](#unified-chat-experience))。
+  * インスタント リモート ワークスペース インデックス作成により、ワークスペースの検索速度と精度が向上しました ([詳細...](#faster-workspace-searches-with-instant-indexing))。
 
-* **Notebook editing**
-  * Create and edit notebooks as easily as code files with support for edit and agent mode ([more...](#ai-notebook-editing-improvements)).
+* **ノートブック編集**
+  * 編集およびエージェント モードのサポートにより、コード ファイルと同じくらい簡単にノートブックを作成および編集できます ([詳細...](#ai-notebook-editing-improvements))。
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+> これらのリリース ノートをオンラインで読むには、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** 新機能をいち早く試したいですか？ nightly [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新のアップデートをいち早くお試しください。
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Agent mode is available in VS Code Stable {#agent-mode-is-available-in-vs-code-stable}
+### エージェント モードが VS Code Stable で利用可能になりました {#agent-mode-is-available-in-vs-code-stable}
 
-**Setting**: `setting(chat.agent.enabled:true)`
+**設定:** `setting(chat.agent.enabled:true)`
 
-We're happy to announce that agent mode is available in VS Code Stable! Enable it by setting `setting(chat.agent.enabled:true)`. Enabling the setting will no longer be needed in the following weeks, as we roll out enablement by default to all users.
+エージェント モードが VS Code Stable で利用可能になったことをお知らせします。`setting(chat.agent.enabled:true)` を設定して有効にします。デフォルトですべてのユーザーに有効にするロールアウトを行うため、数週間後には設定を有効にする必要はなくなります。
 
-Check out the [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) or select agent mode from the chat mode picker in the Chat view.
+[エージェント モードのドキュメント](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)を確認するか、チャット ビューのチャット モード ピッカーからエージェント モードを選択してください。
 
-![Screenshot that shows the Chat view, highlighting agent mode selected in the chat mode picker.](https://code.visualstudio.com/assets/updates/1_99/copilot-edits-agent-mode.png)
+![チャット ビューを示すスクリーンショット。チャット モード ピッカーでエージェント モードが選択されていることが強調表示されています。](https://code.visualstudio.com/assets/updates/1_99/copilot-edits-agent-mode.png)
 
-### Model Context Protocol server support {#model-context-protocol-server-support}
+### Model Context Protocol サーバーのサポート {#model-context-protocol-server-support}
 
-This release supports [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) servers in agent mode. MCP offers a standardized method for AI models to discover and interact with external tools, applications, and data sources. When you input a chat prompt using agent mode in VS Code, the model can invoke various tools to perform tasks such as file operations, accessing databases, or retrieving web data. This integration enables more dynamic and context-aware coding assistance.
+このリリースでは、エージェント モードで [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) サーバーがサポートされています。MCP は、AI モデルが外部ツール、アプリケーション、およびデータ ソースを検出して対話するための標準化された方法を提供します。VS Code でエージェント モードを使用してチャット プロンプトを入力すると、モデルはさまざまなツールを呼び出して、ファイル操作、データベースへのアクセス、Web データの取得などのタスクを実行できます。この統合により、より動的でコンテキストを認識したコーディング支援が可能になります。
 
-MCP servers can be configured under the `mcp` section in your user, remote, or `.code-workspace` settings, or in `.vscode/mcp.json` in your workspace. The configuration supports input variables to avoid hard-coding secrets and constants. For example, you can use `${env:API_KEY}` to reference an environment variable or `${input:ENDPOINT}` to prompt for a value when the server is started.
+MCP サーバーは、ユーザー、リモート、または `.code-workspace` 設定の `mcp` セクション、またはワークスペースの `.vscode/mcp.json` で構成できます。この構成では、シークレットと定数をハードコーディングしないように入力変数がサポートされています。たとえば、`${env:API_KEY}` を使用して環境変数を参照したり、`${input:ENDPOINT}` を使用してサーバーの起動時に値を要求したりできます。
 
-You can use the **MCP: Add Server** command to quickly set up an MCP server from a command line invocation, or use an AI-assisted setup from an MCP server published to Docker, npm, or PyPI.
+**MCP: サーバーの追加** コマンドを使用すると、コマンド ライン呼び出しから MCP サーバーをすばやくセットアップしたり、Docker、npm、または PyPI に公開された MCP サーバーから AI 支援セットアップを使用したりできます。
 
-When a new MCP server is added, a refresh action is shown in the Chat view, which can be used to start the server and discover the tools. Afterwards, servers are started on-demand to save resources.
+新しい MCP サーバーが追加されると、チャット ビューに更新アクションが表示されます。これを使用してサーバーを起動し、ツールを検出できます。その後、リソースを節約するためにサーバーはオンデマンドで起動されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/mcp.mp4" title="Video that shows using a Github MCP tool in chat." autoplay loop controls muted></video>
-_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+<video src="https://code.visualstudio.com/assets/updates/1_99/mcp.mp4" title="チャットで Github MCP ツールを使用するビデオ" autoplay loop controls muted></video>
+_テーマ: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) ([vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong) でプレビュー)_
 
-If you've already been using MCP servers in other applications such as Claude Desktop, VS Code will discover them and offer to run them for you. This behavior can be toggled with the setting `setting(chat.mcp.discovery.enabled)`.
+Claude Desktop などの他のアプリケーションで MCP サーバーを既に使用している場合、VS Code はそれらを検出し、実行するように提案します。この動作は、`setting(chat.mcp.discovery.enabled)` 設定で切り替えることができます。
 
-You can see the list of MCP servers and their current status using the **MCP: List Servers** command, and pick the tools available for use in chat by using the **Select Tools** button in agent mode.
+**MCP: サーバーの一覧表示** コマンドを使用して MCP サーバーの一覧とその現在のステータスを表示したり、エージェント モードの **ツールの選択** ボタンを使用してチャットで使用できるツールを選択したりできます。
 
-You can read more about how to install and use MCP servers in [our documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+MCP サーバーのインストール方法と使用方法の詳細については、[ドキュメント](https://code.visualstudio.com/docs/copilot/chat/mcp-servers)を参照してください。
 
-### Agent mode tools {#agent-mode-tools}
+### エージェント モード ツール {#agent-mode-tools}
 
-This milestone, we have added several new built-in tools to agent mode.
+このマイルストーンでは、いくつかの新しい組み込みツールをエージェント モードに追加しました。
 
-#### Thinking tool (Experimental) {#thinking-tool-experimental}
+#### 思考ツール (試験的) {#thinking-tool-experimental}
 
-**Setting**: `setting(github.copilot.chat.agent.thinkingTool:true)`.
+**設定:** `setting(github.copilot.chat.agent.thinkingTool:true)`。
 
-Inspired by [Anthropic's research](https://www.anthropic.com/engineering/claude-think-tool), we've added support for a thinking tool in agent mode that can be used to give any model the opportunity to think between tool calls. This improves our agent's performance on complex tasks in-product and on the [SWE-bench](https://www.swebench.com/) eval.
+[Anthropic の調査](https://www.anthropic.com/engineering/claude-think-tool) に触発されて、ツール呼び出しの間にモデルに思考の機会を与えるために使用できるエージェント モードの思考ツールのサポートを追加しました。これにより、製品内および [SWE-bench](https://www.swebench.com/) eval での複雑なタスクに対するエージェントのパフォーマンスが向上します。
 
-#### Fetch tool {#fetch-tool}
+#### Fetch ツール {#fetch-tool}
 
-Use the `#fetch` tool for including content from a publicly accessible webpage in your prompt. For instance, if you wanted to include the latest documentation on a topic like [MCP](#model-context-protocol-server-support), you can ask to fetch [the full documentation](https://modelcontextprotocol.io/llms-full.txt) (which is conveniently ready for an LLM to consume) and use that in a prompt. Here's a video of what that might look like:
+プロンプトにパブリックにアクセス可能な Web ページからのコンテンツを含めるには、`#fetch` ツールを使用します。たとえば、[MCP](#model-context-protocol-server-support) のようなトピックに関する最新のドキュメントを含める場合は、[完全なドキュメント](https://modelcontextprotocol.io/llms-full.txt) (LLM が使用できるように便利に準備されています) をフェッチして、プロンプトで使用するように要求できます。その様子を次のビデオで示します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/fetch.mp4" title="Video that shows using the fetch tool to fetch the model context protocol documentation." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/fetch.mp4" title="モデル コンテキスト プロトコル ドキュメントをフェッチするために fetch ツールを使用するビデオ" autoplay loop controls muted></video>
 
-In agent mode, this tool is picked up automatically but you can also reference it explicitly in the other modes via `#fetch`, along with the URL you are looking to fetch.
+エージェント モードでは、このツールは自動的に選択されますが、フェッチする URL とともに `#fetch` を介して他のモードで明示的に参照することもできます。
 
-This tool works by rendering the webpage in a headless browser window in which the data of that page is cached locally, so you can freely ask the model to fetch the contents over and over again without the overhead of re-rendering.
+このツールは、Web ページをヘッドレス ブラウザー ウィンドウでレンダリングすることによって機能します。このウィンドウでは、そのページのデータがローカルにキャッシュされるため、再レンダリングのオーバーヘッドなしに、モデルにコンテンツを何度もフェッチするように自由に要求できます。
 
-Let us know how you use the `#fetch` tool, and what features you'd like to see from it!
+`#fetch` ツールをどのように使用しているか、およびどのような機能が必要かをお知らせください。
 
-**Fetch tool limitations:**
+**Fetch ツールの制限事項:**
 
-* Currently, JavaScript is disabled in this browser window. The tool will not be able to acquire much context if the website depends entirely on JavaScript to render content. This is a limitation we are considering changing and likely will change to allow JavaScript.
-* Due to the headless nature, we are unable to fetch pages that are behind authentication, as this headless browser exists in a different browser context than the browser you use. Instead, consider using [MCP](#model-context-protocol-server-support) to bring in an MCP server that is purpose-built for that target, or a generic browser MCP server such as the [Playwright MCP server](https://github.com/microsoft/playwright-mcp).
+* 現在、このブラウザー ウィンドウでは JavaScript が無効になっています。Web サイトがコンテンツのレンダリングを完全に JavaScript に依存している場合、ツールは多くのコンテキストを取得できません。これは変更を検討している制限事項であり、JavaScript を許可するように変更される可能性があります。
+* ヘッドレスな性質のため、認証が必要なページをフェッチすることはできません。これは、このヘッドレス ブラウザーが使用するブラウザーとは異なるブラウザー コンテキストに存在するためです。代わりに、[MCP](#model-context-protocol-server-support) を使用して、そのターゲット用に特別に構築された MCP サーバー、または [Playwright MCP サーバー](https://github.com/microsoft/playwright-mcp) などの汎用ブラウザー MCP サーバーを導入することを検討してください。
 
-#### Usages tool {#usages-tool}
+#### Usages ツール {#usages-tool}
 
-The `#usages` tool is a combination of "Find All References", "Find Implementation", and "Go to Definition". This tool can help chat to learn more about a function, class, or interface. For instance, chat can use this tool to look for sample implementations of an interface or to find all places that need to be changed when making a refactoring.
+`#usages` ツールは、"すべての参照を検索"、"実装の検索"、および "定義へ移動" の組み合わせです。このツールは、チャットが関数、クラス、またはインターフェイスについて詳しく知るのに役立ちます。たとえば、チャットはこのツールを使用して、インターフェイスのサンプル実装を探したり、リファクタリングを行うときに変更する必要があるすべての場所を見つけたりできます。
 
-In agent mode this tool will be picked up automatically but you can also reference it explicitly via `#usages`
+エージェント モードでは、このツールは自動的に選択されますが、`#usages` を介して明示的に参照することもできます。
 
-### Create a new workspace with agent mode (Experimental) {#create-a-new-workspace-with-agent-mode-experimental}
+### エージェント モードで新しいワークスペースを作成する (試験的) {#create-a-new-workspace-with-agent-mode-experimental}
 
-**Setting**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
+**設定:** `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
 
-You can now scaffold a new VS Code workspace in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode). Whether you’re setting up a VS Code extension, an MCP server, or other development environments, agent mode helps you to initialize, configure, and launch these projects with the necessary dependencies and settings.
+[エージェント モード](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) で新しい VS Code ワークスペースをスキャフォールドできるようになりました。VS Code 拡張機能、MCP サーバー、またはその他の開発環境をセットアップする場合でも、エージェント モードは、必要な依存関係と設定を使用してこれらのプロジェクトを初期化、構成、および起動するのに役立ちます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/new-workspace-demo.mp4" title="Video showing creation of a new MCP server to fetch top N stories from hacker news using Agent mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/new-workspace-demo.mp4" title="エージェント モードを使用してハッカー ニュースから上位 N 件の記事をフェッチする新しい MCP サーバーの作成を示すビデオ" autoplay loop controls muted></video>
 
-### VS Code extension tools in agent mode {#vs-code-extension-tools-in-agent-mode}
+### エージェント モードの VS Code 拡張機能ツール {#vs-code-extension-tools-in-agent-mode}
 
-Several months ago, we finalized our extension API for [language model tools](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) contributed by VS Code extensions. Now, you can use these tools in agent mode.
+数か月前、VS Code 拡張機能によって提供される [言語モデル ツール](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) の拡張機能 API を完成させました。これで、これらのツールをエージェント モードで使用できます。
 
-Any tool contributed to this API which sets `toolReferenceName` and `canBeReferencedInPrompt` in its configuration is automatically available in agent mode.
+構成で `toolReferenceName` および `canBeReferencedInPrompt` を設定するこの API に提供されるツールは、エージェント モードで自動的に使用できます。
 
-By contributing a tool in an extension, it has access to the full VS Code extension APIs, and can be easily installed via the Extension Marketplace.
+拡張機能でツールを提供することにより、完全な VS Code 拡張機能 API にアクセスでき、拡張機能マーケットプレースから簡単にインストールできます。
 
-Similar to tools from MCP servers, you can enable and disable these with the **Select Tools** button in agent mode. See our [language model tools extension guide](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) to build your own!
+MCP サーバーからのツールと同様に、エージェント モードの **ツールの選択** ボタンを使用してこれらを有効または無効にできます。独自のツールを構築するには、[言語モデル ツール拡張機能ガイド](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) を参照してください。
 
-### Agent mode tool approvals {#agent-mode-tool-approvals}
+### エージェント モード ツールの承認 {#agent-mode-tool-approvals}
 
-As part of completing the tasks for a user prompt, agent mode can run tools and terminal commands. This is powerful but potentially comes with risks. Therefore, you need to approve the use of tools and terminal commands in agent mode.
+ユーザー プロンプトのタスクを完了する一環として、エージェント モードはツールとターミナル コマンドを実行できます。これは強力ですが、潜在的なリスクが伴う可能性があります。したがって、エージェント モードでのツールとターミナル コマンドの使用を承認する必要があります。
 
-To optimize this experience, you can now remember that approval on a session, workspace, or application level. This is not currently enabled for the terminal tool, but we plan to develop an approval system for the terminal in future releases.
+このエクスペリエンスを最適化するために、セッション、ワークスペース、またはアプリケーション レベルでその承認を記憶できるようになりました。これは現在ターミナル ツールでは有効になっていませんが、今後のリリースでターミナルの承認システムを開発する予定です。
 
-![Screenshot that shows the agent mode tool Continue button dropdown options for remembering approval.](https://code.visualstudio.com/assets/updates/1_99/chat-tool-approval.png)
+![承認を記憶するためのエージェント モード ツール [続行] ボタンのドロップダウン オプションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/chat-tool-approval.png)
 
-In case you want to auto-approve _all_ tools, you can now use the experimental `setting(chat.tools.autoApprove:true)` setting. This will auto-approve all tools, and VS Code will not ask for confirmation when a language model wishes to run tools. Bear in mind that with this setting enabled, you will not have the opportunity to cancel potentially destructive actions a model wants to take.
+_すべての_ ツールを自動承認する場合は、試験的な `setting(chat.tools.autoApprove:true)` 設定を使用できるようになりました。これにより、すべてのツールが自動承認され、言語モデルがツールを実行したいときに VS Code は確認を求めません。この設定を有効にすると、モデルが実行しようとしている潜在的に破壊的なアクションをキャンセルする機会がなくなることに注意してください。
 
-We plan to expand this setting with more granular capabilities in the future.
+今後、この設定をより詳細な機能で拡張する予定です。
 
-### Agent evaluation on SWE-bench {#agent-evaluation-on-swe-bench}
+### SWE-bench でのエージェントの評価 {#agent-evaluation-on-swe-bench}
 
-VS Code's agent achieves a pass rate of 56.0% on `swebench-verified` with Claude 3.7 Sonnet, following Anthropic's [research](https://www.anthropic.com/engineering/swe-bench-sonnet) on configuring agents to execute without user input in the SWE-bench environment. Our experiments have translated into shipping improved prompts, tool descriptions and tool design for agent mode, including new tools for file edits that are in-distribution for Claude 3.5 and 3.7 Sonnet models.
+VS Code のエージェントは、Claude 3.7 Sonnet で `swebench-verified` で 56.0% の合格率を達成しています。これは、SWE-bench 環境でユーザー入力を必要とせずに実行するようにエージェントを構成することに関する Anthropic の [調査](https://www.anthropic.com/engineering/swe-bench-sonnet) に基づいています。私たちの実験は、Claude 3.5 および 3.7 Sonnet モデルの配信に含まれるファイル編集用の新しいツールを含む、エージェント モードの改善されたプロンプト、ツールの説明、およびツールの設計の出荷につながりました。
 
-### Unified Chat view {#unified-chat-view}
+### 統合されたチャット ビュー {#unified-chat-view}
 
-For the past several months, we've had a "Chat" view for asking questions to the language model, and a "Copilot Edits" view for an AI-powered code editing session. This month, we aim to streamline the chat-based experience by merging the two views into one Chat view. In the Chat view, you'll see a dropdown with three modes:
+過去数か月間、言語モデルに質問するための "チャット" ビューと、AI を利用したコード編集セッション用の "Copilot Edits" ビューがありました。今月は、2 つのビューを 1 つのチャット ビューに統合して、チャットベースのエクスペリエンスを合理化することを目指しています。チャット ビューには、3 つのモードのドロップダウンが表示されます。
 
-![Screenshot that shows the chat mode picker in the Chat view.](https://code.visualstudio.com/assets/updates/1_99/chat-modes.png)
+![チャット ビューのチャット モード ピッカーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/chat-modes.png)
 
-- **[Ask](https://code.visualstudio.com/docs/copilot/chat/chat-ask-mode)**: This is the same as the previous Chat view. Ask questions about your workspace or coding in general, using any model. Use `@` to invoke built-in chat participants or from installed [extensions](https://marketplace.visualstudio.com/search?term=chat-participant&target=VSCode&category=All%20categories&sortBy=Relevance). Use `#` to attach any kind of context manually.
-- **[Agent](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)**: Start an agentic coding flow with a set of tools that let it autonomously collect context, run terminal commands, or take other actions to complete a task. Agent mode is enabled for all [VS Code Insiders](https://code.visualstudio.com/insiders/) users, and we are rolling it out to more and more users in VS Code Stable.
-- **[Edit](https://code.visualstudio.com/docs/copilot/chat/copilot-edits)**: In Edit mode, the model can make directed edits to multiple files. Attach `#codebase` to let it find the files to edit automatically. But it won't run terminal commands or do anything else automatically.
+- **[Ask](https://code.visualstudio.com/docs/copilot/chat/chat-ask-mode)**: これは以前のチャット ビューと同じです。ワークスペースまたは一般的なコーディングについて、任意のモデルを使用して質問します。`@` を使用して、組み込みのチャット参加者またはインストールされている [拡張機能](https://marketplace.visualstudio.com/search?term=chat-participant&target=VSCode&category=All%20categories&sortBy=Relevance) から呼び出します。`#` を使用して、任意の種類のコンテキストを手動で添付します。
+- **[Agent](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)**: コンテキストを自律的に収集し、ターミナル コマンドを実行したり、タスクを完了するために他のアクションを実行したりできる一連のツールを使用して、エージェント コーディング フローを開始します。エージェント モードは、すべての [VS Code Insiders](https://code.visualstudio.com/insiders/) ユーザーに対して有効になっており、VS Code Stable でますます多くのユーザーにロールアウトしています。
+- **[Edit](https://code.visualstudio.com/docs/copilot/chat/copilot-edits)**: Edit モードでは、モデルは複数のファイルに対して指示された編集を行うことができます。編集するファイルを自動的に見つけるには、`#codebase` を添付します。ただし、ターミナル コマンドを実行したり、他のことを自動的に実行したりすることはありません。
 
-> **Note**: If you don't see agent mode in this list, then either it has not yet been enabled for you, or it's disabled by organization policy and needs to be enabled by the [organization owner](https://aka.ms/github-copilot-org-enable-features).
+> **注**: この一覧にエージェント モードが表示されない場合は、まだ有効になっていないか、組織のポリシーによって無効になっているため、[組織の所有者](https://aka.ms/github-copilot-org-enable-features) が有効にする必要があります。
 
-Besides making your chat experience simpler, this unification enables a few new features for AI-powered code editing:
+チャット エクスペリエンスを簡素化することに加えて、この統合により、AI を利用したコード編集のいくつかの新機能が有効になります。
 
-- **Switch modes in the middle of a conversation**: For example, you might start brainstorming an app idea in ask mode, then switch to agent mode to execute the plan. Tip: press `kb(workbench.action.chat.toggleAgentMode)` to change modes quickly.
-- **Edit sessions in history**: Use the **Show Chats** command (clock icon at the top of the Chat view) to restore past edit sessions and keep working on them.
-- **Move chat to editor or window**: Select **Open Chat in New Editor/New Window** to pop out your chat conversation from the side bar into a new editor tab or separate VS Code window. Chat has supported this for a long time, but now you can run your edit/agent sessions from an editor pane or a separate window as well.
-- **Multiple agent sessions**: Following from the above point, this means that you can even run multiple agent sessions at the same time. You might like to have one chat in agent mode working on implementing a feature, and another independent session for doing research and using other tools. Directing two agent sessions to edit files at the same time is not recommended, it can lead to confusion.
+- **会話の途中でモードを切り替える**: たとえば、ask モードでアプリのアイデアをブレインストーミングしてから、エージェント モードに切り替えて計画を実行することができます。ヒント: `kb(workbench.action.chat.toggleAgentMode)` を押すと、モードをすばやく変更できます。
+- **履歴内の編集セッション**: **チャットの表示** コマンド (チャット ビューの上部にある時計アイコン) を使用して、過去の編集セッションを復元し、作業を続けることができます。
+- **チャットをエディターまたはウィンドウに移動**: **新しいエディター/新しいウィンドウでチャットを開く** を選択して、サイド バーから新しいエディター タブまたは別の VS Code ウィンドウにチャットの会話をポップアウトします。チャットはこれを長い間サポートしてきましたが、エディター ペインまたは別のウィンドウから編集/エージェント セッションを実行することもできます。
+- **複数のエージェント セッション**: 上記の点から、これは複数のエージェント セッションを同時に実行できることも意味します。1 つのチャットをエージェント モードで機能の実装に取り組み、別の独立したセッションを調査や他のツールの使用に使用することができます。2 つのエージェント セッションに同時にファイルの編集を指示することはお勧めしません。混乱を招く可能性があります。
 
-### Bring Your Own Key (BYOK) (Preview) {#bring-your-own-key-byok-preview}
+### Bring Your Own Key (BYOK) (プレビュー) {#bring-your-own-key-byok-preview}
 
-Copilot Pro and Copilot Free users can now bring their own API keys for popular providers such as Azure, Anthropic, Gemini, Open AI, Ollama, and Open Router. This allows you to use new models that are not natively supported by Copilot the very first day that they're released.
+Copilot Pro および Copilot Free ユーザーは、Azure、Anthropic、Gemini、Open AI、Ollama、Open Router などの一般的なプロバイダーの独自の API キーを持ち込むことができるようになりました。これにより、Copilot でネイティブにサポートされていない新しいモデルをリリースされたその日に使用できます。
 
-To try it, select **Manage Models...** from the model picker. We’re actively exploring support for Copilot Business and Enterprise customers and will share updates in future releases. To learn more about this feature, head over to our [docs](https://code.visualstudio.com/docs/copilot/language-models).
+試すには、モデル ピッカーから **モデルの管理...** を選択します。Copilot Business および Enterprise 顧客のサポートを積極的に検討しており、今後のリリースで最新情報をお知らせします。この機能の詳細については、[ドキュメント](https://code.visualstudio.com/docs/copilot/language-models)を参照してください。
 
-![A screenshot of a "Manage Models - Preview" dropdown menu in a user interface. The dropdown has the label "Select a provider" at the top, with a list of options below it. The options include "Anthropic" (highlighted in blue), "Azure," "Gemini," "OpenAI," "Ollama," and "OpenRouter." A gear icon is displayed next to the "Anthropic" option.](https://code.visualstudio.com/assets/updates/1_99/byok.png)
+![ユーザー インターフェイスの "モデルの管理 - プレビュー" ドロップダウン メニューのスクリーンショット。"プロバイダーの選択" というラベルが上部にあり、その下にオプションの一覧があります。オプションには、"Anthropic" (青色で強調表示)、"Azure"、"Gemini"、"OpenAI"、"Ollama"、および "OpenRouter" が含まれています。歯車アイコンが "Anthropic" オプションの横に表示されています。](https://code.visualstudio.com/assets/updates/1_99/byok.png)
 
-### Reusable prompt files {#reusable-prompt-files}
+### 再利用可能なプロンプト ファイル {#reusable-prompt-files}
 
-#### Improved configuration {#improved-configuration}
+#### 構成の改善 {#improved-configuration}
 
-**Setting**: `setting(chat.promptFilesLocations)`
+**設定:** `setting(chat.promptFilesLocations)`
 
-The `setting(chat.promptFilesLocations)` setting now supports glob patterns in file paths. For example, to include all `.prompt.md` files in the currently open workspace, you can set the path to `{ "**": true }`.
+`setting(chat.promptFilesLocations)` 設定で、ファイル パスに glob パターンがサポートされるようになりました。たとえば、現在開いているワークスペース内のすべての `.prompt.md` ファイルを含めるには、パスを `{ "**": true }` に設定します。
 
-Additionally, the configuration now respects case sensitivity on filesystems where it applies, aligning with the behavior of the host operating system.
+さらに、構成は、ホスト オペレーティング システムの動作に合わせて、適用されるファイル システムで大文字と小文字を区別するようになりました。
 
-#### Improved prompt file editing {#improved-prompt-file-editing}
+#### プロンプト ファイルの編集の改善 {#improved-prompt-file-editing}
 
-- Your `.prompt.md` files now offer basic autocompletion for filesystem paths and highlight valid file references. Broken links on the other hand now appear as warning or error squiggles and provide detailed diagnostic information.
-- You can now manage prompts using edit and delete actions in the prompt file list within the **Chat: Use Prompt** command.
-- Folder references in prompt files are no longer flagged as invalid.
-- Markdown comments are now properly handled, for instance, all commented-out links are ignored when generating the final prompt sent to the LLM model.
+- `.prompt.md` ファイルで、ファイル システム パスの基本的なオートコンプリートが提供され、有効なファイル参照が強調表示されるようになりました。一方、壊れたリンクは警告またはエラーの波線として表示され、詳細な診断情報が提供されます。
+- **チャット: プロンプトの使用** コマンド内のプロンプト ファイル リストで、編集および削除アクションを使用してプロンプトを管理できるようになりました。
+- プロンプト ファイル内のフォルダー参照は、無効としてフラグが立てられなくなりました。
+- Markdown コメントが適切に処理されるようになりました。たとえば、LLM モデルに送信される最終的なプロンプトを生成するときに、コメントアウトされたすべてのリンクは無視されます。
 
-#### Alignment with custom instructions {#alignment-with-custom-instructions}
+#### カスタム指示との整合性 {#alignment-with-custom-instructions}
 
-The `.github/copilot-instructions.md` file now behaves like any other reusable `.prompt.md` file, with support for nested link resolution and enhanced language features. Furthermore, any `.prompt.md` file can now be referenced and is handled appropriately.
+`.github/copilot-instructions.md` ファイルは、ネストされたリンク解決と拡張された言語機能をサポートする、他の再利用可能な `.prompt.md` ファイルと同様に動作するようになりました。さらに、`.prompt.md` ファイルは参照できるようになり、適切に処理されます。
 
-Learn more about [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
+[カスタム指示](https://code.visualstudio.com/docs/copilot/copilot-customization) の詳細をご覧ください。
 
-#### User prompts {#user-prompts}
+#### ユーザー プロンプト {#user-prompts}
 
-The **Create User Prompt** command now allows creating a new type of prompts called _user prompts_. These are stored in the user data folder and can be synchronized across machines, similar to code snippets or user settings. The synchronization can be configured in [Sync Settings](https://code.visualstudio.com/docs/configure/settings-sync) by using the **Prompts** item in the synchronization resources list.
+**ユーザー プロンプトの作成** コマンドで、_ユーザー プロンプト_ と呼ばれる新しい種類のプロンプトを作成できるようになりました。これらはユーザー データ フォルダーに保存され、コード スニペットやユーザー設定と同様に、マシン間で同期できます。同期は、同期リソース リストの **プロンプト** 項目を使用して、[設定の同期](https://code.visualstudio.com/docs/configure/settings-sync) で構成できます。
 
-### Improved vision support (Preview) {#improved-vision-support-preview}
+### 改善されたビジョン サポート (プレビュー) {#improved-vision-support-preview}
 
-Last iteration, Copilot Vision was enabled for `GPT-4o`. Check our [release notes](https://code.visualstudio.com/updates/v1_98#_copilot-vision-preview) to learn more about how you can attach and use images in chat.
+前回のイテレーションでは、Copilot Vision が `GPT-4o` で有効になりました。チャットで画像を添付して使用する方法の詳細については、[リリース ノート](https://code.visualstudio.com/updates/v1_98#_copilot-vision-preview) を確認してください。
 
-This release, you can attach images from any browser via drag and drop. Images drag and dropped from browsers must have the correct url extension, with `.jpg`, `.png`, `.gif`, `.webp`, or `.bmp`.
+このリリースでは、ドラッグ アンド ドロップで任意のブラウザーから画像を添付できます。ブラウザーからドラッグ アンド ドロップされた画像には、`.jpg`、`.png`、`.gif`、`.webp`、または `.bmp` の正しい URL 拡張子が必要です。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/image-url-dnd.mp4" title="Video that shows an image from Chrome being dragged into the chat panel." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/image-url-dnd.mp4" title="Chrome からチャット パネルに画像をドラッグする様子を示すビデオ" autoplay loop controls muted></video>
 
-## Configure the editor {#configure-the-editor}
+## エディターの構成 {#configure-the-editor}
 
-### Unified chat experience {#unified-chat-experience}
+### 統合されたチャット エクスペリエンス {#unified-chat-experience}
 
-We have streamlined the chat experience in VS Code into a single unified Chat view. Instead of having to move between separate views and lose the context of a conversation, you can now easily switch between the different chat modes.
+VS Code のチャット エクスペリエンスを 1 つの統合されたチャット ビューに合理化しました。個別のビュー間を移動して会話のコンテキストを失う必要はなくなり、さまざまなチャット モードを簡単に切り替えることができるようになりました。
 
-![Screenshot that shows the chat mode picker in the Chat view.](https://code.visualstudio.com/assets/updates/1_99/chat-modes.png)
+![チャット ビューのチャット モード ピッカーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/chat-modes.png)
 
-Depending on your scenario, use either of these modes, and freely move mid-conversation:
+シナリオに応じて、次のいずれかのモードを使用し、会話の途中で自由に移動します。
 
-- Ask mode: optimized for asking questions about your codebase and brainstorming ideas.
-- Edit mode: optimized for making edits across multiple files in your codebase.
-- Agent mode: optimized for an autonomous coding flow, combining code edits and tool invocations.
+- Ask モード: コードベースに関する質問やアイデアのブレインストーミングに最適化されています。
+- Edit モード: コードベース内の複数のファイルにわたって編集を行うのに最適化されています。
+- Agent モード: コード編集とツール呼び出しを組み合わせた自律的なコーディング フローに最適化されています。
 
-Get more details about the [unified chat view](#unified-chat-view).
+[統合されたチャット ビュー](#unified-chat-view) の詳細をご覧ください。
 
-### Faster workspace searches with instant indexing {#faster-workspace-searches-with-instant-indexing}
+### インスタント インデックス作成によるワークスペース検索の高速化 {#faster-workspace-searches-with-instant-indexing}
 
-[Remote workspace indexes](https://code.visualstudio.com/docs/copilot/reference/workspace-context#remote-index) accelerate searching large codebases for relevant code snippets that AI uses while answering questions and generating edits. These remote indexes are especially useful for large codebases with tens or even hundreds of thousands of files.
+[リモート ワークスペース インデックス](https://code.visualstudio.com/docs/copilot/reference/workspace-context#remote-index) は、AI が質問に答えたり編集を生成したりするときに使用する関連するコード スニペットについて、大規模なコードベースの検索を高速化します。これらのリモート インデックスは、数万または数十万ものファイルを含む大規模なコードベースに特に役立ちます。
 
-Previously, you'd have to press a button or run a command to build and start using a remote workspace index. With our new instant indexing support, we now automatically build the remote workspace index when you first try to ask a `#codebase`/`@workspace` question. In most cases, this remote index can be built in a few seconds. Once built, any codebase searches that you or anyone else working with that repo in VS Code makes will automatically use the remote index.
+以前は、リモート ワークスペース インデックスを構築して使用を開始するには、ボタンを押すか、コマンドを実行する必要がありました。新しいインスタント インデックス作成のサポートにより、`#codebase`/`@workspace` の質問を最初に試みるときに、リモート ワークスペース インデックスが自動的に構築されるようになりました。ほとんどの場合、このリモート インデックスは数秒で構築できます。構築されると、あなたまたは VS Code でそのリポジトリを操作する他のユーザーが行うコードベース検索は、自動的にリモート インデックスを使用します。
 
-Keep in mind that remote workspaces indexes are currently only available for code stored on GitHub. To use a remote workspace index, make sure your workspace contains a git project with a GitHub remote. You can use the [Copilot status menu](#copilot-status-menu) to see the type of index currently being used:
+リモート ワークスペース インデックスは現在、GitHub に保存されているコードでのみ使用できることに注意してください。リモート ワークスペース インデックスを使用するには、ワークスペースに GitHub リモートを含む git プロジェクトが含まれていることを確認してください。[Copilot ステータス メニュー](#copilot-status-menu) を使用して、現在使用されているインデックスのタイプを確認できます。
 
-![Screenshot that shows the workspace index status in the Copilot Status Bar menu.](https://code.visualstudio.com/assets/updates/1_99/copilot-workspace-index-remote.png)
+![Copilot ステータス バー メニューのワークスペース インデックスのステータスを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/copilot-workspace-index-remote.png)
 
-To manage load, we are slowly rolling out instant indexing over the next few weeks, so you may not see it right away. You can still run the `GitHub Copilot: Build remote index command` command to start using a remote index when instant indexing is not yet enabled for you.
+負荷を管理するために、今後数週間かけてインスタント インデックス作成を徐々に展開しているため、すぐに表示されない場合があります。インスタント インデックス作成がまだ有効になっていない場合は、`GitHub Copilot: リモート インデックスの構築` コマンドを実行して、リモート インデックスの使用を開始できます。
 
-### Copilot status menu {#copilot-status-menu}
+### Copilot ステータス メニュー {#copilot-status-menu}
 
-The Copilot status menu, accessible from the Status Bar, is now enabled for all users. This milestone we added some new features to it:
+ステータス バーからアクセスできる Copilot ステータス メニューが、すべてのユーザーで有効になりました。このマイルストーンでは、いくつかの新機能が追加されました。
 
-- View [workspace index](https://code.visualstudio.com/docs/copilot/reference/workspace-context) status information at any time.
+- [ワークスペース インデックス](https://code.visualstudio.com/docs/copilot/reference/workspace-context) のステータス情報をいつでも表示します。
 
-    ![Screenshot that shows the workspace index status of a workspace in the Copilot menu.](https://code.visualstudio.com/assets/updates/1_99/copilot-worksspace-index-local-status.png)
+    ![Copilot メニューのワークスペースのワークスペース インデックスのステータスを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/copilot-worksspace-index-local-status.png)
 
-- View if code completions are enabled for the active editor.
+- アクティブなエディターでコード補完が有効になっているかどうかを表示します。
 
-    A new icon reflects the status, so that you can quickly see if code completions are enabled or not.
+    新しいアイコンはステータスを反映するため、コード補完が有効になっているかどうかをすばやく確認できます。
 
-    ![Screenshot that shows the Copilot status icon when completions is disabled.](https://code.visualstudio.com/assets/updates/1_99/copilot-disabled-status.png)
+    ![補完が無効になっている場合の Copilot ステータス アイコンを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/copilot-disabled-status.png)
 
-- Enable or disable [code completions and NES](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
+- [コード補完と NES](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions) を有効または無効にします。
 
-### Out of the box Copilot setup (Experimental) {#out-of-the-box-copilot-setup-experimental}
+### すぐに使える Copilot セットアップ (試験的) {#out-of-the-box-copilot-setup-experimental}
 
-**Setting**: `setting(chat.setupFromDialog)`
+**設定:** `setting(chat.setupFromDialog)`
 
-We are shipping an experimental feature to show functional chat experiences out of the box. This includes the Chat view, editor/terminal inline chat, and quick chat. The first time you send a chat request, we will guide you through signing in and signing up for Copilot Free.
+すぐに使える機能的なチャット エクスペリエンスを表示するための試験的な機能を出荷しています。これには、チャット ビュー、エディター/ターミナルのインライン チャット、およびクイック チャットが含まれます。最初のチャット リクエストを送信すると、Copilot Free へのサインインとサインアップをご案内します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/copilot-ootb.mp4" title="Video that shows Copilot out of the box." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/copilot-ootb.mp4" title="すぐに使える Copilot を示すビデオ" autoplay loop controls muted></video>
 
-If you want to see this experience for yourself, enable the `setting(chat.setupFromDialog)` setting.
+このエクスペリエンスを自分で確認する場合は、`setting(chat.setupFromDialog)` 設定を有効にします。
 
-### Chat prerelease channel mismatch {#chat-prerelease-channel-mismatch}
+### チャット プレリリース チャネルの不一致 {#chat-prerelease-channel-mismatch}
 
-If you have the prerelease version of the Copilot Chat extension installed in VS Code Stable, a new welcome screen will inform you that this configuration is not supported. Due to rapid development of chat features, the extension will not activate in VS Code Stable.
+VS Code Stable に Copilot Chat 拡張機能のプレリリース バージョンがインストールされている場合、この構成はサポートされていないことを通知する新しいウェルカム画面が表示されます。チャット機能の急速な開発により、拡張機能は VS Code Stable でアクティブになりません。
 
-The welcome screen provides options to either switch to the release version of the extension or download [VS Code Insiders](https://code.visualstudio.com/insiders/).
+ウェルカム画面には、拡張機能のリリース バージョンに切り替えるか、[VS Code Insiders](https://code.visualstudio.com/insiders/) をダウンロードするオプションが表示されます。
 
-![Screenshot that shows the welcome view of chat, indicating that the pre-release version of the extension is not supported in VS Code stable. A button is shown to switch to the release version, and a secondary link is shown to switch to VS Code Insiders.](https://code.visualstudio.com/assets/updates/1_99/welcome-pre-release.png)
+![チャットのウェルカム ビューを示すスクリーンショット。拡張機能のプレリリース バージョンが VS Code Stable でサポートされていないことを示しています。リリース バージョンに切り替えるためのボタンと、VS Code Insiders に切り替えるためのセカンダリ リンクが表示されています。](https://code.visualstudio.com/assets/updates/1_99/welcome-pre-release.png)
 
-### Semantic text search improvements (Experimental) {#semantic-text-search-improvements-experimental}
+### セマンティック テキスト検索の改善 (試験的) {#semantic-text-search-improvements-experimental}
 
-**Setting**: `setting(github.copilot.chat.search.semanticTextResults:true)`
+**設定:** `setting(github.copilot.chat.search.semanticTextResults:true)`
 
-AI-powered semantic text search is now enabled by default in the Search view. Use the `kb(search.action.searchWithAI)` keyboard shortcut to trigger a semantic search, which shows you the most relevant results based on your query, on top of the regular search results.
+AI を利用したセマンティック テキスト検索が、検索ビューでデフォルトで有効になりました。`kb(search.action.searchWithAI)` キーボード ショートカットを使用してセマンティック検索をトリガーすると、通常の検索結果に加えて、クエリに基づいて最も関連性の高い結果が表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search.mp4" title="Video that shows semantic search improvements in Visual Studio Code." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search.mp4" title="Visual Studio Code でのセマンティック検索の改善を示すビデオ" autoplay loop controls muted></video>
 
-You can also reference the semantic search results in your chat prompt by using the `#searchResults` tool. This allows you to ask the LLM to summarize or explain the results, or even generate code based on them.
+`#searchResults` ツールを使用して、チャット プロンプトでセマンティック検索結果を参照することもできます。これにより、LLM に結果の要約または説明を求めたり、結果に基づいてコードを生成したりすることもできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search-results.mp4" title="Video that shows using search results in chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search-results.mp4" title="チャット ビューで検索結果を使用する様子を示すビデオ" autoplay loop controls muted></video>
 
-### Settings editor search updates {#settings-editor-search-updates}
+### 設定エディターの検索の更新 {#settings-editor-search-updates}
 
-By default, the Settings editor search now uses the key-matching algorithm we introduced in the previous release. It also shows additional settings even when the settings ID matches exactly with a known setting.
+デフォルトでは、設定エディターの検索で、前のリリースで導入されたキー一致アルゴリズムが使用されるようになりました。また、設定 ID が既知の設定と完全に一致する場合でも、追加の設定が表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/settings-search-show-extra.mp4" title="Video that shows searching for 'files.autoSave' and 'mcp' in the Settings editor, both show more than one setting." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/settings-search-show-extra.mp4" title="設定エディターで 'files.autoSave' と 'mcp' を検索すると、どちらも複数の設定が表示される様子を示すビデオ" autoplay loop controls muted></video>
 
-_Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
+_テーマ: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) ([vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme) でプレビュー)_
 
-### New setting for window controls (Linux, Windows) {#new-setting-for-window-controls-linux-windows}
+### ウィンドウ コントロールの新しい設定 (Linux、Windows) {#new-setting-for-window-controls-linux-windows}
 
-**Setting**: `setting(window.controlsStyle)`
+**設定:** `setting(window.controlsStyle)`
 
-If you have set the title bar style (`setting(window.titleBarStyle)`) to `custom`, you can now choose between three different styles for the window controls.
+タイトル バーのスタイル (`setting(window.titleBarStyle)`) を `custom` に設定している場合は、ウィンドウ コントロールに 3 つの異なるスタイルから選択できるようになりました。
 
-- `native`: this is the default and renders window controls according to the underlying platform
-- `custom`: renders window controls with custom styling if you prefer that over the native one
-- `hidden`: hides window controls entirely if you want to gain some space in the title bar and are a more keyboard-centric user
+- `native`: これはデフォルトであり、基になるプラットフォームに従ってウィンドウ コントロールをレンダリングします。
+- `custom`: ネイティブのものよりもカスタム スタイルの方が好みの場合は、カスタム スタイルでウィンドウ コントロールをレンダリングします。
+- `hidden`: タイトル バーのスペースを少しでも増やしたい場合や、キーボード中心のユーザーの場合は、ウィンドウ コントロールを完全に非表示にします。
 
 ## Code Editing {#code-editing}
 
-### Next Edit Suggestions general availability {#next-edit-suggestions-general-availability}
+### Next Edit Suggestions の一般提供開始 {#next-edit-suggestions-general-availability}
 
-**Setting**: `setting(github.copilot.nextEditSuggestions.enabled:true)`
+**設定:** `setting(github.copilot.nextEditSuggestions.enabled:true)`
 
-We're happy to announce the general availability of Next Edit Suggestions (NES)! In addition, we've also made several improvements to the overall user experience of NES:
+Next Edit Suggestions (NES) の一般提供開始をお知らせします! さらに、NES の全体的なユーザー エクスペリエンスを向上させるために、いくつかの改善も行いました。
 
-* Make edit suggestions more compact, less interfering with surrounding code, and easier to read at a glance.
-* Updates to the gutter indicator to make sure that all suggestions are more easily noticeable.
+* 編集候補をよりコンパクトにし、周囲のコードへの干渉を減らし、一目で読みやすくしました。
+* すべての候補がより見やすくなるように、gutter インジケーターを更新しました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/next-edit-suggestion.mp4" title="Video that shows NES suggesting edits based on the recent changes due by the user." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/next-edit-suggestion.mp4" title="ユーザーによる最近の変更に基づいて、NES が編集候補を提示するビデオ。" autoplay loop controls muted></video>
 
-### AI edits improvements {#ai-edits-improvements}
+### AI 編集の改善 {#ai-edits-improvements}
 
-We have done some smaller tweaks when generating edits with AI:
+AI を使用して編集を生成する際に、いくつかの小さな調整を行いました。
 
-* Mute diagnostics events outside the editor while rewriting a file with AI edits. Previously, we already disabled squiggles in this scenario. These changes reduce flicker in the Problems panel and also ensure that we don't issue requests for the quick fix code actions.
+* AI 編集でファイルを書き換えている間、エディター外の診断イベントをミュートします。以前は、このシナリオではすでに波線を無効にしていました。これらの変更により、[問題] パネルのちらつきが軽減され、クイック修正コード アクションのリクエストが発行されないようになります。
 
-* We now explicitly save a file when you decide to keep the AI edits.
+* AI 編集を保持することにした場合、ファイルを明示的に保存するようになりました。
 
-### Tool-based edit mode {#tool-based-edit-mode}
+### ツールベースの編集モード {#tool-based-edit-mode}
 
-**Setting**: `setting(chat.edits2.enabled:true)`
+**設定:** `setting(chat.edits2.enabled:true)`
 
-We're making a change to the way [edit mode in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-edits) operates. The new edit mode uses the same approach as agent mode, where it lets the model call a tool to make edits to files. An upside to this alignment is that it enables you to switch seamlessly between all three modes, while providing a huge simplification to how these modes work under the hood.
+[チャットの編集モード](https://code.visualstudio.com/docs/copilot/chat/copilot-edits) の動作方法を変更します。新しい編集モードでは、エージェント モードと同じアプローチを使用します。これにより、モデルはツールを呼び出してファイルを編集できます。この調整の利点は、3 つのモードすべてをシームレスに切り替えることができると同時に、これらのモードが内部でどのように機能するかを大幅に簡素化できることです。
 
-A downside is that this means that the new mode only works with the same reduced set of models that agent mode works with, namely models that support tool calling and have been tested to be sure that we can have a good experience when tools are involved. You may notice models like `o3-mini` and `Claude 3.7 (Thinking)` missing from the list in edit mode. If you'd like to keep using those models for editing, disable the `setting(chat.edits2.enabled)` setting to revert to the previous edit mode. You'll be asked to clear the session when switching modes.
+欠点は、新しいモードがエージェント モードで動作するのと同じ、ツール呼び出しをサポートし、ツールが関与する場合に優れたエクスペリエンスが得られることを確認するためにテストされた、削減されたモデル セットでのみ動作することを意味します。`o3-mini` や `Claude 3.7 (Thinking)` などのモデルが編集モードの一覧に表示されない場合があります。これらのモデルを編集に使用し続けたい場合は、`setting(chat.edits2.enabled)` 設定を無効にして、以前の編集モードに戻してください。モードを切り替えるときに、セッションをクリアするように求められます。
 
-We've learned that prompting to get consistent results across different models is harder when using tools, but we are working on getting these models lit up for edit (and agent) modes.
+ツールを使用する場合、さまざまなモデルで一貫した結果を得るためのプロンプトは難しいことがわかりましたが、これらのモデルを編集 (およびエージェント) モードで利用できるように取り組んでいます。
 
-This setting will be enabled gradually for users in VS Code Stable.
+この設定は、VS Code Stable のユーザーに対して徐々に有効になります。
 
-### Inline suggestion syntax highlighting {#inline-suggestion-syntax-highlighting}
+### インライン サジェストの構文の強調表示 {#inline-suggestion-syntax-highlighting}
 
-**Setting**: `setting(editor.inlineSuggest.syntaxHighlightingEnabled)`
+**設定:** `setting(editor.inlineSuggest.syntaxHighlightingEnabled)`
 
-With this update, syntax highlighting for inline suggestions is now enabled by default. Notice in the following screenshot that the code suggestion has syntax coloring applied to it.
+今回の更新により、インライン サジェストの構文の強調表示がデフォルトで有効になりました。次のスクリーンショットでは、コード サジェストに構文の色付けが適用されていることに注意してください。
 
-![Screenshot of the editor, showing that syntax highlighting is enabled for ghost text.](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingEnabled.png)
+![エディターのスクリーンショット。ゴースト テキストで構文の強調表示が有効になっていることを示しています。](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingEnabled.png)
 
-If you prefer inline suggestions without syntax highlighting, you can disable it with `setting(editor.inlineSuggest.syntaxHighlightingEnabled:false)`.
+構文の強調表示なしでインライン サジェストを使用する場合は、`setting(editor.inlineSuggest.syntaxHighlightingEnabled:false)` で無効にできます。
 
-![Screenshot of the editor showing that highlighting for ghost text is turned off.](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingDisabled.png)
+![ゴースト テキストの強調表示が無効になっているエディターのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingDisabled.png)
 
-### Tree-Sitter based syntax highlighting (Preview) {#tree-sitter-based-syntax-highlighting-preview}
+### Tree-Sitter ベースの構文の強調表示 (プレビュー) {#tree-sitter-based-syntax-highlighting-preview}
 
-**Setting**: `setting(editor.experimental.preferTreeSitter.css:true)` and `setting(editor.experimental.preferTreeSitter.regex:true)`
+**設定:** `setting(editor.experimental.preferTreeSitter.css:true)` および `setting(editor.experimental.preferTreeSitter.regex:true)`
 
-Building upon the previous work for using Tree-Sitter for syntax highlighting, we now support experimental, Tree-Sitter based, syntax highlighting for CSS files and for regular expressions within TypeScript.
+Tree-Sitter を構文の強調表示に使用するための以前の作業に基づいて、CSS ファイルと TypeScript 内の正規表現に対して、試験的な Tree-Sitter ベースの構文の強調表示をサポートするようになりました。
 
 ## Notebooks {#notebooks}
 
-### Minimal version of Jupyter notebook document to 4.5 {#minimal-version-of-jupyter-notebook-document-to-45}
+### Jupyter Notebook ドキュメントの最小バージョンを 4.5 に変更 {#minimal-version-of-jupyter-notebook-document-to-45}
 
-The default version of `nbformat` for new notebooks has been bumped from 4.2 to 4.5, which will now set `id` fields for each cell of the notebook to help with calculating diffs. You can also manually update existing notebooks by setting the `nbformat_minor` to `5` in the raw JSON of the notebook.
+新しい Notebook の `nbformat` のデフォルト バージョンが 4.2 から 4.5 に引き上げられました。これにより、Notebook の各セルの `id` フィールドが設定され、差分の計算に役立ちます。Notebook の raw JSON で `nbformat_minor` を `5` に設定して、既存の Notebook を手動で更新することもできます。
 
-### AI notebook editing improvements {#ai-notebook-editing-improvements}
+### AI Notebook 編集の改善 {#ai-notebook-editing-improvements}
 
-AI-powered editing support for notebooks (including agent mode) is now available in the Stable release. This was added last month as a preview feature in [VS Code Insiders](https://code.visualstudio.com/insiders).
+Notebook の AI を利用した編集サポート (エージェント モードを含む) が、Stable リリースで利用できるようになりました。これは、先月 [VS Code Insiders](https://code.visualstudio.com/insiders) でプレビュー機能として追加されました。
 
-You can now use chat to edit notebook files with the same intuitive experience as editing code files: modify content across multiple cells, insert and delete cells, and change cell types. This feature provides a seamless workflow when working with data science or documentation notebooks.
+チャットを使用して、コード ファイルを編集するのと同じ直感的なエクスペリエンスで Notebook ファイルを編集できるようになりました。複数のセルにわたってコンテンツを変更したり、セルを挿入および削除したり、セルの種類を変更したりできます。この機能は、データ サイエンスまたはドキュメント Notebook を操作する際にシームレスなワークフローを提供します。
 
-#### New notebook tool {#new-notebook-tool}
+#### 新しい Notebook ツール {#new-notebook-tool}
 
-VS Code now provides a dedicated tool for creating new Jupyter notebooks directly from chat. This tool plans and creates a new notebook based on your query.
+VS Code には、チャットから直接新しい Jupyter Notebook を作成するための専用ツールが用意されています。このツールは、クエリに基づいて新しい Notebook を計画および作成します。
 
-Use the new notebook tool in agent mode or edit mode (make sure to enable the improved edit mode with `setting(chat.edits2.enabled:true)`). If you're using ask mode, type `/newNotebook` in the chat prompt to create a new notebook.
+エージェント モードまたは編集モードで新しい Notebook ツールを使用します (`setting(chat.edits2.enabled:true)` で改善された編集モードを有効にしてください)。Ask モードを使用している場合は、チャット プロンプトに `/newNotebook` と入力して、新しい Notebook を作成します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/new-notebook-tool-release-notes.mp4" title="Video showing creation of a new Jupyter notebook using chat in agent mode and the New Notebook tool." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/new-notebook-tool-release-notes.mp4" title="エージェント モードのチャットと新しい Notebook ツールを使用して新しい Jupyter Notebook を作成するビデオ。" autoplay loop controls muted></video>
 
-#### Navigate through AI edits {#navigate-through-ai-edits}
+#### AI 編集のナビゲート {#navigate-through-ai-edits}
 
-Use the diff toolbars to iterate through and review each AI edit across cells.
+diff ツールバーを使用して、セル全体の各 AI 編集を反復処理して確認します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/navigate-notebook-edits.mp4" title="Video showing chat implementing a TODO task and then navigating through those changes." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/navigate-notebook-edits.mp4" title="チャットが TODO タスクを実装し、それらの変更をナビゲートする様子を示すビデオ。" autoplay loop controls muted></video>
 
-#### Undo AI edits {#undo-ai-edits}
+#### AI 編集の取り消し {#undo-ai-edits}
 
-When focused on a cell container, the **Undo** command reverts the full set of AI changes at the notebook level.
+セル コンテナーにフォーカスがある場合、**取り消し** コマンドは Notebook レベルでの AI による変更の完全なセットを元に戻します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/undo-copilot-notebook-edits.mp4" title="Video showing chat making several edits to a notebook and undoing those edits with ctrl+z." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/undo-copilot-notebook-edits.mp4" title="チャットが Notebook にいくつかの編集を加え、ctrl+z でそれらの編集を取り消す様子を示すビデオ。" autoplay loop controls muted></video>
 
-#### Text and image output support in chat {#text-and-image-output-support-in-chat}
+#### チャットでのテキストおよび画像の出力サポート {#text-and-image-output-support-in-chat}
 
-You can now add notebook cell outputs, such as text, errors, and images, directly to chat as context. This lets you reference the output when using ask, edit, or agent mode, making it easier for the language model to understand and assist with your notebook content.
+テキスト、エラー、画像などの Notebook セルの出力を、コンテキストとしてチャットに直接追加できるようになりました。これにより、Ask、Edit、またはエージェント モードを使用するときに出力を参照できるため、言語モデルが Notebook コンテンツを理解して支援することが容易になります。
 
-Use the **Add cell output to chat** action, available via the triple-dot menu or by right-clicking the output.
+3 つのドット メニューを使用するか、出力を右クリックして、**セル出力をチャットに追加** アクションを使用します。
 
-To attach the cell error output as chat context:
+セル エラー出力をチャット コンテキストとして添付するには:
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-attach.mp4" title="Video that shows attaching an notebook cell error output to chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-attach.mp4" title="Notebook セル エラー出力をチャットに添付する様子を示すビデオ。" autoplay loop controls muted></video>
 
-To attach the cell output image as chat context:
+セル出力画像をチャット コンテキストとして添付するには:
 
-<video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-image-demo.mp4" title="Video that shows attaching an notebook cell output image to chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-image-demo.mp4" title="Notebook セル出力画像をチャットに添付する様子を示すビデオ。" autoplay loop controls muted></video>
 
 ## Accessibility {#accessibility}
 
-### Chat agent mode improvements {#chat-agent-mode-improvements}
+### チャット エージェント モードの改善 {#chat-agent-mode-improvements}
 
-You are now notified when manual action is required during a tool invocation, such as "Run command in terminal." This information is also included in the ARIA label for the relevant chat response, enhancing accessibility for screen reader users.
+「ターミナルでコマンドを実行」など、ツール呼び出し中に手動操作が必要な場合に通知されるようになりました。この情報は、関連するチャット応答の ARIA ラベルにも含まれており、スクリーン リーダー ユーザーのアクセシビリティが向上しています。
 
-Additionally, a new accessibility help dialog is available in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode), explaining what users can expect from the feature and how to navigate it effectively.
+さらに、[エージェント モード](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) で新しいアクセシビリティ ヘルプ ダイアログが利用できるようになり、ユーザーがこの機能に期待できることと、効果的にナビゲートする方法について説明します。
 
-### Accessibility Signals for chat edit actions {#accessibility-signals-for-chat-edit-actions}
+### チャット編集アクションのアクセシビリティ シグナル {#accessibility-signals-for-chat-edit-actions}
 
-VS Code now provides auditory signals when you keep or undo AI-generated edits. These signals are configurable via `setting(accessibility.signals.editsKept)` and `setting(accessibility.signals.editsUndone)`.
+VS Code は、AI によって生成された編集を保持または元に戻すときに、聴覚シグナルを提供するようになりました。これらのシグナルは、`setting(accessibility.signals.editsKept)` および `setting(accessibility.signals.editsUndone)` を介して構成できます。
 
-### Improved ARIA labels for suggest control {#improved-aria-labels-for-suggest-control}
+### サジェスト コントロールの ARIA ラベルの改善 {#improved-aria-labels-for-suggest-control}
 
-ARIA labels for suggest control items now include richer and descriptive information, such as the type of suggestion (for example, method or variable). This information was previously only available to sighted users via icons.
+サジェスト コントロール項目の ARIA ラベルに、サジェストの種類 (メソッドや変数など) などのより豊富で説明的な情報が含まれるようになりました。この情報は、以前はアイコンを介して視覚ユーザーのみが利用できました。
 
 ## Source Control {#source-control}
 
-### Reference picker improvements {#reference-picker-improvements}
+### 参照ピッカーの改善 {#reference-picker-improvements}
 
-**Setting**: `setting(git.showReferenceDetails)`
+**設定:** `setting(git.showReferenceDetails)`
 
-This milestone, we have made improvements of the reference picker that is used for various source control operations like checkout, merge, rebase, or delete branch. The updated reference picker contains the details of the last commit (author, commit message, commit date), as well as ahead/behind information for local branches. This additional context will help you pick the right reference for the various operations.
+今回のマイルストーンでは、チェックアウト、マージ、リベース、またはブランチの削除などのさまざまなソース管理操作に使用される参照ピッカーを改善しました。更新された参照ピッカーには、最後のコミットの詳細 (作成者、コミット メッセージ、コミット日) と、ローカル ブランチの先行/遅延情報が含まれています。この追加のコンテキストは、さまざまな操作に適した参照を選択するのに役立ちます。
 
-Hide the additional information by toggling the `setting(git.showReferenceDetails:false)` setting.
+`setting(git.showReferenceDetails:false)` 設定を切り替えて、追加情報を非表示にします。
 
-![Screenshot of the source control references picker showing a list of git branches with details of the last commit, and ahead/behind information.](https://code.visualstudio.com/assets/updates/1_99/scm-reference-picker.png)
+![最後のコミットの詳細と先行/遅延情報を含む git ブランチの一覧を示すソース管理参照ピッカーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/scm-reference-picker.png)
 
-### Repository Status Bar item {#repository-status-bar-item}
+### リポジトリ ステータス バー項目 {#repository-status-bar-item}
 
-Workspaces that contain multiple repositories now have a Source Control Provider Status Bar item that displays the active repository to the left of the branch picker. The new Status Bar item provides additional context, so you know which is the active repository as you navigate between editors and use the Source Control view.
+複数のリポジトリを含むワークスペースには、ブランチ ピッカーの左側にアクティブなリポジトリを表示するソース管理プロバイダー ステータス バー項目が表示されるようになりました。新しいステータス バー項目は追加のコンテキストを提供するため、エディター間を移動したり、ソース管理ビューを使用したりするときに、アクティブなリポジトリがわかります。
 
-To hide the Source Control Provider Status Bar item, right-click the Status Bar, and deselect **Source Control Provider** from the context menu.
+ソース管理プロバイダー ステータス バー項目を非表示にするには、ステータス バーを右クリックし、コンテキスト メニューから **ソース管理プロバイダー** を選択解除します。
 
-![Screenshot showing the repository status bar item for workspaces that contain more than one repository.](https://code.visualstudio.com/assets/updates/1_99/scm-repository-picker.png)
+![複数のリポジトリを含むワークスペースのリポジトリ ステータス バー項目を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_99/scm-repository-picker.png)
 
-### Git blame editor decoration improvements {#git-blame-editor-decoration-improvements}
+### Git blame エディター装飾の改善 {#git-blame-editor-decoration-improvements}
 
-We have heard feedback that while typing, the "Not Yet Committed" editor decoration does not provide much value and it is more of a distraction. Starting this milestone the "Not Yet Committed" editor decoration is only shown while navigating around the codebase either by using the keyboard or the mouse.
+入力中に、"まだコミットされていません" エディター装飾はあまり価値を提供せず、むしろ気を散らすものであるというフィードバックがありました。今回のマイルストーン以降、"まだコミットされていません" エディター装飾は、キーボードまたはマウスを使用してコードベースをナビゲートしている場合にのみ表示されます。
 
-### Commit input cursor customization {#commit-input-cursor-customization}
+### コミット入力カーソルのカスタマイズ {#commit-input-cursor-customization}
 
-This milestone, thanks to a community contribution, we have added the `setting(editor.cursorStyle)` and `setting(editor.cursorWidth)` settings to the list of settings that are being honored by the source control input box.
+今回のマイルストーンでは、コミュニティの貢献のおかげで、`setting(editor.cursorStyle)` および `setting(editor.cursorWidth)` 設定が、ソース管理入力ボックスで有効になっている設定の一覧に追加されました。
 
 ## Terminal {#terminal}
 
-### Reliability in agent mode {#reliability-in-agent-mode}
+### エージェント モードの信頼性 {#reliability-in-agent-mode}
 
-The tool that allows agent mode to run commands in the terminal has a number of reliability and compatibility improvements. You should expect fewer cases where the tool gets stuck or where the command finishes without the output being present.
+エージェント モードがターミナルでコマンドを実行できるようにするツールには、多くの信頼性と互換性の改善が含まれています。ツールがスタックしたり、出力が存在せずにコマンドが完了したりするケースが少なくなるはずです。
 
-One of the bigger changes is the introduction of the concept of "rich" quality [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration), as opposed to "basic" and "none". The shell integration scripts shipped with VS Code should generally all enable rich shell integration which provides the best experience in the run in terminal tool (and terminal usage in general). You can view the shell integration quality by hovering over the terminal tab.
+より大きな変更の 1 つは、"基本" および "なし" とは対照的に、"リッチ" な品質の [シェル統合](https://code.visualstudio.com/docs/terminal/shell-integration) の概念の導入です。VS Code に付属するシェル統合スクリプトは、通常、ターミナル ツール (および一般的なターミナルの使用) での実行で最高のエクスペリエンスを提供するリッチ シェル統合をすべて有効にする必要があります。ターミナル タブにカーソルを合わせると、シェル統合の品質を表示できます。
 
-### Terminal IntelliSense improvements (Preview) {#terminal-intellisense-improvements-preview}
+### ターミナル IntelliSense の改善 (プレビュー) {#terminal-intellisense-improvements-preview}
 
-#### Enhanced IntelliSense for the `code` CLI {#enhanced-intellisense-for-the-code-cli}
+#### `code` CLI の拡張された IntelliSense {#enhanced-intellisense-for-the-code-cli}
 
-IntelliSense now supports subcommands for the `code`, `code-insiders`, and `code-tunnel` CLI. For instance, typing `code tunnel` shows available subcommands like `help`, `kill`, and `prune`, each with descriptive info.
+IntelliSense は、`code`、`code-insiders`、および `code-tunnel` CLI のサブコマンドをサポートするようになりました。たとえば、`code tunnel` と入力すると、`help`、`kill`、および `prune` などの利用可能なサブコマンドが、それぞれ説明的な情報とともに表示されます。
 
-![Screenshot of the terminal window, showing code tunnel has been typed. The suggest widget shows subcommands like help, kill, prune, and others, with descriptions for each command.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-code-tunnel.png)
+![ターミナル ウィンドウのスクリーンショット。code tunnel が入力されていることを示しています。サジェスト ウィジェットには、help、kill、prune などのサブコマンドが、各コマンドの説明とともに表示されています。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-code-tunnel.png)
 
-We've also added option suggestions for:
+次のオプションのサジェストも追加しました。
 
 - `--uninstall-extension`
 - `--disable-extension`
 - `--install-extension`
 
-These show a list of installed extensions to help complete the command.
+これらは、コマンドの完了を支援するために、インストールされている拡張機能の一覧を表示します。
 
-![Screenshot of the VSCode terminal with code --uninstall-extension. A list of available extensions is displayed, including vscode-eslint and editorconfig.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-extension.png)
+![VSCode ターミナルのスクリーンショット。code --uninstall-extension が表示されています。vscode-eslint や editorconfig などの利用可能な拡張機能の一覧が表示されています。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-extension.png)
 
-Additionally, `code --locate-shell-integration-path` now provides shell-specific options such as `bash`, `zsh`, `fish`, and `pwsh`.
+さらに、`code --locate-shell-integration-path` は、`bash`、`zsh`、`fish`、および `pwsh` などのシェル固有のオプションを提供するようになりました。
 
-![Screenshot of the VSCode terminal showing a command input: code --locate-shell-integration-path with a dropdown menu listing shell options bash, fish, pwsh, and zsh.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-locate-shell-integration.png)
+![コマンド入力 code --locate-shell-integration-path を示す VSCode ターミナルのスクリーンショット。ドロップダウン メニューには、シェル オプション bash、fish、pwsh、および zsh が一覧表示されています。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-locate-shell-integration.png)
 
-#### Auto-refresh for global commands {#auto-refresh-for-global-commands}
+#### グローバル コマンドの自動更新 {#auto-refresh-for-global-commands}
 
-The terminal now automatically refreshes its list of global commands when changes are detected in the system `bin` directory. This means newly installed CLI tools (for example, after running `npm install -g pnpm`) will show up in completions immediately, without the need to reload the window.
+ターミナルは、システムの `bin` ディレクトリで変更が検出されると、グローバル コマンドの一覧を自動的に更新するようになりました。これは、新しくインストールされた CLI ツール (たとえば、`npm install -g pnpm` の実行後) が、ウィンドウをリロードしなくても、すぐに補完に表示されることを意味します。
 
-Previously, completions for new tools wouldn’t appear due to caching until the window was manually reloaded.
+以前は、新しいツールの補完は、ウィンドウを手動でリロードするまでキャッシュが原因で表示されませんでした。
 
-#### Option value context {#option-value-context}
+#### オプション値のコンテキスト {#option-value-context}
 
-Terminal suggestions now display contextual information about expected option values, helping you more easily complete commands.
+ターミナルのサジェストは、予期されるオプション値に関するコンテキスト情報を表示するようになり、コマンドをより簡単に完了できるようになりました。
 
-![Screenshot of the terminal showing a command in progress: npm install --omit. The terminal suggest widget displays <package type> to indicate that's the option that's expected.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-options.png)
+![コマンドの進行状況を示すターミナルのスクリーンショット: npm install --omit。ターミナルのサジェスト ウィジェットには、それが予期されるオプションであることを示す <package type> が表示されています。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-options.png)
 
-#### Rich completions for fish shell {#rich-completions-for-fish-shell}
+#### fish シェルのリッチな補完 {#rich-completions-for-fish-shell}
 
-In the last release, we added detailed command completions for bash and zsh. This iteration, we've expanded that support to fish as well. Completion details are sourced from the shell’s documentation or built-in help commands.
+前回のリリースでは、bash と zsh の詳細なコマンド補完を追加しました。今回のイテレーションでは、そのサポートを fish にも拡張しました。補完の詳細は、シェルのドキュメントまたは組み込みのヘルプ コマンドから取得されます。
 
-For example, typing `jobs` in fish displays usage info and options:
+たとえば、fish で `jobs` と入力すると、使用法情報とオプションが表示されます。
 
-![Screenshot of the Visual Studio Code Terminal with a fish terminal showing a user has typed jobs. The suggest widget shown provides information about the jobs command with detailed usage examples and options.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-fish.png)
+![ユーザーが jobs と入力したことを示す fish ターミナルを備えた Visual Studio Code ターミナルのスクリーンショット。表示されているサジェスト ウィジェットは、詳細な使用例とオプションを含む jobs コマンドに関する情報を提供します。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-fish.png)
 
-#### File type icons in suggestions {#file-type-icons-in-suggestions}
+#### サジェストのファイルの種類アイコン {#file-type-icons-in-suggestions}
 
-Suggestions in the terminal now include specific icons for different file types, making it easier to distinguish between scripts and binaries at a glance.
+ターミナルのサジェストに、さまざまなファイルの種類に固有のアイコンが含まれるようになり、スクリプトとバイナリを一目で区別しやすくなりました。
 
-![Screenshot of the terminal, showing suggestions for various script files, including code.sh, code-cli.sh, and code-server.js. Icons indicate the specific file type.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-icons.png)
+![code.sh、code-cli.sh、および code-server.js などのさまざまなスクリプト ファイルのサジェストを示すターミナルのスクリーンショット。アイコンは特定のファイルの種類を示しています。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-icons.png)
 
-#### Inline suggestion details {#inline-suggestion-details}
+#### インライン サジェストの詳細 {#inline-suggestion-details}
 
-Inline suggestions, displayed as ghost text in the terminal, continue to appear at the top of the suggestions list. In this release, we've added command details to these entries to provide more context before accepting them.
+ターミナルにゴースト テキストとして表示されるインライン サジェストは、サジェストの一覧の一番上に引き続き表示されます。今回のリリースでは、これらのエントリにコマンドの詳細を追加して、受け入れる前により多くのコンテキストを提供するようにしました。
 
-![Screenshot of the terminal, showing the Block command as ghost text in the terminal. The first suggestion is block and it contains usage information.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-consolidated.png)
+![ターミナルにゴースト テキストとして Block コマンドを表示するターミナルのスクリーンショット。最初のサジェストは block であり、使用法情報が含まれています。](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-consolidated.png)
 
-### New simplified and detailed tab hover {#new-simplified-and-detailed-tab-hover}
+### 新しい簡略化された詳細なタブ ホバー {#new-simplified-and-detailed-tab-hover}
 
-By default, the terminal tab shows much less detail now.
+デフォルトでは、ターミナル タブに表示される詳細が大幅に少なくなりました。
 
-![Screenshot of the simple hover showing the terminal name, PID, command line, shell integration quality and actions](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-simple.png)
+![ターミナル名、PID、コマンド ライン、シェル統合の品質、およびアクションを示す簡単なホバーのスクリーンショット](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-simple.png)
 
-To view everything, there is a **Show Details** button at the bottom of the hover.
+すべてを表示するには、ホバーの下部にある **詳細の表示** ボタンがあります。
 
-![Screenshot of the detailed hover showing extensions that contribute to the environment and detailed shell integration diagnostics](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-detailed.png)
+![環境に貢献する拡張機能と詳細なシェル統合診断を示す詳細なホバーのスクリーンショット](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-detailed.png)
 
-### Signed PowerShell shell integration {#signed-powershell-shell-integration}
+### 署名付き PowerShell シェル統合 {#signed-powershell-shell-integration}
 
-The shell integration PowerShell script is now signed, meaning shell integration on Windows when using the default PowerShell execution policy of `RemoteSigned` should now start working automatically. You can read more about [shell integration's benefits here](https://code.visualstudio.com/docs/terminal/shell-integration).
+シェル統合 PowerShell スクリプトが署名されるようになったため、デフォルトの PowerShell 実行ポリシー `RemoteSigned` を使用する場合、Windows でのシェル統合が自動的に開始されるようになりました。[シェル統合の利点については、こちら](https://code.visualstudio.com/docs/terminal/shell-integration) を参照してください。
 
-### Terminal shell type {#terminal-shell-type}
+### ターミナル シェル タイプ {#terminal-shell-type}
 
-This iteration, we've finalized our terminal shell API, allowing extensions to see the user's current shell type in their terminal.
-Subscribing to event `onDidChangeTerminalState` allows you to see the changes of the user's shell type in the terminal.
-For example, the shell could change from zsh to bash.
+今回のイテレーションでは、ターミナル シェル API を完成させ、拡張機能がターミナルでユーザーの現在のシェル タイプを確認できるようにしました。
+イベント `onDidChangeTerminalState` をサブスクライブすると、ターミナルでのユーザーのシェル タイプの変更を確認できます。
+たとえば、シェルは zsh から bash に変更される可能性があります。
 
-The list of all the shells that are identifiable are currently listed [here](https://github.com/microsoft/vscode/blob/99e3ae5586a74ab1c554b6a2a50bb9eb3a4ff7fd/src/vscode-dts/vscode.d.ts#L7740-L7750)
+識別可能なすべてのシェルの一覧は、現在 [こちら](https://github.com/microsoft/vscode/blob/99e3ae5586a74ab1c554b6a2a50bb9eb3a4ff7fd/src/vscode-dts/vscode.d.ts#L7740-L7750) に記載されています。
 
 ## Remote Development {#remote-development}
 
-### Linux legacy server support has ended {#linux-legacy-server-support-has-ended}
+### Linux レガシー サーバーのサポートが終了しました {#linux-legacy-server-support-has-ended}
 
-As of release 1.99, you can no longer connect to these servers. As noted in our [1.97 release](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md#migration-path-for-linux-legacy-server), users that require additional time to complete migration to a supported Linux distro can provide custom builds of `glibc` and `libstdc++` as a workaround. More info on this workaround can be found in the [FAQ](https://aka.ms/vscode-remote/faq/old-linux) section.
+リリース 1.99 以降、これらのサーバーに接続できなくなりました。[1.97 リリース](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md#migration-path-for-linux-legacy-server) で説明したように、サポートされている Linux ディストリビューションへの移行を完了するために追加の時間が必要なユーザーは、`glibc` および `libstdc++` のカスタム ビルドを回避策として提供できます。この回避策の詳細については、[FAQ](https://aka.ms/vscode-remote/faq/old-linux) セクションを参照してください。
 
 ## Enterprise {#enterprise}
 
-### macOS device management {#macos-device-management}
+### macOS デバイス管理 {#macos-device-management}
 
-VS Code now supports device management on macOS in addition to Windows.  This allows system administrators to push policies from a centralized management system, like Microsoft Intune.
+VS Code は、Windows に加えて macOS でのデバイス管理をサポートするようになりました。これにより、システム管理者は、Microsoft Intune などの集中管理システムからポリシーをプッシュできます。
 
-See the [Enterprise Support](https://code.visualstudio.com/docs/setup/enterprise#_device-management) documentation for more details.
+詳細については、[エンタープライズ サポート](https://code.visualstudio.com/docs/setup/enterprise#_device-management) のドキュメントを参照してください。
 
 ## Contributions to extensions {#contributions-to-extensions}
 
 ### Python {#python}
 
-#### Better support for editable installs with Pylance {#better-support-for-editable-installs-with-pylance}
+#### Pylance での編集可能なインストールに対するより良いサポート {#better-support-for-editable-installs-with-pylance}
 
-Pylance now supports resolving import paths for packages installed in editable mode (`pip install -e .`) as defined by [PEP 660](https://peps.python.org/pep-0660/), which enables an improved IntelliSense experience in these scenarios.
+Pylance は、[PEP 660](https://peps.python.org/pep-0660/) で定義されているように、編集可能なモード (`pip install -e .`) でインストールされたパッケージのインポート パスの解決をサポートするようになり、これらのシナリオで IntelliSense エクスペリエンスが向上します。
 
-This feature is enabled via `setting(python.analysis.enableEditableInstalls:true)` and we plan to start rolling it out as the default experience throughout this month. If you experience any issues, please report them at the [Pylance GitHub repository](https://github.com/microsoft/pylance-release).
+この機能は `setting(python.analysis.enableEditableInstalls:true)` を介して有効になり、今月中にデフォルトのエクスペリエンスとしてロールアウトを開始する予定です。問題が発生した場合は、[Pylance GitHub リポジトリ](https://github.com/microsoft/pylance-release) で報告してください。
 
-#### Faster and more reliable diagnostic experience with Pylance (Experimental) {#faster-and-more-reliable-diagnostic-experience-with-pylance-experimental}
+#### Pylance によるより高速で信頼性の高い診断エクスペリエンス (試験的) {#faster-and-more-reliable-diagnostic-experience-with-pylance-experimental}
 
-We're starting to roll out a change to improve the accuracy and responsiveness of Pylance's diagnostics when using the release version of the extension. This is especially helpful for scenarios with multiple open or recently closed files.
+拡張機能のリリース バージョンを使用する場合に、Pylance の診断の精度と応答性を向上させるための変更のロールアウトを開始しています。これは、複数のファイルが開いているか、最近閉じられたファイルがあるシナリオで特に役立ちます。
 
-If you do not want to wait for the roll-out, you can set `setting(python.analysis.usePullDiagnostics:true)`. If you experience any issues, please report them at the [Pylance GitHub repository](https://github.com/microsoft/pylance-release).
+ロールアウトを待機したくない場合は、`setting(python.analysis.usePullDiagnostics:true)` を設定できます。問題が発生した場合は、[Pylance GitHub リポジトリ](https://github.com/microsoft/pylance-release) で報告してください。
 
-#### Pylance custom Node.js arguments {#pylance-custom-nodejs-arguments}
+#### Pylance カスタム Node.js 引数 {#pylance-custom-nodejs-arguments}
 
-There's a new `setting(python.analysis.nodeArguments)` setting, which allows you to pass custom arguments directly to Node.js when using `setting(python.analysis.nodeExecutable)`. By default, it is set to `"--max-old-space-size=8192"`, but you can modify it to suit your needs (for example, to allocate more memory to Node.js when working with large workspaces).
+新しい `setting(python.analysis.nodeArguments)` 設定があります。これにより、`setting(python.analysis.nodeExecutable)` を使用する場合に、カスタム引数を Node.js に直接渡すことができます。デフォルトでは、`"--max-old-space-size=8192"` に設定されていますが、ニーズに合わせて変更できます (たとえば、大規模なワークスペースを操作する場合に、Node.js により多くのメモリを割り当てるなど)。
 
-Additionally, when setting `setting(python.analysis.nodeExecutable)` to `auto`, Pylance now automatically downloads Node.js.
+さらに、`setting(python.analysis.nodeExecutable)` を `auto` に設定すると、Pylance は Node.js を自動的にダウンロードするようになりました。
 
 ## Extension authoring {#extension-authoring}
 
-### Terminal.shellIntegration tweaks {#terminalshellintegration-tweaks}
+### Terminal.shellIntegration の調整 {#terminalshellintegration-tweaks}
 
-The `Terminal.shellIntegration` API will now only light up when command detection happens. Previously, this should work when _only_ the current working directory was reported, which caused `TerminalShellIntegration.executeCommand` to not function well.
+`Terminal.shellIntegration` API は、コマンド検出が発生した場合にのみ有効になります。以前は、現在の作業ディレクトリが報告された _場合にのみ_ これが機能するはずでしたが、これにより `TerminalShellIntegration.executeCommand` がうまく機能しませんでした。
 
-Additionally, `TerminalShellIntegration.executeCommand` will now behave more consistently and track multiple "sub-executions" for a single command line that ended up running multiple commands. This depends on rich shell integration as mentioned in the [reliability in agent mode section](#reliability-in-agent-mode).
+さらに、`TerminalShellIntegration.executeCommand` は、より一貫して動作し、複数のコマンドを実行することになった単一のコマンド ラインの複数の "サブ実行" を追跡するようになりました。これは、[エージェント モードの信頼性セクション](#reliability-in-agent-mode) で説明されているように、リッチ シェル統合に依存します。
 
 ## Proposed APIs {#proposed-apis}
 
-### Task problem matcher status {#task-problem-matcher-status}
+### タスクの問題マッチャーのステータス {#task-problem-matcher-status}
 
-We've added [proposed API](https://github.com/microsoft/vscode/blob/c98092f1caaad64e18be5b3f8761a09c24c7669c/src/vscode-dts/vscode.proposed.taskProblemMatcherStatus.d.ts#L9-L40), so that extensions can monitor when a task's problem matchers start and finish processing lines. Enable it with `taskProblemMatcherStatus`.
+拡張機能がタスクの問題マッチャーが開始および終了するタイミングを監視できるように、[提案された API](https://github.com/microsoft/vscode/blob/c98092f1caaad64e18be5b3f8761a09c24c7669c/src/vscode-dts/vscode.proposed.taskProblemMatcherStatus.d.ts#L9-L40) を追加しました。`taskProblemMatcherStatus` で有効にします。
 
-### Send images to LLM {#send-images-to-llm}
+### LLM に画像を送信 {#send-images-to-llm}
 
-This iteration, we've added a [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts), so that extensions can attach images and send vision requests to the language model. Attachments must be the raw, non base64-encoded binary data of the image (`Uint8Array`). Maximum image size is 5MB.
+今回のイテレーションでは、拡張機能が画像を添付してビジョン リクエストを言語モデルに送信できるように、[提案された API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts) を追加しました。添付ファイルは、画像の raw で、base64 でエンコードされていないバイナリ データ (`Uint8Array`) である必要があります。最大画像サイズは 5MB です。
 
-Check out [this API proposal issue](https://github.com/microsoft/vscode/issues/245104) to see a usage example and to stay up to date with the status of this API.
+使用例を確認し、この API のステータスを最新の状態に保つには、[この API 提案の問題](https://github.com/microsoft/vscode/issues/245104) を確認してください。
 
 ## Engineering {#engineering}
 
-### Use new `/latest` API from Marketplace to check for extensions updates {#use-new-latest-api-from-marketplace-to-check-for-extensions-updates}
+### Marketplace から新しい `/latest` API を使用して拡張機能の更新を確認する {#use-new-latest-api-from-marketplace-to-check-for-extensions-updates}
 
-Couple of milestones back, we introduced a new API endpoint in `vscode-unpkg` service to check for extension updates. Marketplace now supports the same endpoint and VS Code is now using this endpoint to check for extension updates. This is behind an experiment and will be rolled out to users in stages.
+数マイルストーン前に、拡張機能の更新を確認するために、`vscode-unpkg` サービスに新しい API エンドポイントを導入しました。Marketplace は同じエンドポイントをサポートするようになり、VS Code はこのエンドポイントを使用して拡張機能の更新を確認するようになりました。これは実験の背後にあり、段階的にユーザーにロールアウトされます。
 
 ## Thank you {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆様に _**感謝**_ 申し上げます。
 
 ### Issue tracking {#issue-tracking}
 
-Contributions to our issue tracking:
+Issue tracking への貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
@@ -589,84 +589,84 @@ Contributions to our issue tracking:
 
 ### Pull requests {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Add a 2 hour offset to tests to avoid being a day short after the clocks change [PR #243194](https://github.com/microsoft/vscode/pull/243194)
-* [@acdzh (Vukk)](https://github.com/acdzh): Fix hasEdits flag's value when updating multiple values in JSONEditingService  [PR #243876](https://github.com/microsoft/vscode/pull/243876)
-* [@c-claeys (Cristopher Claeys)](https://github.com/c-claeys): Increment the request attempt in the chat retry action [PR #243471](https://github.com/microsoft/vscode/pull/243471)
-* [@ChaseKnowlden (Chase Knowlden)](https://github.com/ChaseKnowlden): Add Merge Editor Accessibility help [PR #240745](https://github.com/microsoft/vscode/pull/240745)
-* [@dibarbet (David Barbet)](https://github.com/dibarbet): Update C# onEnterRules to account for documentation comments [PR #242121](https://github.com/microsoft/vscode/pull/242121)
-* [@dsanders11 (David Sanders)](https://github.com/dsanders11): Fix a few broken `@link` in vscode.d.ts [PR #242407](https://github.com/microsoft/vscode/pull/242407)
-* [@jacekkopecky (Jacek Kopecký)](https://github.com/jacekkopecky): Honor more cursor settings in scm input editor [PR #242903](https://github.com/microsoft/vscode/pull/242903)
-* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Show support URL and license URL even if extension URL is not set [PR #243565](https://github.com/microsoft/vscode/pull/243565)
-* [@kevmo314 (Kevin Wang)](https://github.com/kevmo314): Fix comment typo [PR #243145](https://github.com/microsoft/vscode/pull/243145)
-* [@liudonghua123 (liudonghua)](https://github.com/liudonghua123): support explorer.copyPathSeparator [PR #184884](https://github.com/microsoft/vscode/pull/184884)
-* [@mattmaniak](https://github.com/mattmaniak): Make telemetry info table a little bit narrower and aligned [PR #233961](https://github.com/microsoft/vscode/pull/233961)
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): クロック変更後に 1 日短くなるのを避けるために、テストに 2 時間のオフセットを追加 [PR #243194](https://github.com/microsoft/vscode/pull/243194)
+* [@acdzh (Vukk)](https://github.com/acdzh): JSONEditingService で複数の値を更新するときに hasEdits フラグの値を修正 [PR #243876](https://github.com/microsoft/vscode/pull/243876)
+* [@c-claeys (Cristopher Claeys)](https://github.com/c-claeys): チャット再試行アクションでリクエスト試行回数を増やす [PR #243471](https://github.com/microsoft/vscode/pull/243471)
+* [@ChaseKnowlden (Chase Knowlden)](https://github.com/ChaseKnowlden): マージ エディターのアクセシビリティ ヘルプを追加 [PR #240745](https://github.com/microsoft/vscode/pull/240745)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): ドキュメント コメントを考慮するように C# onEnterRules を更新 [PR #242121](https://github.com/microsoft/vscode/pull/242121)
+* [@dsanders11 (David Sanders)](https://github.com/dsanders11): vscode.d.ts のいくつかの壊れた `@link` を修正 [PR #242407](https://github.com/microsoft/vscode/pull/242407)
+* [@jacekkopecky (Jacek Kopecký)](https://github.com/jacekkopecky): scm 入力エディターでより多くのカーソル設定を尊重 [PR #242903](https://github.com/microsoft/vscode/pull/242903)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): 拡張機能 URL が設定されていない場合でも、サポート URL とライセンス URL を表示 [PR #243565](https://github.com/microsoft/vscode/pull/243565)
+* [@kevmo314 (Kevin Wang)](https://github.com/kevmo314): コメントのタイプミスを修正 [PR #243145](https://github.com/microsoft/vscode/pull/243145)
+* [@liudonghua123 (liudonghua)](https://github.com/liudonghua123): explorer.copyPathSeparator をサポート [PR #184884](https://github.com/microsoft/vscode/pull/184884)
+* [@mattmaniak](https://github.com/mattmaniak): テレメトリ情報テーブルを少し狭くして、配置 [PR #233961](https://github.com/microsoft/vscode/pull/233961)
 * [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango)
-  * fix: use the copy command for images with CORS errors in the markdown preview [PR #240508](https://github.com/microsoft/vscode/pull/240508)
-  * Fix Incorrect character indentation on settings with line break [PR #242074](https://github.com/microsoft/vscode/pull/242074)
-* [@pprchal (Pavel Prchal)](https://github.com/pprchal): Added localization to right-click on icon [PR #243679](https://github.com/microsoft/vscode/pull/243679)
-* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): feature: support font family picker in settings [PR #214572](https://github.com/microsoft/vscode/pull/214572)
-* [@tribals (Anthony)](https://github.com/tribals): Add discovery of PowerShell Core user installation [PR #243025](https://github.com/microsoft/vscode/pull/243025)
-* [@tusharsadhwani (Tushar Sadhwani)](https://github.com/tusharsadhwani): Make `git show` ref argument unambiguous [PR #242483](https://github.com/microsoft/vscode/pull/242483)
-* [@wszgrcy (chen)](https://github.com/wszgrcy): fix: extension uncaughtException listen Maximum call stack size exceeded [PR #244690](https://github.com/microsoft/vscode/pull/244690)
-* [@zyoshoka (zyoshoka)](https://github.com/zyoshoka): Correct `typescript-basics` extension path [PR #243833](https://github.com/microsoft/vscode/pull/243833)
+  * fix: markdown プレビューで CORS エラーが発生した画像に copy コマンドを使用 [PR #240508](https://github.com/microsoft/vscode/pull/240508)
+  * Fix: 改行を含む設定で不正な文字インデント [PR #242074](https://github.com/microsoft/vscode/pull/242074)
+* [@pprchal (Pavel Prchal)](https://github.com/pprchal): アイコンの右クリックにローカリゼーションを追加 [PR #243679](https://github.com/microsoft/vscode/pull/243679)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): feature: 設定でフォント ファミリー ピッカーをサポート [PR #214572](https://github.com/microsoft/vscode/pull/214572)
+* [@tribals (Anthony)](https://github.com/tribals): PowerShell Core ユーザー インストールの検出を追加 [PR #243025](https://github.com/microsoft/vscode/pull/243025)
+* [@tusharsadhwani (Tushar Sadhwani)](https://github.com/tusharsadhwani): `git show` ref 引数を明確にする [PR #242483](https://github.com/microsoft/vscode/pull/242483)
+* [@wszgrcy (chen)](https://github.com/wszgrcy): fix: 拡張機能 uncaughtException listen Maximum call stack size exceeded [PR #244690](https://github.com/microsoft/vscode/pull/244690)
+* [@zyoshoka (zyoshoka)](https://github.com/zyoshoka): `typescript-basics` 拡張機能パスを修正 [PR #243833](https://github.com/microsoft/vscode/pull/243833)
 
-Contributions to `vscode-css-languageservice`:
+`vscode-css-languageservice` への貢献:
 
-* [@lilnasy (Arsh)](https://github.com/lilnasy): Support `@starting-style` [PR #421](https://github.com/microsoft/vscode-css-languageservice/pull/421)
+* [@lilnasy (Arsh)](https://github.com/lilnasy): `@starting-style` をサポート [PR #421](https://github.com/microsoft/vscode-css-languageservice/pull/421)
 
-Contributions to `vscode-custom-data`:
+`vscode-custom-data` への貢献:
 
-* [@rviscomi (Rick Viscomi)](https://github.com/rviscomi): Add computed Baseline status [PR #111](https://github.com/microsoft/vscode-custom-data/pull/111)
+* [@rviscomi (Rick Viscomi)](https://github.com/rviscomi): 計算されたベースライン ステータスを追加 [PR #111](https://github.com/microsoft/vscode-custom-data/pull/111)
 
-Contributions to `vscode-extension-samples`:
+`vscode-extension-samples` への貢献:
 
-* [@ratmice (matt rice)](https://github.com/ratmice): Fix esbuild scripts [PR #1154](https://github.com/microsoft/vscode-extension-samples/pull/1154)
+* [@ratmice (matt rice)](https://github.com/ratmice): esbuild スクリプトを修正 [PR #1154](https://github.com/microsoft/vscode-extension-samples/pull/1154)
 
-Contributions to `vscode-extension-telemetry`:
+`vscode-extension-telemetry` への貢献:
 
-* [@minestarks (Mine Starks)](https://github.com/minestarks): Remove extra brace from common.platformversion [PR #221](https://github.com/microsoft/vscode-extension-telemetry/pull/221)
+* [@minestarks (Mine Starks)](https://github.com/minestarks): common.platformversion から余分な中かっこを削除 [PR #221](https://github.com/microsoft/vscode-extension-telemetry/pull/221)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@erikson84 (Erikson Kaszubowski)](https://github.com/erikson84): fix: ensure backslash in path when setting breakpoints in windows [PR #2184](https://github.com/microsoft/vscode-js-debug/pull/2184)
-* [@xymopen (xymopen_Official)](https://github.com/xymopen): Support usenode as npm script runner [PR #2178](https://github.com/microsoft/vscode-js-debug/pull/2178)
+* [@erikson84 (Erikson Kaszubowski)](https://github.com/erikson84): fix: Windows でブレークポイントを設定するときに、パスに円記号が含まれていることを確認 [PR #2184](https://github.com/microsoft/vscode-js-debug/pull/2184)
+* [@xymopen (xymopen_Official)](https://github.com/xymopen): npm スクリプト ランナーとして usenode をサポート [PR #2178](https://github.com/microsoft/vscode-js-debug/pull/2178)
 
-Contributions to `vscode-mypy`:
+`vscode-mypy` への貢献:
 
-* [@ivirabyan (Ivan Virabyan)](https://github.com/ivirabyan): Report only files specified by mypy config [PR #352](https://github.com/microsoft/vscode-mypy/pull/352)
+* [@ivirabyan (Ivan Virabyan)](https://github.com/ivirabyan): mypy 構成で指定されたファイルのみを報告 [PR #352](https://github.com/microsoft/vscode-mypy/pull/352)
 
-Contributions to `vscode-prompt-tsx`:
+`vscode-prompt-tsx` への貢献:
 
-* [@dsanders11 (David Sanders)](https://github.com/dsanders11): docs: fix sendRequest API name in README example [PR #159](https://github.com/microsoft/vscode-prompt-tsx/pull/159)
+* [@dsanders11 (David Sanders)](https://github.com/dsanders11): docs: README の例で sendRequest API 名を修正 [PR #159](https://github.com/microsoft/vscode-prompt-tsx/pull/159)
 * [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
-  * fix: `text` should be `this.props.text` [PR #163](https://github.com/microsoft/vscode-prompt-tsx/pull/163)
-  * Fix the Usage in Tools section in README.md [PR #164](https://github.com/microsoft/vscode-prompt-tsx/pull/164)
+  * fix: `text` は `this.props.text` である必要があります [PR #163](https://github.com/microsoft/vscode-prompt-tsx/pull/163)
+  * README.md の [ツールでの使用法] セクションを修正 [PR #164](https://github.com/microsoft/vscode-prompt-tsx/pull/164)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@aedm (Gábor Gyebnár)](https://github.com/aedm): Adds `sanitizedLowercaseIssueTitle` to settings docs [PR #6690](https://github.com/microsoft/vscode-pull-request-github/pull/6690)
+* [@aedm (Gábor Gyebnár)](https://github.com/aedm): `sanitizedLowercaseIssueTitle` を設定ドキュメントに追加 [PR #6690](https://github.com/microsoft/vscode-pull-request-github/pull/6690)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
-* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Update debugpy to latest version [PR #653](https://github.com/microsoft/vscode-python-debugger/pull/653)
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): debugpy を最新バージョンに更新 [PR #653](https://github.com/microsoft/vscode-python-debugger/pull/653)
 
-Contributions to `vscode-test`:
+`vscode-test` への貢献:
 
-* [@SKaplanOfficial (Stephen Kaplan)](https://github.com/SKaplanOfficial): fix: avoid 'Invalid extraction directory' when unzipping [PR #303](https://github.com/microsoft/vscode-test/pull/303)
+* [@SKaplanOfficial (Stephen Kaplan)](https://github.com/SKaplanOfficial): fix: 解凍時に「無効な抽出ディレクトリ」を回避 [PR #303](https://github.com/microsoft/vscode-test/pull/303)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Update range formatting capabilities in metamodel [PR #2106](https://github.com/microsoft/language-server-protocol/pull/2106)
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): メタモデルの範囲書式設定機能を更新 [PR #2106](https://github.com/microsoft/language-server-protocol/pull/2106)
 
-Contributions to `python-environment-tools`:
+`python-environment-tools` への貢献:
 
-* [@CharlesChen0823](https://github.com/CharlesChen0823): bump winreg [PR #195](https://github.com/microsoft/python-environment-tools/pull/195)
+* [@CharlesChen0823](https://github.com/CharlesChen0823): winreg をバンプ [PR #195](https://github.com/microsoft/python-environment-tools/pull/195)
 * [@elprans (Elvis Pranskevichus)](https://github.com/elprans)
-  * Avoid misdetecting global Linux Python as virtualenv [PR #197](https://github.com/microsoft/python-environment-tools/pull/197)
-  * Fix env version detection on systems with multiple system Pythons [PR #198](https://github.com/microsoft/python-environment-tools/pull/198)
-  * Populate `name` in virtualenvwrapper envs [PR #199](https://github.com/microsoft/python-environment-tools/pull/199)
+  * グローバル Linux Python を virtualenv として誤検出しないようにする [PR #197](https://github.com/microsoft/python-environment-tools/pull/197)
+  * 複数のシステム Python を持つシステムでの env バージョン検出を修正 [PR #198](https://github.com/microsoft/python-environment-tools/pull/198)
+  * virtualenvwrapper envs で `name` を設定 [PR #199](https://github.com/microsoft/python-environment-tools/pull/199)
 
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>

--- a/docs/release-notes/v1_99.md
+++ b/docs/release-notes/v1_99.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_99/release-highlights.png
 Date: 2025-04-03
 DownloadVersion: 1.99.0
 ---
-# March 2025 (version 1.99)
+# March 2025 (version 1.99) {#march-2025}
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
@@ -35,9 +35,9 @@ Welcome to the March 2025 release of Visual Studio Code. There are many updates 
 >If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 **Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
 
-## Chat
+## Chat {#chat}
 
-### Agent mode is available in VS Code Stable
+### Agent mode is available in VS Code Stable {#agent-mode-is-available-in-vs-code-stable}
 
 **Setting**: `setting(chat.agent.enabled:true)`
 
@@ -47,7 +47,7 @@ Check out the [agent mode documentation](https://code.visualstudio.com/docs/copi
 
 ![Screenshot that shows the Chat view, highlighting agent mode selected in the chat mode picker.](https://code.visualstudio.com/assets/updates/1_99/copilot-edits-agent-mode.png)
 
-### Model Context Protocol server support
+### Model Context Protocol server support {#model-context-protocol-server-support}
 
 This release supports [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) servers in agent mode. MCP offers a standardized method for AI models to discover and interact with external tools, applications, and data sources. When you input a chat prompt using agent mode in VS Code, the model can invoke various tools to perform tasks such as file operations, accessing databases, or retrieving web data. This integration enables more dynamic and context-aware coding assistance.
 
@@ -66,17 +66,17 @@ You can see the list of MCP servers and their current status using the **MCP: Li
 
 You can read more about how to install and use MCP servers in [our documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 
-### Agent mode tools
+### Agent mode tools {#agent-mode-tools}
 
 This milestone, we have added several new built-in tools to agent mode.
 
-#### Thinking tool (Experimental)
+#### Thinking tool (Experimental) {#thinking-tool-experimental}
 
 **Setting**: `setting(github.copilot.chat.agent.thinkingTool:true)`.
 
 Inspired by [Anthropic's research](https://www.anthropic.com/engineering/claude-think-tool), we've added support for a thinking tool in agent mode that can be used to give any model the opportunity to think between tool calls. This improves our agent's performance on complex tasks in-product and on the [SWE-bench](https://www.swebench.com/) eval.
 
-#### Fetch tool
+#### Fetch tool {#fetch-tool}
 
 Use the `#fetch` tool for including content from a publicly accessible webpage in your prompt. For instance, if you wanted to include the latest documentation on a topic like [MCP](#model-context-protocol-server-support), you can ask to fetch [the full documentation](https://modelcontextprotocol.io/llms-full.txt) (which is conveniently ready for an LLM to consume) and use that in a prompt. Here's a video of what that might look like:
 
@@ -93,13 +93,13 @@ Let us know how you use the `#fetch` tool, and what features you'd like to see f
 * Currently, JavaScript is disabled in this browser window. The tool will not be able to acquire much context if the website depends entirely on JavaScript to render content. This is a limitation we are considering changing and likely will change to allow JavaScript.
 * Due to the headless nature, we are unable to fetch pages that are behind authentication, as this headless browser exists in a different browser context than the browser you use. Instead, consider using [MCP](#model-context-protocol-server-support) to bring in an MCP server that is purpose-built for that target, or a generic browser MCP server such as the [Playwright MCP server](https://github.com/microsoft/playwright-mcp).
 
-#### Usages tool
+#### Usages tool {#usages-tool}
 
 The `#usages` tool is a combination of "Find All References", "Find Implementation", and "Go to Definition". This tool can help chat to learn more about a function, class, or interface. For instance, chat can use this tool to look for sample implementations of an interface or to find all places that need to be changed when making a refactoring.
 
 In agent mode this tool will be picked up automatically but you can also reference it explicitly via `#usages`
 
-### Create a new workspace with agent mode (Experimental)
+### Create a new workspace with agent mode (Experimental) {#create-a-new-workspace-with-agent-mode-experimental}
 
 **Setting**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
 
@@ -107,7 +107,7 @@ You can now scaffold a new VS Code workspace in [agent mode](https://code.visual
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/new-workspace-demo.mp4" title="Video showing creation of a new MCP server to fetch top N stories from hacker news using Agent mode." autoplay loop controls muted></video>
 
-### VS Code extension tools in agent mode
+### VS Code extension tools in agent mode {#vs-code-extension-tools-in-agent-mode}
 
 Several months ago, we finalized our extension API for [language model tools](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) contributed by VS Code extensions. Now, you can use these tools in agent mode.
 
@@ -117,7 +117,7 @@ By contributing a tool in an extension, it has access to the full VS Code extens
 
 Similar to tools from MCP servers, you can enable and disable these with the **Select Tools** button in agent mode. See our [language model tools extension guide](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) to build your own!
 
-### Agent mode tool approvals
+### Agent mode tool approvals {#agent-mode-tool-approvals}
 
 As part of completing the tasks for a user prompt, agent mode can run tools and terminal commands. This is powerful but potentially comes with risks. Therefore, you need to approve the use of tools and terminal commands in agent mode.
 
@@ -129,11 +129,11 @@ In case you want to auto-approve _all_ tools, you can now use the experimental `
 
 We plan to expand this setting with more granular capabilities in the future.
 
-### Agent evaluation on SWE-bench
+### Agent evaluation on SWE-bench {#agent-evaluation-on-swe-bench}
 
 VS Code's agent achieves a pass rate of 56.0% on `swebench-verified` with Claude 3.7 Sonnet, following Anthropic's [research](https://www.anthropic.com/engineering/swe-bench-sonnet) on configuring agents to execute without user input in the SWE-bench environment. Our experiments have translated into shipping improved prompts, tool descriptions and tool design for agent mode, including new tools for file edits that are in-distribution for Claude 3.5 and 3.7 Sonnet models.
 
-### Unified Chat view
+### Unified Chat view {#unified-chat-view}
 
 For the past several months, we've had a "Chat" view for asking questions to the language model, and a "Copilot Edits" view for an AI-powered code editing session. This month, we aim to streamline the chat-based experience by merging the two views into one Chat view. In the Chat view, you'll see a dropdown with three modes:
 
@@ -152,7 +152,7 @@ Besides making your chat experience simpler, this unification enables a few new 
 - **Move chat to editor or window**: Select **Open Chat in New Editor/New Window** to pop out your chat conversation from the side bar into a new editor tab or separate VS Code window. Chat has supported this for a long time, but now you can run your edit/agent sessions from an editor pane or a separate window as well.
 - **Multiple agent sessions**: Following from the above point, this means that you can even run multiple agent sessions at the same time. You might like to have one chat in agent mode working on implementing a feature, and another independent session for doing research and using other tools. Directing two agent sessions to edit files at the same time is not recommended, it can lead to confusion.
 
-### Bring Your Own Key (BYOK) (Preview)
+### Bring Your Own Key (BYOK) (Preview) {#bring-your-own-key-byok-preview}
 
 Copilot Pro and Copilot Free users can now bring their own API keys for popular providers such as Azure, Anthropic, Gemini, Open AI, Ollama, and Open Router. This allows you to use new models that are not natively supported by Copilot the very first day that they're released.
 
@@ -160,9 +160,9 @@ To try it, select **Manage Models...** from the model picker. We’re actively e
 
 ![A screenshot of a "Manage Models - Preview" dropdown menu in a user interface. The dropdown has the label "Select a provider" at the top, with a list of options below it. The options include "Anthropic" (highlighted in blue), "Azure," "Gemini," "OpenAI," "Ollama," and "OpenRouter." A gear icon is displayed next to the "Anthropic" option.](https://code.visualstudio.com/assets/updates/1_99/byok.png)
 
-### Reusable prompt files
+### Reusable prompt files {#reusable-prompt-files}
 
-#### Improved configuration
+#### Improved configuration {#improved-configuration}
 
 **Setting**: `setting(chat.promptFilesLocations)`
 
@@ -170,24 +170,24 @@ The `setting(chat.promptFilesLocations)` setting now supports glob patterns in f
 
 Additionally, the configuration now respects case sensitivity on filesystems where it applies, aligning with the behavior of the host operating system.
 
-#### Improved prompt file editing
+#### Improved prompt file editing {#improved-prompt-file-editing}
 
 - Your `.prompt.md` files now offer basic autocompletion for filesystem paths and highlight valid file references. Broken links on the other hand now appear as warning or error squiggles and provide detailed diagnostic information.
 - You can now manage prompts using edit and delete actions in the prompt file list within the **Chat: Use Prompt** command.
 - Folder references in prompt files are no longer flagged as invalid.
 - Markdown comments are now properly handled, for instance, all commented-out links are ignored when generating the final prompt sent to the LLM model.
 
-#### Alignment with custom instructions
+#### Alignment with custom instructions {#alignment-with-custom-instructions}
 
 The `.github/copilot-instructions.md` file now behaves like any other reusable `.prompt.md` file, with support for nested link resolution and enhanced language features. Furthermore, any `.prompt.md` file can now be referenced and is handled appropriately.
 
 Learn more about [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
 
-#### User prompts
+#### User prompts {#user-prompts}
 
 The **Create User Prompt** command now allows creating a new type of prompts called _user prompts_. These are stored in the user data folder and can be synchronized across machines, similar to code snippets or user settings. The synchronization can be configured in [Sync Settings](https://code.visualstudio.com/docs/configure/settings-sync) by using the **Prompts** item in the synchronization resources list.
 
-### Improved vision support (Preview)
+### Improved vision support (Preview) {#improved-vision-support-preview}
 
 Last iteration, Copilot Vision was enabled for `GPT-4o`. Check our [release notes](https://code.visualstudio.com/updates/v1_98#_copilot-vision-preview) to learn more about how you can attach and use images in chat.
 
@@ -195,9 +195,9 @@ This release, you can attach images from any browser via drag and drop. Images d
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/image-url-dnd.mp4" title="Video that shows an image from Chrome being dragged into the chat panel." autoplay loop controls muted></video>
 
-## Configure the editor
+## Configure the editor {#configure-the-editor}
 
-### Unified chat experience
+### Unified chat experience {#unified-chat-experience}
 
 We have streamlined the chat experience in VS Code into a single unified Chat view. Instead of having to move between separate views and lose the context of a conversation, you can now easily switch between the different chat modes.
 
@@ -211,7 +211,7 @@ Depending on your scenario, use either of these modes, and freely move mid-conve
 
 Get more details about the [unified chat view](#unified-chat-view).
 
-### Faster workspace searches with instant indexing
+### Faster workspace searches with instant indexing {#faster-workspace-searches-with-instant-indexing}
 
 [Remote workspace indexes](https://code.visualstudio.com/docs/copilot/reference/workspace-context#remote-index) accelerate searching large codebases for relevant code snippets that AI uses while answering questions and generating edits. These remote indexes are especially useful for large codebases with tens or even hundreds of thousands of files.
 
@@ -223,7 +223,7 @@ Keep in mind that remote workspaces indexes are currently only available for cod
 
 To manage load, we are slowly rolling out instant indexing over the next few weeks, so you may not see it right away. You can still run the `GitHub Copilot: Build remote index command` command to start using a remote index when instant indexing is not yet enabled for you.
 
-### Copilot status menu
+### Copilot status menu {#copilot-status-menu}
 
 The Copilot status menu, accessible from the Status Bar, is now enabled for all users. This milestone we added some new features to it:
 
@@ -239,7 +239,7 @@ The Copilot status menu, accessible from the Status Bar, is now enabled for all 
 
 - Enable or disable [code completions and NES](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
 
-### Out of the box Copilot setup (Experimental)
+### Out of the box Copilot setup (Experimental) {#out-of-the-box-copilot-setup-experimental}
 
 **Setting**: `setting(chat.setupFromDialog)`
 
@@ -249,7 +249,7 @@ We are shipping an experimental feature to show functional chat experiences out 
 
 If you want to see this experience for yourself, enable the `setting(chat.setupFromDialog)` setting.
 
-### Chat prerelease channel mismatch
+### Chat prerelease channel mismatch {#chat-prerelease-channel-mismatch}
 
 If you have the prerelease version of the Copilot Chat extension installed in VS Code Stable, a new welcome screen will inform you that this configuration is not supported. Due to rapid development of chat features, the extension will not activate in VS Code Stable.
 
@@ -257,7 +257,7 @@ The welcome screen provides options to either switch to the release version of t
 
 ![Screenshot that shows the welcome view of chat, indicating that the pre-release version of the extension is not supported in VS Code stable. A button is shown to switch to the release version, and a secondary link is shown to switch to VS Code Insiders.](https://code.visualstudio.com/assets/updates/1_99/welcome-pre-release.png)
 
-### Semantic text search improvements (Experimental)
+### Semantic text search improvements (Experimental) {#semantic-text-search-improvements-experimental}
 
 **Setting**: `setting(github.copilot.chat.search.semanticTextResults:true)`
 
@@ -269,7 +269,7 @@ You can also reference the semantic search results in your chat prompt by using 
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search-results.mp4" title="Video that shows using search results in chat view." autoplay loop controls muted></video>
 
-### Settings editor search updates
+### Settings editor search updates {#settings-editor-search-updates}
 
 By default, the Settings editor search now uses the key-matching algorithm we introduced in the previous release. It also shows additional settings even when the settings ID matches exactly with a known setting.
 
@@ -277,7 +277,7 @@ By default, the Settings editor search now uses the key-matching algorithm we in
 
 _Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
 
-### New setting for window controls (Linux, Windows)
+### New setting for window controls (Linux, Windows) {#new-setting-for-window-controls-linux-windows}
 
 **Setting**: `setting(window.controlsStyle)`
 
@@ -287,9 +287,9 @@ If you have set the title bar style (`setting(window.titleBarStyle)`) to `custom
 - `custom`: renders window controls with custom styling if you prefer that over the native one
 - `hidden`: hides window controls entirely if you want to gain some space in the title bar and are a more keyboard-centric user
 
-## Code Editing
+## Code Editing {#code-editing}
 
-### Next Edit Suggestions general availability
+### Next Edit Suggestions general availability {#next-edit-suggestions-general-availability}
 
 **Setting**: `setting(github.copilot.nextEditSuggestions.enabled:true)`
 
@@ -300,7 +300,7 @@ We're happy to announce the general availability of Next Edit Suggestions (NES)!
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/next-edit-suggestion.mp4" title="Video that shows NES suggesting edits based on the recent changes due by the user." autoplay loop controls muted></video>
 
-### AI edits improvements
+### AI edits improvements {#ai-edits-improvements}
 
 We have done some smaller tweaks when generating edits with AI:
 
@@ -308,7 +308,7 @@ We have done some smaller tweaks when generating edits with AI:
 
 * We now explicitly save a file when you decide to keep the AI edits.
 
-### Tool-based edit mode
+### Tool-based edit mode {#tool-based-edit-mode}
 
 **Setting**: `setting(chat.edits2.enabled:true)`
 
@@ -320,7 +320,7 @@ We've learned that prompting to get consistent results across different models i
 
 This setting will be enabled gradually for users in VS Code Stable.
 
-### Inline suggestion syntax highlighting
+### Inline suggestion syntax highlighting {#inline-suggestion-syntax-highlighting}
 
 **Setting**: `setting(editor.inlineSuggest.syntaxHighlightingEnabled)`
 
@@ -332,25 +332,25 @@ If you prefer inline suggestions without syntax highlighting, you can disable it
 
 ![Screenshot of the editor showing that highlighting for ghost text is turned off.](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingDisabled.png)
 
-### Tree-Sitter based syntax highlighting (Preview)
+### Tree-Sitter based syntax highlighting (Preview) {#tree-sitter-based-syntax-highlighting-preview}
 
 **Setting**: `setting(editor.experimental.preferTreeSitter.css:true)` and `setting(editor.experimental.preferTreeSitter.regex:true)`
 
 Building upon the previous work for using Tree-Sitter for syntax highlighting, we now support experimental, Tree-Sitter based, syntax highlighting for CSS files and for regular expressions within TypeScript.
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Minimal version of Jupyter notebook document to 4.5
+### Minimal version of Jupyter notebook document to 4.5 {#minimal-version-of-jupyter-notebook-document-to-45}
 
 The default version of `nbformat` for new notebooks has been bumped from 4.2 to 4.5, which will now set `id` fields for each cell of the notebook to help with calculating diffs. You can also manually update existing notebooks by setting the `nbformat_minor` to `5` in the raw JSON of the notebook.
 
-### AI notebook editing improvements
+### AI notebook editing improvements {#ai-notebook-editing-improvements}
 
 AI-powered editing support for notebooks (including agent mode) is now available in the Stable release. This was added last month as a preview feature in [VS Code Insiders](https://code.visualstudio.com/insiders).
 
 You can now use chat to edit notebook files with the same intuitive experience as editing code files: modify content across multiple cells, insert and delete cells, and change cell types. This feature provides a seamless workflow when working with data science or documentation notebooks.
 
-#### New notebook tool
+#### New notebook tool {#new-notebook-tool}
 
 VS Code now provides a dedicated tool for creating new Jupyter notebooks directly from chat. This tool plans and creates a new notebook based on your query.
 
@@ -358,19 +358,19 @@ Use the new notebook tool in agent mode or edit mode (make sure to enable the im
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/new-notebook-tool-release-notes.mp4" title="Video showing creation of a new Jupyter notebook using chat in agent mode and the New Notebook tool." autoplay loop controls muted></video>
 
-#### Navigate through AI edits
+#### Navigate through AI edits {#navigate-through-ai-edits}
 
 Use the diff toolbars to iterate through and review each AI edit across cells.
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/navigate-notebook-edits.mp4" title="Video showing chat implementing a TODO task and then navigating through those changes." autoplay loop controls muted></video>
 
-#### Undo AI edits
+#### Undo AI edits {#undo-ai-edits}
 
 When focused on a cell container, the **Undo** command reverts the full set of AI changes at the notebook level.
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/undo-copilot-notebook-edits.mp4" title="Video showing chat making several edits to a notebook and undoing those edits with ctrl+z." autoplay loop controls muted></video>
 
-#### Text and image output support in chat
+#### Text and image output support in chat {#text-and-image-output-support-in-chat}
 
 You can now add notebook cell outputs, such as text, errors, and images, directly to chat as context. This lets you reference the output when using ask, edit, or agent mode, making it easier for the language model to understand and assist with your notebook content.
 
@@ -384,25 +384,25 @@ To attach the cell output image as chat context:
 
 <video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-image-demo.mp4" title="Video that shows attaching an notebook cell output image to chat." autoplay loop controls muted></video>
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Chat agent mode improvements
+### Chat agent mode improvements {#chat-agent-mode-improvements}
 
 You are now notified when manual action is required during a tool invocation, such as "Run command in terminal." This information is also included in the ARIA label for the relevant chat response, enhancing accessibility for screen reader users.
 
 Additionally, a new accessibility help dialog is available in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode), explaining what users can expect from the feature and how to navigate it effectively.
 
-### Accessibility Signals for chat edit actions
+### Accessibility Signals for chat edit actions {#accessibility-signals-for-chat-edit-actions}
 
 VS Code now provides auditory signals when you keep or undo AI-generated edits. These signals are configurable via `setting(accessibility.signals.editsKept)` and `setting(accessibility.signals.editsUndone)`.
 
-### Improved ARIA labels for suggest control
+### Improved ARIA labels for suggest control {#improved-aria-labels-for-suggest-control}
 
 ARIA labels for suggest control items now include richer and descriptive information, such as the type of suggestion (for example, method or variable). This information was previously only available to sighted users via icons.
 
-## Source Control
+## Source Control {#source-control}
 
-### Reference picker improvements
+### Reference picker improvements {#reference-picker-improvements}
 
 **Setting**: `setting(git.showReferenceDetails)`
 
@@ -412,7 +412,7 @@ Hide the additional information by toggling the `setting(git.showReferenceDetail
 
 ![Screenshot of the source control references picker showing a list of git branches with details of the last commit, and ahead/behind information.](https://code.visualstudio.com/assets/updates/1_99/scm-reference-picker.png)
 
-### Repository Status Bar item
+### Repository Status Bar item {#repository-status-bar-item}
 
 Workspaces that contain multiple repositories now have a Source Control Provider Status Bar item that displays the active repository to the left of the branch picker. The new Status Bar item provides additional context, so you know which is the active repository as you navigate between editors and use the Source Control view.
 
@@ -420,25 +420,25 @@ To hide the Source Control Provider Status Bar item, right-click the Status Bar,
 
 ![Screenshot showing the repository status bar item for workspaces that contain more than one repository.](https://code.visualstudio.com/assets/updates/1_99/scm-repository-picker.png)
 
-### Git blame editor decoration improvements
+### Git blame editor decoration improvements {#git-blame-editor-decoration-improvements}
 
 We have heard feedback that while typing, the "Not Yet Committed" editor decoration does not provide much value and it is more of a distraction. Starting this milestone the "Not Yet Committed" editor decoration is only shown while navigating around the codebase either by using the keyboard or the mouse.
 
-### Commit input cursor customization
+### Commit input cursor customization {#commit-input-cursor-customization}
 
 This milestone, thanks to a community contribution, we have added the `setting(editor.cursorStyle)` and `setting(editor.cursorWidth)` settings to the list of settings that are being honored by the source control input box.
 
-## Terminal
+## Terminal {#terminal}
 
-### Reliability in agent mode
+### Reliability in agent mode {#reliability-in-agent-mode}
 
 The tool that allows agent mode to run commands in the terminal has a number of reliability and compatibility improvements. You should expect fewer cases where the tool gets stuck or where the command finishes without the output being present.
 
 One of the bigger changes is the introduction of the concept of "rich" quality [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration), as opposed to "basic" and "none". The shell integration scripts shipped with VS Code should generally all enable rich shell integration which provides the best experience in the run in terminal tool (and terminal usage in general). You can view the shell integration quality by hovering over the terminal tab.
 
-### Terminal IntelliSense improvements (Preview)
+### Terminal IntelliSense improvements (Preview) {#terminal-intellisense-improvements-preview}
 
-#### Enhanced IntelliSense for the `code` CLI
+#### Enhanced IntelliSense for the `code` CLI {#enhanced-intellisense-for-the-code-cli}
 
 IntelliSense now supports subcommands for the `code`, `code-insiders`, and `code-tunnel` CLI. For instance, typing `code tunnel` shows available subcommands like `help`, `kill`, and `prune`, each with descriptive info.
 
@@ -458,19 +458,19 @@ Additionally, `code --locate-shell-integration-path` now provides shell-specific
 
 ![Screenshot of the VSCode terminal showing a command input: code --locate-shell-integration-path with a dropdown menu listing shell options bash, fish, pwsh, and zsh.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-locate-shell-integration.png)
 
-#### Auto-refresh for global commands
+#### Auto-refresh for global commands {#auto-refresh-for-global-commands}
 
 The terminal now automatically refreshes its list of global commands when changes are detected in the system `bin` directory. This means newly installed CLI tools (for example, after running `npm install -g pnpm`) will show up in completions immediately, without the need to reload the window.
 
 Previously, completions for new tools wouldn’t appear due to caching until the window was manually reloaded.
 
-#### Option value context
+#### Option value context {#option-value-context}
 
 Terminal suggestions now display contextual information about expected option values, helping you more easily complete commands.
 
 ![Screenshot of the terminal showing a command in progress: npm install --omit. The terminal suggest widget displays <package type> to indicate that's the option that's expected.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-options.png)
 
-#### Rich completions for fish shell
+#### Rich completions for fish shell {#rich-completions-for-fish-shell}
 
 In the last release, we added detailed command completions for bash and zsh. This iteration, we've expanded that support to fish as well. Completion details are sourced from the shell’s documentation or built-in help commands.
 
@@ -478,19 +478,19 @@ For example, typing `jobs` in fish displays usage info and options:
 
 ![Screenshot of the Visual Studio Code Terminal with a fish terminal showing a user has typed jobs. The suggest widget shown provides information about the jobs command with detailed usage examples and options.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-fish.png)
 
-#### File type icons in suggestions
+#### File type icons in suggestions {#file-type-icons-in-suggestions}
 
 Suggestions in the terminal now include specific icons for different file types, making it easier to distinguish between scripts and binaries at a glance.
 
 ![Screenshot of the terminal, showing suggestions for various script files, including code.sh, code-cli.sh, and code-server.js. Icons indicate the specific file type.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-icons.png)
 
-#### Inline suggestion details
+#### Inline suggestion details {#inline-suggestion-details}
 
 Inline suggestions, displayed as ghost text in the terminal, continue to appear at the top of the suggestions list. In this release, we've added command details to these entries to provide more context before accepting them.
 
 ![Screenshot of the terminal, showing the Block command as ghost text in the terminal. The first suggestion is block and it contains usage information.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-consolidated.png)
 
-### New simplified and detailed tab hover
+### New simplified and detailed tab hover {#new-simplified-and-detailed-tab-hover}
 
 By default, the terminal tab shows much less detail now.
 
@@ -500,11 +500,11 @@ To view everything, there is a **Show Details** button at the bottom of the hove
 
 ![Screenshot of the detailed hover showing extensions that contribute to the environment and detailed shell integration diagnostics](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-detailed.png)
 
-### Signed PowerShell shell integration
+### Signed PowerShell shell integration {#signed-powershell-shell-integration}
 
 The shell integration PowerShell script is now signed, meaning shell integration on Windows when using the default PowerShell execution policy of `RemoteSigned` should now start working automatically. You can read more about [shell integration's benefits here](https://code.visualstudio.com/docs/terminal/shell-integration).
 
-### Terminal shell type
+### Terminal shell type {#terminal-shell-type}
 
 This iteration, we've finalized our terminal shell API, allowing extensions to see the user's current shell type in their terminal.
 Subscribing to event `onDidChangeTerminalState` allows you to see the changes of the user's shell type in the terminal.
@@ -512,73 +512,73 @@ For example, the shell could change from zsh to bash.
 
 The list of all the shells that are identifiable are currently listed [here](https://github.com/microsoft/vscode/blob/99e3ae5586a74ab1c554b6a2a50bb9eb3a4ff7fd/src/vscode-dts/vscode.d.ts#L7740-L7750)
 
-## Remote Development
+## Remote Development {#remote-development}
 
-### Linux legacy server support has ended
+### Linux legacy server support has ended {#linux-legacy-server-support-has-ended}
 
 As of release 1.99, you can no longer connect to these servers. As noted in our [1.97 release](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md#migration-path-for-linux-legacy-server), users that require additional time to complete migration to a supported Linux distro can provide custom builds of `glibc` and `libstdc++` as a workaround. More info on this workaround can be found in the [FAQ](https://aka.ms/vscode-remote/faq/old-linux) section.
 
-## Enterprise
+## Enterprise {#enterprise}
 
-### macOS device management
+### macOS device management {#macos-device-management}
 
 VS Code now supports device management on macOS in addition to Windows.  This allows system administrators to push policies from a centralized management system, like Microsoft Intune.
 
 See the [Enterprise Support](https://code.visualstudio.com/docs/setup/enterprise#_device-management) documentation for more details.
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### Python
+### Python {#python}
 
-#### Better support for editable installs with Pylance
+#### Better support for editable installs with Pylance {#better-support-for-editable-installs-with-pylance}
 
 Pylance now supports resolving import paths for packages installed in editable mode (`pip install -e .`) as defined by [PEP 660](https://peps.python.org/pep-0660/), which enables an improved IntelliSense experience in these scenarios.
 
 This feature is enabled via `setting(python.analysis.enableEditableInstalls:true)` and we plan to start rolling it out as the default experience throughout this month. If you experience any issues, please report them at the [Pylance GitHub repository](https://github.com/microsoft/pylance-release).
 
-#### Faster and more reliable diagnostic experience with Pylance (Experimental)
+#### Faster and more reliable diagnostic experience with Pylance (Experimental) {#faster-and-more-reliable-diagnostic-experience-with-pylance-experimental}
 
 We're starting to roll out a change to improve the accuracy and responsiveness of Pylance's diagnostics when using the release version of the extension. This is especially helpful for scenarios with multiple open or recently closed files.
 
 If you do not want to wait for the roll-out, you can set `setting(python.analysis.usePullDiagnostics:true)`. If you experience any issues, please report them at the [Pylance GitHub repository](https://github.com/microsoft/pylance-release).
 
-#### Pylance custom Node.js arguments
+#### Pylance custom Node.js arguments {#pylance-custom-nodejs-arguments}
 
 There's a new `setting(python.analysis.nodeArguments)` setting, which allows you to pass custom arguments directly to Node.js when using `setting(python.analysis.nodeExecutable)`. By default, it is set to `"--max-old-space-size=8192"`, but you can modify it to suit your needs (for example, to allocate more memory to Node.js when working with large workspaces).
 
 Additionally, when setting `setting(python.analysis.nodeExecutable)` to `auto`, Pylance now automatically downloads Node.js.
 
-## Extension authoring
+## Extension authoring {#extension-authoring}
 
-### Terminal.shellIntegration tweaks
+### Terminal.shellIntegration tweaks {#terminalshellintegration-tweaks}
 
 The `Terminal.shellIntegration` API will now only light up when command detection happens. Previously, this should work when _only_ the current working directory was reported, which caused `TerminalShellIntegration.executeCommand` to not function well.
 
 Additionally, `TerminalShellIntegration.executeCommand` will now behave more consistently and track multiple "sub-executions" for a single command line that ended up running multiple commands. This depends on rich shell integration as mentioned in the [reliability in agent mode section](#reliability-in-agent-mode).
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Task problem matcher status
+### Task problem matcher status {#task-problem-matcher-status}
 
 We've added [proposed API](https://github.com/microsoft/vscode/blob/c98092f1caaad64e18be5b3f8761a09c24c7669c/src/vscode-dts/vscode.proposed.taskProblemMatcherStatus.d.ts#L9-L40), so that extensions can monitor when a task's problem matchers start and finish processing lines. Enable it with `taskProblemMatcherStatus`.
 
-### Send images to LLM
+### Send images to LLM {#send-images-to-llm}
 
 This iteration, we've added a [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts), so that extensions can attach images and send vision requests to the language model. Attachments must be the raw, non base64-encoded binary data of the image (`Uint8Array`). Maximum image size is 5MB.
 
 Check out [this API proposal issue](https://github.com/microsoft/vscode/issues/245104) to see a usage example and to stay up to date with the status of this API.
 
-## Engineering
+## Engineering {#engineering}
 
-### Use new `/latest` API from Marketplace to check for extensions updates
+### Use new `/latest` API from Marketplace to check for extensions updates {#use-new-latest-api-from-marketplace-to-check-for-extensions-updates}
 
 Couple of milestones back, we introduced a new API endpoint in `vscode-unpkg` service to check for extension updates. Marketplace now supports the same endpoint and VS Code is now using this endpoint to check for extension updates. This is behind an experiment and will be rolled out to users in stages.
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -587,7 +587,7 @@ Contributions to our issue tracking:
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 
-### Pull requests
+### Pull requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_99.md
+++ b/docs/release-notes/v1_99.md
@@ -1,0 +1,673 @@
+---
+Order: 108
+TOCTitle: March 2025
+PageTitle: Visual Studio Code March 2025
+MetaDescription: Learn what is new in the Visual Studio Code March 2025 Release (1.99)
+MetaSocialImage: 1_99/release-highlights.png
+Date: 2025-04-03
+DownloadVersion: 1.99.0
+---
+# March 2025 (version 1.99)
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the March 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* **Agent mode**
+  * Agent mode is available in VS Code Stable. Enable it by setting `setting(chat.agent.enabled:true)` ([more...](#agent-mode-is-available-in-vs-code-stable)).
+  * Extend agent mode with Model Context Protocol (MCP) server tools ([more...](#model-context-protocol-server-support)).
+  * Try the new built-in tools in agent mode for fetching web content, finding symbol references, and deep thinking ([more...](#agent-mode-tools)).
+
+* **Code editing**
+  * Next Edit Suggestions is now generally available ([more...](#next-edit-suggestions-general-availability)).
+  * Benefit from fewer distractions such as diagnostics events while AI edits are applied in the editor ([more...](#ai-edits-improvements)).
+
+* **Chat**
+  * Use your own API keys to access more language models in chat (preview) ([more...](#bring-your-own-key-byok-preview)).
+  * Easily switch between ask, edit, and agent mode from the unified chat experience ([more...](#unified-chat-experience)).
+  * Experience improved workspace search speed and accuracy with instant remote workspace indexing ([more...](#faster-workspace-searches-with-instant-indexing)).
+
+* **Notebook editing**
+  * Create and edit notebooks as easily as code files with support for edit and agent mode ([more...](#ai-notebook-editing-improvements)).
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## Chat
+
+### Agent mode is available in VS Code Stable
+
+**Setting**: `setting(chat.agent.enabled:true)`
+
+We're happy to announce that agent mode is available in VS Code Stable! Enable it by setting `setting(chat.agent.enabled:true)`. Enabling the setting will no longer be needed in the following weeks, as we roll out enablement by default to all users.
+
+Check out the [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) or select agent mode from the chat mode picker in the Chat view.
+
+![Screenshot that shows the Chat view, highlighting agent mode selected in the chat mode picker.](images/1_99/copilot-edits-agent-mode.png)
+
+### Model Context Protocol server support
+
+This release supports [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) servers in agent mode. MCP offers a standardized method for AI models to discover and interact with external tools, applications, and data sources. When you input a chat prompt using agent mode in VS Code, the model can invoke various tools to perform tasks such as file operations, accessing databases, or retrieving web data. This integration enables more dynamic and context-aware coding assistance.
+
+MCP servers can be configured under the `mcp` section in your user, remote, or `.code-workspace` settings, or in `.vscode/mcp.json` in your workspace. The configuration supports input variables to avoid hard-coding secrets and constants. For example, you can use `${env:API_KEY}` to reference an environment variable or `${input:ENDPOINT}` to prompt for a value when the server is started.
+
+You can use the **MCP: Add Server** command to quickly set up an MCP server from a command line invocation, or use an AI-assisted setup from an MCP server published to Docker, npm, or PyPI.
+
+When a new MCP server is added, a refresh action is shown in the Chat view, which can be used to start the server and discover the tools. Afterwards, servers are started on-demand to save resources.
+
+<video src="images/1_99/mcp.mp4" title="Video that shows using a Github MCP tool in chat." autoplay loop controls muted></video>
+_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+
+If you've already been using MCP servers in other applications such as Claude Desktop, VS Code will discover them and offer to run them for you. This behavior can be toggled with the setting `setting(chat.mcp.discovery.enabled)`.
+
+You can see the list of MCP servers and their current status using the **MCP: List Servers** command, and pick the tools available for use in chat by using the **Select Tools** button in agent mode.
+
+You can read more about how to install and use MCP servers in [our documentation](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+
+### Agent mode tools
+
+This milestone, we have added several new built-in tools to agent mode.
+
+#### Thinking tool (Experimental)
+
+**Setting**: `setting(github.copilot.chat.agent.thinkingTool:true)`.
+
+Inspired by [Anthropic's research](https://www.anthropic.com/engineering/claude-think-tool), we've added support for a thinking tool in agent mode that can be used to give any model the opportunity to think between tool calls. This improves our agent's performance on complex tasks in-product and on the [SWE-bench](https://www.swebench.com/) eval.
+
+#### Fetch tool
+
+Use the `#fetch` tool for including content from a publicly accessible webpage in your prompt. For instance, if you wanted to include the latest documentation on a topic like [MCP](#model-context-protocol-server-support), you can ask to fetch [the full documentation](https://modelcontextprotocol.io/llms-full.txt) (which is conveniently ready for an LLM to consume) and use that in a prompt. Here's a video of what that might look like:
+
+<video src="images/1_99/fetch.mp4" title="Video that shows using the fetch tool to fetch the model context protocol documentation." autoplay loop controls muted></video>
+
+In agent mode, this tool is picked up automatically but you can also reference it explicitly in the other modes via `#fetch`, along with the URL you are looking to fetch.
+
+This tool works by rendering the webpage in a headless browser window in which the data of that page is cached locally, so you can freely ask the model to fetch the contents over and over again without the overhead of re-rendering.
+
+Let us know how you use the `#fetch` tool, and what features you'd like to see from it!
+
+**Fetch tool limitations:**
+
+* Currently, JavaScript is disabled in this browser window. The tool will not be able to acquire much context if the website depends entirely on JavaScript to render content. This is a limitation we are considering changing and likely will change to allow JavaScript.
+* Due to the headless nature, we are unable to fetch pages that are behind authentication, as this headless browser exists in a different browser context than the browser you use. Instead, consider using [MCP](#model-context-protocol-server-support) to bring in an MCP server that is purpose-built for that target, or a generic browser MCP server such as the [Playwright MCP server](https://github.com/microsoft/playwright-mcp).
+
+#### Usages tool
+
+The `#usages` tool is a combination of "Find All References", "Find Implementation", and "Go to Definition". This tool can help chat to learn more about a function, class, or interface. For instance, chat can use this tool to look for sample implementations of an interface or to find all places that need to be changed when making a refactoring.
+
+In agent mode this tool will be picked up automatically but you can also reference it explicitly via `#usages`
+
+### Create a new workspace with agent mode (Experimental)
+
+**Setting**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
+
+You can now scaffold a new VS Code workspace in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode). Whether you’re setting up a VS Code extension, an MCP server, or other development environments, agent mode helps you to initialize, configure, and launch these projects with the necessary dependencies and settings.
+
+<video src="images/1_99/new-workspace-demo.mp4" title="Video showing creation of a new MCP server to fetch top N stories from hacker news using Agent mode." autoplay loop controls muted></video>
+
+### VS Code extension tools in agent mode
+
+Several months ago, we finalized our extension API for [language model tools](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) contributed by VS Code extensions. Now, you can use these tools in agent mode.
+
+Any tool contributed to this API which sets `toolReferenceName` and `canBeReferencedInPrompt` in its configuration is automatically available in agent mode.
+
+By contributing a tool in an extension, it has access to the full VS Code extension APIs, and can be easily installed via the Extension Marketplace.
+
+Similar to tools from MCP servers, you can enable and disable these with the **Select Tools** button in agent mode. See our [language model tools extension guide](https://code.visualstudio.com/api/extension-guides/tools#create-a-language-model-tool) to build your own!
+
+### Agent mode tool approvals
+
+As part of completing the tasks for a user prompt, agent mode can run tools and terminal commands. This is powerful but potentially comes with risks. Therefore, you need to approve the use of tools and terminal commands in agent mode.
+
+To optimize this experience, you can now remember that approval on a session, workspace, or application level. This is not currently enabled for the terminal tool, but we plan to develop an approval system for the terminal in future releases.
+
+![Screenshot that shows the agent mode tool Continue button dropdown options for remembering approval.](./images/1_99/chat-tool-approval.png)
+
+In case you want to auto-approve _all_ tools, you can now use the experimental `setting(chat.tools.autoApprove:true)` setting. This will auto-approve all tools, and VS Code will not ask for confirmation when a language model wishes to run tools. Bear in mind that with this setting enabled, you will not have the opportunity to cancel potentially destructive actions a model wants to take.
+
+We plan to expand this setting with more granular capabilities in the future.
+
+### Agent evaluation on SWE-bench
+
+VS Code's agent achieves a pass rate of 56.0% on `swebench-verified` with Claude 3.7 Sonnet, following Anthropic's [research](https://www.anthropic.com/engineering/swe-bench-sonnet) on configuring agents to execute without user input in the SWE-bench environment. Our experiments have translated into shipping improved prompts, tool descriptions and tool design for agent mode, including new tools for file edits that are in-distribution for Claude 3.5 and 3.7 Sonnet models.
+
+### Unified Chat view
+
+For the past several months, we've had a "Chat" view for asking questions to the language model, and a "Copilot Edits" view for an AI-powered code editing session. This month, we aim to streamline the chat-based experience by merging the two views into one Chat view. In the Chat view, you'll see a dropdown with three modes:
+
+![Screenshot that shows the chat mode picker in the Chat view.](images/1_99/chat-modes.png)
+
+- **[Ask](https://code.visualstudio.com/docs/copilot/chat/chat-ask-mode)**: This is the same as the previous Chat view. Ask questions about your workspace or coding in general, using any model. Use `@` to invoke built-in chat participants or from installed [extensions](https://marketplace.visualstudio.com/search?term=chat-participant&target=VSCode&category=All%20categories&sortBy=Relevance). Use `#` to attach any kind of context manually.
+- **[Agent](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)**: Start an agentic coding flow with a set of tools that let it autonomously collect context, run terminal commands, or take other actions to complete a task. Agent mode is enabled for all [VS Code Insiders](https://code.visualstudio.com/insiders/) users, and we are rolling it out to more and more users in VS Code Stable.
+- **[Edit](https://code.visualstudio.com/docs/copilot/chat/copilot-edits)**: In Edit mode, the model can make directed edits to multiple files. Attach `#codebase` to let it find the files to edit automatically. But it won't run terminal commands or do anything else automatically.
+
+> **Note**: If you don't see agent mode in this list, then either it has not yet been enabled for you, or it's disabled by organization policy and needs to be enabled by the [organization owner](https://aka.ms/github-copilot-org-enable-features).
+
+Besides making your chat experience simpler, this unification enables a few new features for AI-powered code editing:
+
+- **Switch modes in the middle of a conversation**: For example, you might start brainstorming an app idea in ask mode, then switch to agent mode to execute the plan. Tip: press `kb(workbench.action.chat.toggleAgentMode)` to change modes quickly.
+- **Edit sessions in history**: Use the **Show Chats** command (clock icon at the top of the Chat view) to restore past edit sessions and keep working on them.
+- **Move chat to editor or window**: Select **Open Chat in New Editor/New Window** to pop out your chat conversation from the side bar into a new editor tab or separate VS Code window. Chat has supported this for a long time, but now you can run your edit/agent sessions from an editor pane or a separate window as well.
+- **Multiple agent sessions**: Following from the above point, this means that you can even run multiple agent sessions at the same time. You might like to have one chat in agent mode working on implementing a feature, and another independent session for doing research and using other tools. Directing two agent sessions to edit files at the same time is not recommended, it can lead to confusion.
+
+### Bring Your Own Key (BYOK) (Preview)
+
+Copilot Pro and Copilot Free users can now bring their own API keys for popular providers such as Azure, Anthropic, Gemini, Open AI, Ollama, and Open Router. This allows you to use new models that are not natively supported by Copilot the very first day that they're released.
+
+To try it, select **Manage Models...** from the model picker. We’re actively exploring support for Copilot Business and Enterprise customers and will share updates in future releases. To learn more about this feature, head over to our [docs](https://code.visualstudio.com/docs/copilot/language-models).
+
+![A screenshot of a "Manage Models - Preview" dropdown menu in a user interface. The dropdown has the label "Select a provider" at the top, with a list of options below it. The options include "Anthropic" (highlighted in blue), "Azure," "Gemini," "OpenAI," "Ollama," and "OpenRouter." A gear icon is displayed next to the "Anthropic" option.](images/1_99/byok.png)
+
+### Reusable prompt files
+
+#### Improved configuration
+
+**Setting**: `setting(chat.promptFilesLocations)`
+
+The `setting(chat.promptFilesLocations)` setting now supports glob patterns in file paths. For example, to include all `.prompt.md` files in the currently open workspace, you can set the path to `{ "**": true }`.
+
+Additionally, the configuration now respects case sensitivity on filesystems where it applies, aligning with the behavior of the host operating system.
+
+#### Improved prompt file editing
+
+- Your `.prompt.md` files now offer basic autocompletion for filesystem paths and highlight valid file references. Broken links on the other hand now appear as warning or error squiggles and provide detailed diagnostic information.
+- You can now manage prompts using edit and delete actions in the prompt file list within the **Chat: Use Prompt** command.
+- Folder references in prompt files are no longer flagged as invalid.
+- Markdown comments are now properly handled, for instance, all commented-out links are ignored when generating the final prompt sent to the LLM model.
+
+#### Alignment with custom instructions
+
+The `.github/copilot-instructions.md` file now behaves like any other reusable `.prompt.md` file, with support for nested link resolution and enhanced language features. Furthermore, any `.prompt.md` file can now be referenced and is handled appropriately.
+
+Learn more about [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
+
+#### User prompts
+
+The **Create User Prompt** command now allows creating a new type of prompts called _user prompts_. These are stored in the user data folder and can be synchronized across machines, similar to code snippets or user settings. The synchronization can be configured in [Sync Settings](https://code.visualstudio.com/docs/configure/settings-sync) by using the **Prompts** item in the synchronization resources list.
+
+### Improved vision support (Preview)
+
+Last iteration, Copilot Vision was enabled for `GPT-4o`. Check our [release notes](https://code.visualstudio.com/updates/v1_98#_copilot-vision-preview) to learn more about how you can attach and use images in chat.
+
+This release, you can attach images from any browser via drag and drop. Images drag and dropped from browsers must have the correct url extension, with `.jpg`, `.png`, `.gif`, `.webp`, or `.bmp`.
+
+<video src="images/1_99/image-url-dnd.mp4" title="Video that shows an image from Chrome being dragged into the chat panel." autoplay loop controls muted></video>
+
+## Configure the editor
+
+### Unified chat experience
+
+We have streamlined the chat experience in VS Code into a single unified Chat view. Instead of having to move between separate views and lose the context of a conversation, you can now easily switch between the different chat modes.
+
+![Screenshot that shows the chat mode picker in the Chat view.](images/1_99/chat-modes.png)
+
+Depending on your scenario, use either of these modes, and freely move mid-conversation:
+
+- Ask mode: optimized for asking questions about your codebase and brainstorming ideas.
+- Edit mode: optimized for making edits across multiple files in your codebase.
+- Agent mode: optimized for an autonomous coding flow, combining code edits and tool invocations.
+
+Get more details about the [unified chat view](#unified-chat-view).
+
+### Faster workspace searches with instant indexing
+
+[Remote workspace indexes](https://code.visualstudio.com/docs/copilot/reference/workspace-context#remote-index) accelerate searching large codebases for relevant code snippets that AI uses while answering questions and generating edits. These remote indexes are especially useful for large codebases with tens or even hundreds of thousands of files.
+
+Previously, you'd have to press a button or run a command to build and start using a remote workspace index. With our new instant indexing support, we now automatically build the remote workspace index when you first try to ask a `#codebase`/`@workspace` question. In most cases, this remote index can be built in a few seconds. Once built, any codebase searches that you or anyone else working with that repo in VS Code makes will automatically use the remote index.
+
+Keep in mind that remote workspaces indexes are currently only available for code stored on GitHub. To use a remote workspace index, make sure your workspace contains a git project with a GitHub remote. You can use the [Copilot status menu](#copilot-status-menu) to see the type of index currently being used:
+
+![Screenshot that shows the workspace index status in the Copilot Status Bar menu.](images/1_99/copilot-workspace-index-remote.png)
+
+To manage load, we are slowly rolling out instant indexing over the next few weeks, so you may not see it right away. You can still run the `GitHub Copilot: Build remote index command` command to start using a remote index when instant indexing is not yet enabled for you.
+
+### Copilot status menu
+
+The Copilot status menu, accessible from the Status Bar, is now enabled for all users. This milestone we added some new features to it:
+
+- View [workspace index](https://code.visualstudio.com/docs/copilot/reference/workspace-context) status information at any time.
+
+    ![Screenshot that shows the workspace index status of a workspace in the Copilot menu.](images/1_99/copilot-worksspace-index-local-status.png)
+
+- View if code completions are enabled for the active editor.
+
+    A new icon reflects the status, so that you can quickly see if code completions are enabled or not.
+
+    ![Screenshot that shows the Copilot status icon when completions is disabled.](images/1_99/copilot-disabled-status.png)
+
+- Enable or disable [code completions and NES](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
+
+### Out of the box Copilot setup (Experimental)
+
+**Setting**: `setting(chat.setupFromDialog)`
+
+We are shipping an experimental feature to show functional chat experiences out of the box. This includes the Chat view, editor/terminal inline chat, and quick chat. The first time you send a chat request, we will guide you through signing in and signing up for Copilot Free.
+
+<video src="images/1_99/copilot-ootb.mp4" title="Video that shows Copilot out of the box." autoplay loop controls muted></video>
+
+If you want to see this experience for yourself, enable the `setting(chat.setupFromDialog)` setting.
+
+### Chat prerelease channel mismatch
+
+If you have the prerelease version of the Copilot Chat extension installed in VS Code Stable, a new welcome screen will inform you that this configuration is not supported. Due to rapid development of chat features, the extension will not activate in VS Code Stable.
+
+The welcome screen provides options to either switch to the release version of the extension or download [VS Code Insiders](https://code.visualstudio.com/insiders/).
+
+![Screenshot that shows the welcome view of chat, indicating that the pre-release version of the extension is not supported in VS Code stable. A button is shown to switch to the release version, and a secondary link is shown to switch to VS Code Insiders.](images/1_99/welcome-pre-release.png)
+
+### Semantic text search improvements (Experimental)
+
+**Setting**: `setting(github.copilot.chat.search.semanticTextResults:true)`
+
+AI-powered semantic text search is now enabled by default in the Search view. Use the `kb(search.action.searchWithAI)` keyboard shortcut to trigger a semantic search, which shows you the most relevant results based on your query, on top of the regular search results.
+
+<video src="images/1_99/semantic-search.mp4" title="Video that shows semantic search improvements in Visual Studio Code." autoplay loop controls muted></video>
+
+You can also reference the semantic search results in your chat prompt by using the `#searchResults` tool. This allows you to ask the LLM to summarize or explain the results, or even generate code based on them.
+
+<video src="images/1_99/semantic-search-results.mp4" title="Video that shows using search results in chat view." autoplay loop controls muted></video>
+
+### Settings editor search updates
+
+By default, the Settings editor search now uses the key-matching algorithm we introduced in the previous release. It also shows additional settings even when the settings ID matches exactly with a known setting.
+
+<video src="images/1_99/settings-search-show-extra.mp4" title="Video that shows searching for 'files.autoSave' and 'mcp' in the Settings editor, both show more than one setting." autoplay loop controls muted></video>
+
+_Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
+
+### New setting for window controls (Linux, Windows)
+
+**Setting**: `setting(window.controlsStyle)`
+
+If you have set the title bar style (`setting(window.titleBarStyle)`) to `custom`, you can now choose between three different styles for the window controls.
+
+- `native`: this is the default and renders window controls according to the underlying platform
+- `custom`: renders window controls with custom styling if you prefer that over the native one
+- `hidden`: hides window controls entirely if you want to gain some space in the title bar and are a more keyboard-centric user
+
+## Code Editing
+
+### Next Edit Suggestions general availability
+
+**Setting**: `setting(github.copilot.nextEditSuggestions.enabled:true)`
+
+We're happy to announce the general availability of Next Edit Suggestions (NES)! In addition, we've also made several improvements to the overall user experience of NES:
+
+* Make edit suggestions more compact, less interfering with surrounding code, and easier to read at a glance.
+* Updates to the gutter indicator to make sure that all suggestions are more easily noticeable.
+
+<video src="images/1_99/next-edit-suggestion.mp4" title="Video that shows NES suggesting edits based on the recent changes due by the user." autoplay loop controls muted></video>
+
+### AI edits improvements
+
+We have done some smaller tweaks when generating edits with AI:
+
+* Mute diagnostics events outside the editor while rewriting a file with AI edits. Previously, we already disabled squiggles in this scenario. These changes reduce flicker in the Problems panel and also ensure that we don't issue requests for the quick fix code actions.
+
+* We now explicitly save a file when you decide to keep the AI edits.
+
+### Tool-based edit mode
+
+**Setting**: `setting(chat.edits2.enabled:true)`
+
+We're making a change to the way [edit mode in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-edits) operates. The new edit mode uses the same approach as agent mode, where it lets the model call a tool to make edits to files. An upside to this alignment is that it enables you to switch seamlessly between all three modes, while providing a huge simplification to how these modes work under the hood.
+
+A downside is that this means that the new mode only works with the same reduced set of models that agent mode works with, namely models that support tool calling and have been tested to be sure that we can have a good experience when tools are involved. You may notice models like `o3-mini` and `Claude 3.7 (Thinking)` missing from the list in edit mode. If you'd like to keep using those models for editing, disable the `setting(chat.edits2.enabled)` setting to revert to the previous edit mode. You'll be asked to clear the session when switching modes.
+
+We've learned that prompting to get consistent results across different models is harder when using tools, but we are working on getting these models lit up for edit (and agent) modes.
+
+This setting will be enabled gradually for users in VS Code Stable.
+
+### Inline suggestion syntax highlighting
+
+**Setting**: `setting(editor.inlineSuggest.syntaxHighlightingEnabled)`
+
+With this update, syntax highlighting for inline suggestions is now enabled by default. Notice in the following screenshot that the code suggestion has syntax coloring applied to it.
+
+![Screenshot of the editor, showing that syntax highlighting is enabled for ghost text.](images/1_99/inlineSuggestionHighlightingEnabled.png)
+
+If you prefer inline suggestions without syntax highlighting, you can disable it with `setting(editor.inlineSuggest.syntaxHighlightingEnabled:false)`.
+
+![Screenshot of the editor showing that highlighting for ghost text is turned off.](images/1_99/inlineSuggestionHighlightingDisabled.png)
+
+### Tree-Sitter based syntax highlighting (Preview)
+
+**Setting**: `setting(editor.experimental.preferTreeSitter.css:true)` and `setting(editor.experimental.preferTreeSitter.regex:true)`
+
+Building upon the previous work for using Tree-Sitter for syntax highlighting, we now support experimental, Tree-Sitter based, syntax highlighting for CSS files and for regular expressions within TypeScript.
+
+## Notebooks
+
+### Minimal version of Jupyter notebook document to 4.5
+
+The default version of `nbformat` for new notebooks has been bumped from 4.2 to 4.5, which will now set `id` fields for each cell of the notebook to help with calculating diffs. You can also manually update existing notebooks by setting the `nbformat_minor` to `5` in the raw JSON of the notebook.
+
+### AI notebook editing improvements
+
+AI-powered editing support for notebooks (including agent mode) is now available in the Stable release. This was added last month as a preview feature in [VS Code Insiders](https://code.visualstudio.com/insiders).
+
+You can now use chat to edit notebook files with the same intuitive experience as editing code files: modify content across multiple cells, insert and delete cells, and change cell types. This feature provides a seamless workflow when working with data science or documentation notebooks.
+
+#### New notebook tool
+
+VS Code now provides a dedicated tool for creating new Jupyter notebooks directly from chat. This tool plans and creates a new notebook based on your query.
+
+Use the new notebook tool in agent mode or edit mode (make sure to enable the improved edit mode with `setting(chat.edits2.enabled:true)`). If you're using ask mode, type `/newNotebook` in the chat prompt to create a new notebook.
+
+<video src="images/1_99/new-notebook-tool-release-notes.mp4" title="Video showing creation of a new Jupyter notebook using chat in agent mode and the New Notebook tool." autoplay loop controls muted></video>
+
+#### Navigate through AI edits
+
+Use the diff toolbars to iterate through and review each AI edit across cells.
+
+<video src="images/1_99/navigate-notebook-edits.mp4" title="Video showing chat implementing a TODO task and then navigating through those changes." autoplay loop controls muted></video>
+
+#### Undo AI edits
+
+When focused on a cell container, the **Undo** command reverts the full set of AI changes at the notebook level.
+
+<video src="images/1_99/undo-copilot-notebook-edits.mp4" title="Video showing chat making several edits to a notebook and undoing those edits with ctrl+z." autoplay loop controls muted></video>
+
+#### Text and image output support in chat
+
+You can now add notebook cell outputs, such as text, errors, and images, directly to chat as context. This lets you reference the output when using ask, edit, or agent mode, making it easier for the language model to understand and assist with your notebook content.
+
+Use the **Add cell output to chat** action, available via the triple-dot menu or by right-clicking the output.
+
+To attach the cell error output as chat context:
+
+<video src="images/1_99/notebook-output-attach.mp4" title="Video that shows attaching an notebook cell error output to chat." autoplay loop controls muted></video>
+
+To attach the cell output image as chat context:
+
+<video src="images/1_99/notebook-output-image-demo.mp4" title="Video that shows attaching an notebook cell output image to chat." autoplay loop controls muted></video>
+
+## Accessibility
+
+### Chat agent mode improvements
+
+You are now notified when manual action is required during a tool invocation, such as "Run command in terminal." This information is also included in the ARIA label for the relevant chat response, enhancing accessibility for screen reader users.
+
+Additionally, a new accessibility help dialog is available in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode), explaining what users can expect from the feature and how to navigate it effectively.
+
+### Accessibility Signals for chat edit actions
+
+VS Code now provides auditory signals when you keep or undo AI-generated edits. These signals are configurable via `setting(accessibility.signals.editsKept)` and `setting(accessibility.signals.editsUndone)`.
+
+### Improved ARIA labels for suggest control
+
+ARIA labels for suggest control items now include richer and descriptive information, such as the type of suggestion (for example, method or variable). This information was previously only available to sighted users via icons.
+
+## Source Control
+
+### Reference picker improvements
+
+**Setting**: `setting(git.showReferenceDetails)`
+
+This milestone, we have made improvements of the reference picker that is used for various source control operations like checkout, merge, rebase, or delete branch. The updated reference picker contains the details of the last commit (author, commit message, commit date), as well as ahead/behind information for local branches. This additional context will help you pick the right reference for the various operations.
+
+Hide the additional information by toggling the `setting(git.showReferenceDetails:false)` setting.
+
+![Screenshot of the source control references picker showing a list of git branches with details of the last commit, and ahead/behind information.](images/1_99/scm-reference-picker.png)
+
+### Repository Status Bar item
+
+Workspaces that contain multiple repositories now have a Source Control Provider Status Bar item that displays the active repository to the left of the branch picker. The new Status Bar item provides additional context, so you know which is the active repository as you navigate between editors and use the Source Control view.
+
+To hide the Source Control Provider Status Bar item, right-click the Status Bar, and deselect **Source Control Provider** from the context menu.
+
+![Screenshot showing the repository status bar item for workspaces that contain more than one repository.](images/1_99/scm-repository-picker.png)
+
+### Git blame editor decoration improvements
+
+We have heard feedback that while typing, the "Not Yet Committed" editor decoration does not provide much value and it is more of a distraction. Starting this milestone the "Not Yet Committed" editor decoration is only shown while navigating around the codebase either by using the keyboard or the mouse.
+
+### Commit input cursor customization
+
+This milestone, thanks to a community contribution, we have added the `setting(editor.cursorStyle)` and `setting(editor.cursorWidth)` settings to the list of settings that are being honored by the source control input box.
+
+## Terminal
+
+### Reliability in agent mode
+
+The tool that allows agent mode to run commands in the terminal has a number of reliability and compatibility improvements. You should expect fewer cases where the tool gets stuck or where the command finishes without the output being present.
+
+One of the bigger changes is the introduction of the concept of "rich" quality [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration), as opposed to "basic" and "none". The shell integration scripts shipped with VS Code should generally all enable rich shell integration which provides the best experience in the run in terminal tool (and terminal usage in general). You can view the shell integration quality by hovering over the terminal tab.
+
+### Terminal IntelliSense improvements (Preview)
+
+#### Enhanced IntelliSense for the `code` CLI
+
+IntelliSense now supports subcommands for the `code`, `code-insiders`, and `code-tunnel` CLI. For instance, typing `code tunnel` shows available subcommands like `help`, `kill`, and `prune`, each with descriptive info.
+
+![Screenshot of the terminal window, showing code tunnel has been typed. The suggest widget shows subcommands like help, kill, prune, and others, with descriptions for each command.](images/1_99/terminal-intellisense-code-tunnel.png)
+
+We've also added option suggestions for:
+
+- `--uninstall-extension`
+- `--disable-extension`
+- `--install-extension`
+
+These show a list of installed extensions to help complete the command.
+
+![Screenshot of the VSCode terminal with code --uninstall-extension. A list of available extensions is displayed, including vscode-eslint and editorconfig.](images/1_99/terminal-intellisense-extension.png)
+
+Additionally, `code --locate-shell-integration-path` now provides shell-specific options such as `bash`, `zsh`, `fish`, and `pwsh`.
+
+![Screenshot of the VSCode terminal showing a command input: code --locate-shell-integration-path with a dropdown menu listing shell options bash, fish, pwsh, and zsh.](images/1_99/terminal-intellisense-locate-shell-integration.png)
+
+#### Auto-refresh for global commands
+
+The terminal now automatically refreshes its list of global commands when changes are detected in the system `bin` directory. This means newly installed CLI tools (for example, after running `npm install -g pnpm`) will show up in completions immediately, without the need to reload the window.
+
+Previously, completions for new tools wouldn’t appear due to caching until the window was manually reloaded.
+
+#### Option value context
+
+Terminal suggestions now display contextual information about expected option values, helping you more easily complete commands.
+
+![Screenshot of the terminal showing a command in progress: npm install --omit. The terminal suggest widget displays <package type> to indicate that's the option that's expected.](images/1_99/terminal-intellisense-options.png)
+
+#### Rich completions for fish shell
+
+In the last release, we added detailed command completions for bash and zsh. This iteration, we've expanded that support to fish as well. Completion details are sourced from the shell’s documentation or built-in help commands.
+
+For example, typing `jobs` in fish displays usage info and options:
+
+![Screenshot of the Visual Studio Code Terminal with a fish terminal showing a user has typed jobs. The suggest widget shown provides information about the jobs command with detailed usage examples and options.](images/1_99/terminal-intellisense-fish.png)
+
+#### File type icons in suggestions
+
+Suggestions in the terminal now include specific icons for different file types, making it easier to distinguish between scripts and binaries at a glance.
+
+![Screenshot of the terminal, showing suggestions for various script files, including code.sh, code-cli.sh, and code-server.js. Icons indicate the specific file type.](images/1_99/terminal-intellisense-icons.png)
+
+#### Inline suggestion details
+
+Inline suggestions, displayed as ghost text in the terminal, continue to appear at the top of the suggestions list. In this release, we've added command details to these entries to provide more context before accepting them.
+
+![Screenshot of the terminal, showing the Block command as ghost text in the terminal. The first suggestion is block and it contains usage information.](images/1_99/terminal-intellisense-consolidated.png)
+
+### New simplified and detailed tab hover
+
+By default, the terminal tab shows much less detail now.
+
+![Screenshot of the simple hover showing the terminal name, PID, command line, shell integration quality and actions](images/1_99/terminal-hover-simple.png)
+
+To view everything, there is a **Show Details** button at the bottom of the hover.
+
+![Screenshot of the detailed hover showing extensions that contribute to the environment and detailed shell integration diagnostics](images/1_99/terminal-hover-detailed.png)
+
+### Signed PowerShell shell integration
+
+The shell integration PowerShell script is now signed, meaning shell integration on Windows when using the default PowerShell execution policy of `RemoteSigned` should now start working automatically. You can read more about [shell integration's benefits here](https://code.visualstudio.com/docs/terminal/shell-integration).
+
+### Terminal shell type
+
+This iteration, we've finalized our terminal shell API, allowing extensions to see the user's current shell type in their terminal.
+Subscribing to event `onDidChangeTerminalState` allows you to see the changes of the user's shell type in the terminal.
+For example, the shell could change from zsh to bash.
+
+The list of all the shells that are identifiable are currently listed [here](https://github.com/microsoft/vscode/blob/99e3ae5586a74ab1c554b6a2a50bb9eb3a4ff7fd/src/vscode-dts/vscode.d.ts#L7740-L7750)
+
+## Remote Development
+
+### Linux legacy server support has ended
+
+As of release 1.99, you can no longer connect to these servers. As noted in our [1.97 release](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_97.md#migration-path-for-linux-legacy-server), users that require additional time to complete migration to a supported Linux distro can provide custom builds of `glibc` and `libstdc++` as a workaround. More info on this workaround can be found in the [FAQ](https://aka.ms/vscode-remote/faq/old-linux) section.
+
+## Enterprise
+
+### macOS device management
+
+VS Code now supports device management on macOS in addition to Windows.  This allows system administrators to push policies from a centralized management system, like Microsoft Intune.
+
+See the [Enterprise Support](https://code.visualstudio.com/docs/setup/enterprise#_device-management) documentation for more details.
+
+## Contributions to extensions
+
+### Python
+
+#### Better support for editable installs with Pylance
+
+Pylance now supports resolving import paths for packages installed in editable mode (`pip install -e .`) as defined by [PEP 660](https://peps.python.org/pep-0660/), which enables an improved IntelliSense experience in these scenarios.
+
+This feature is enabled via `setting(python.analysis.enableEditableInstalls:true)` and we plan to start rolling it out as the default experience throughout this month. If you experience any issues, please report them at the [Pylance GitHub repository](https://github.com/microsoft/pylance-release).
+
+#### Faster and more reliable diagnostic experience with Pylance (Experimental)
+
+We're starting to roll out a change to improve the accuracy and responsiveness of Pylance's diagnostics when using the release version of the extension. This is especially helpful for scenarios with multiple open or recently closed files.
+
+If you do not want to wait for the roll-out, you can set `setting(python.analysis.usePullDiagnostics:true)`. If you experience any issues, please report them at the [Pylance GitHub repository](https://github.com/microsoft/pylance-release).
+
+#### Pylance custom Node.js arguments
+
+There's a new `setting(python.analysis.nodeArguments)` setting, which allows you to pass custom arguments directly to Node.js when using `setting(python.analysis.nodeExecutable)`. By default, it is set to `"--max-old-space-size=8192"`, but you can modify it to suit your needs (for example, to allocate more memory to Node.js when working with large workspaces).
+
+Additionally, when setting `setting(python.analysis.nodeExecutable)` to `auto`, Pylance now automatically downloads Node.js.
+
+## Extension authoring
+
+### Terminal.shellIntegration tweaks
+
+The `Terminal.shellIntegration` API will now only light up when command detection happens. Previously, this should work when _only_ the current working directory was reported, which caused `TerminalShellIntegration.executeCommand` to not function well.
+
+Additionally, `TerminalShellIntegration.executeCommand` will now behave more consistently and track multiple "sub-executions" for a single command line that ended up running multiple commands. This depends on rich shell integration as mentioned in the [reliability in agent mode section](#reliability-in-agent-mode).
+
+## Proposed APIs
+
+### Task problem matcher status
+
+We've added [proposed API](https://github.com/microsoft/vscode/blob/c98092f1caaad64e18be5b3f8761a09c24c7669c/src/vscode-dts/vscode.proposed.taskProblemMatcherStatus.d.ts#L9-L40), so that extensions can monitor when a task's problem matchers start and finish processing lines. Enable it with `taskProblemMatcherStatus`.
+
+### Send images to LLM
+
+This iteration, we've added a [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts), so that extensions can attach images and send vision requests to the language model. Attachments must be the raw, non base64-encoded binary data of the image (`Uint8Array`). Maximum image size is 5MB.
+
+Check out [this API proposal issue](https://github.com/microsoft/vscode/issues/245104) to see a usage example and to stay up to date with the status of this API.
+
+## Engineering
+
+### Use new `/latest` API from Marketplace to check for extensions updates
+
+Couple of milestones back, we introduced a new API endpoint in `vscode-unpkg` service to check for extension updates. Marketplace now supports the same endpoint and VS Code is now using this endpoint to check for extension updates. This is behind an experiment and will be rolled out to users in stages.
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Add a 2 hour offset to tests to avoid being a day short after the clocks change [PR #243194](https://github.com/microsoft/vscode/pull/243194)
+* [@acdzh (Vukk)](https://github.com/acdzh): Fix hasEdits flag's value when updating multiple values in JSONEditingService  [PR #243876](https://github.com/microsoft/vscode/pull/243876)
+* [@c-claeys (Cristopher Claeys)](https://github.com/c-claeys): Increment the request attempt in the chat retry action [PR #243471](https://github.com/microsoft/vscode/pull/243471)
+* [@ChaseKnowlden (Chase Knowlden)](https://github.com/ChaseKnowlden): Add Merge Editor Accessibility help [PR #240745](https://github.com/microsoft/vscode/pull/240745)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): Update C# onEnterRules to account for documentation comments [PR #242121](https://github.com/microsoft/vscode/pull/242121)
+* [@dsanders11 (David Sanders)](https://github.com/dsanders11): Fix a few broken `@link` in vscode.d.ts [PR #242407](https://github.com/microsoft/vscode/pull/242407)
+* [@jacekkopecky (Jacek Kopecký)](https://github.com/jacekkopecky): Honor more cursor settings in scm input editor [PR #242903](https://github.com/microsoft/vscode/pull/242903)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Show support URL and license URL even if extension URL is not set [PR #243565](https://github.com/microsoft/vscode/pull/243565)
+* [@kevmo314 (Kevin Wang)](https://github.com/kevmo314): Fix comment typo [PR #243145](https://github.com/microsoft/vscode/pull/243145)
+* [@liudonghua123 (liudonghua)](https://github.com/liudonghua123): support explorer.copyPathSeparator [PR #184884](https://github.com/microsoft/vscode/pull/184884)
+* [@mattmaniak](https://github.com/mattmaniak): Make telemetry info table a little bit narrower and aligned [PR #233961](https://github.com/microsoft/vscode/pull/233961)
+* [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango)
+  * fix: use the copy command for images with CORS errors in the markdown preview [PR #240508](https://github.com/microsoft/vscode/pull/240508)
+  * Fix Incorrect character indentation on settings with line break [PR #242074](https://github.com/microsoft/vscode/pull/242074)
+* [@pprchal (Pavel Prchal)](https://github.com/pprchal): Added localization to right-click on icon [PR #243679](https://github.com/microsoft/vscode/pull/243679)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke): feature: support font family picker in settings [PR #214572](https://github.com/microsoft/vscode/pull/214572)
+* [@tribals (Anthony)](https://github.com/tribals): Add discovery of PowerShell Core user installation [PR #243025](https://github.com/microsoft/vscode/pull/243025)
+* [@tusharsadhwani (Tushar Sadhwani)](https://github.com/tusharsadhwani): Make `git show` ref argument unambiguous [PR #242483](https://github.com/microsoft/vscode/pull/242483)
+* [@wszgrcy (chen)](https://github.com/wszgrcy): fix: extension uncaughtException listen Maximum call stack size exceeded [PR #244690](https://github.com/microsoft/vscode/pull/244690)
+* [@zyoshoka (zyoshoka)](https://github.com/zyoshoka): Correct `typescript-basics` extension path [PR #243833](https://github.com/microsoft/vscode/pull/243833)
+
+Contributions to `vscode-css-languageservice`:
+
+* [@lilnasy (Arsh)](https://github.com/lilnasy): Support `@starting-style` [PR #421](https://github.com/microsoft/vscode-css-languageservice/pull/421)
+
+Contributions to `vscode-custom-data`:
+
+* [@rviscomi (Rick Viscomi)](https://github.com/rviscomi): Add computed Baseline status [PR #111](https://github.com/microsoft/vscode-custom-data/pull/111)
+
+Contributions to `vscode-extension-samples`:
+
+* [@ratmice (matt rice)](https://github.com/ratmice): Fix esbuild scripts [PR #1154](https://github.com/microsoft/vscode-extension-samples/pull/1154)
+
+Contributions to `vscode-extension-telemetry`:
+
+* [@minestarks (Mine Starks)](https://github.com/minestarks): Remove extra brace from common.platformversion [PR #221](https://github.com/microsoft/vscode-extension-telemetry/pull/221)
+
+Contributions to `vscode-js-debug`:
+
+* [@erikson84 (Erikson Kaszubowski)](https://github.com/erikson84): fix: ensure backslash in path when setting breakpoints in windows [PR #2184](https://github.com/microsoft/vscode-js-debug/pull/2184)
+* [@xymopen (xymopen_Official)](https://github.com/xymopen): Support usenode as npm script runner [PR #2178](https://github.com/microsoft/vscode-js-debug/pull/2178)
+
+Contributions to `vscode-mypy`:
+
+* [@ivirabyan (Ivan Virabyan)](https://github.com/ivirabyan): Report only files specified by mypy config [PR #352](https://github.com/microsoft/vscode-mypy/pull/352)
+
+Contributions to `vscode-prompt-tsx`:
+
+* [@dsanders11 (David Sanders)](https://github.com/dsanders11): docs: fix sendRequest API name in README example [PR #159](https://github.com/microsoft/vscode-prompt-tsx/pull/159)
+* [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
+  * fix: `text` should be `this.props.text` [PR #163](https://github.com/microsoft/vscode-prompt-tsx/pull/163)
+  * Fix the Usage in Tools section in README.md [PR #164](https://github.com/microsoft/vscode-prompt-tsx/pull/164)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@aedm (Gábor Gyebnár)](https://github.com/aedm): Adds `sanitizedLowercaseIssueTitle` to settings docs [PR #6690](https://github.com/microsoft/vscode-pull-request-github/pull/6690)
+
+Contributions to `vscode-python-debugger`:
+
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Update debugpy to latest version [PR #653](https://github.com/microsoft/vscode-python-debugger/pull/653)
+
+Contributions to `vscode-test`:
+
+* [@SKaplanOfficial (Stephen Kaplan)](https://github.com/SKaplanOfficial): fix: avoid 'Invalid extraction directory' when unzipping [PR #303](https://github.com/microsoft/vscode-test/pull/303)
+
+Contributions to `language-server-protocol`:
+
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Update range formatting capabilities in metamodel [PR #2106](https://github.com/microsoft/language-server-protocol/pull/2106)
+
+Contributions to `python-environment-tools`:
+
+* [@CharlesChen0823](https://github.com/CharlesChen0823): bump winreg [PR #195](https://github.com/microsoft/python-environment-tools/pull/195)
+* [@elprans (Elvis Pranskevichus)](https://github.com/elprans)
+  * Avoid misdetecting global Linux Python as virtualenv [PR #197](https://github.com/microsoft/python-environment-tools/pull/197)
+  * Fix env version detection on systems with multiple system Pythons [PR #198](https://github.com/microsoft/python-environment-tools/pull/198)
+  * Populate `name` in virtualenvwrapper envs [PR #199](https://github.com/microsoft/python-environment-tools/pull/199)
+
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_99.md
+++ b/docs/release-notes/v1_99.md
@@ -45,7 +45,7 @@ We're happy to announce that agent mode is available in VS Code Stable! Enable i
 
 Check out the [agent mode documentation](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) or select agent mode from the chat mode picker in the Chat view.
 
-![Screenshot that shows the Chat view, highlighting agent mode selected in the chat mode picker.](images/1_99/copilot-edits-agent-mode.png)
+![Screenshot that shows the Chat view, highlighting agent mode selected in the chat mode picker.](https://code.visualstudio.com/assets/updates/1_99/copilot-edits-agent-mode.png)
 
 ### Model Context Protocol server support
 
@@ -57,7 +57,7 @@ You can use the **MCP: Add Server** command to quickly set up an MCP server from
 
 When a new MCP server is added, a refresh action is shown in the Chat view, which can be used to start the server and discover the tools. Afterwards, servers are started on-demand to save resources.
 
-<video src="images/1_99/mcp.mp4" title="Video that shows using a Github MCP tool in chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/mcp.mp4" title="Video that shows using a Github MCP tool in chat." autoplay loop controls muted></video>
 _Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
 
 If you've already been using MCP servers in other applications such as Claude Desktop, VS Code will discover them and offer to run them for you. This behavior can be toggled with the setting `setting(chat.mcp.discovery.enabled)`.
@@ -80,7 +80,7 @@ Inspired by [Anthropic's research](https://www.anthropic.com/engineering/claude-
 
 Use the `#fetch` tool for including content from a publicly accessible webpage in your prompt. For instance, if you wanted to include the latest documentation on a topic like [MCP](#model-context-protocol-server-support), you can ask to fetch [the full documentation](https://modelcontextprotocol.io/llms-full.txt) (which is conveniently ready for an LLM to consume) and use that in a prompt. Here's a video of what that might look like:
 
-<video src="images/1_99/fetch.mp4" title="Video that shows using the fetch tool to fetch the model context protocol documentation." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/fetch.mp4" title="Video that shows using the fetch tool to fetch the model context protocol documentation." autoplay loop controls muted></video>
 
 In agent mode, this tool is picked up automatically but you can also reference it explicitly in the other modes via `#fetch`, along with the URL you are looking to fetch.
 
@@ -105,7 +105,7 @@ In agent mode this tool will be picked up automatically but you can also referen
 
 You can now scaffold a new VS Code workspace in [agent mode](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode). Whether you’re setting up a VS Code extension, an MCP server, or other development environments, agent mode helps you to initialize, configure, and launch these projects with the necessary dependencies and settings.
 
-<video src="images/1_99/new-workspace-demo.mp4" title="Video showing creation of a new MCP server to fetch top N stories from hacker news using Agent mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/new-workspace-demo.mp4" title="Video showing creation of a new MCP server to fetch top N stories from hacker news using Agent mode." autoplay loop controls muted></video>
 
 ### VS Code extension tools in agent mode
 
@@ -123,7 +123,7 @@ As part of completing the tasks for a user prompt, agent mode can run tools and 
 
 To optimize this experience, you can now remember that approval on a session, workspace, or application level. This is not currently enabled for the terminal tool, but we plan to develop an approval system for the terminal in future releases.
 
-![Screenshot that shows the agent mode tool Continue button dropdown options for remembering approval.](./images/1_99/chat-tool-approval.png)
+![Screenshot that shows the agent mode tool Continue button dropdown options for remembering approval.](https://code.visualstudio.com/assets/updates/1_99/chat-tool-approval.png)
 
 In case you want to auto-approve _all_ tools, you can now use the experimental `setting(chat.tools.autoApprove:true)` setting. This will auto-approve all tools, and VS Code will not ask for confirmation when a language model wishes to run tools. Bear in mind that with this setting enabled, you will not have the opportunity to cancel potentially destructive actions a model wants to take.
 
@@ -137,7 +137,7 @@ VS Code's agent achieves a pass rate of 56.0% on `swebench-verified` with Claude
 
 For the past several months, we've had a "Chat" view for asking questions to the language model, and a "Copilot Edits" view for an AI-powered code editing session. This month, we aim to streamline the chat-based experience by merging the two views into one Chat view. In the Chat view, you'll see a dropdown with three modes:
 
-![Screenshot that shows the chat mode picker in the Chat view.](images/1_99/chat-modes.png)
+![Screenshot that shows the chat mode picker in the Chat view.](https://code.visualstudio.com/assets/updates/1_99/chat-modes.png)
 
 - **[Ask](https://code.visualstudio.com/docs/copilot/chat/chat-ask-mode)**: This is the same as the previous Chat view. Ask questions about your workspace or coding in general, using any model. Use `@` to invoke built-in chat participants or from installed [extensions](https://marketplace.visualstudio.com/search?term=chat-participant&target=VSCode&category=All%20categories&sortBy=Relevance). Use `#` to attach any kind of context manually.
 - **[Agent](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode)**: Start an agentic coding flow with a set of tools that let it autonomously collect context, run terminal commands, or take other actions to complete a task. Agent mode is enabled for all [VS Code Insiders](https://code.visualstudio.com/insiders/) users, and we are rolling it out to more and more users in VS Code Stable.
@@ -158,7 +158,7 @@ Copilot Pro and Copilot Free users can now bring their own API keys for popular 
 
 To try it, select **Manage Models...** from the model picker. We’re actively exploring support for Copilot Business and Enterprise customers and will share updates in future releases. To learn more about this feature, head over to our [docs](https://code.visualstudio.com/docs/copilot/language-models).
 
-![A screenshot of a "Manage Models - Preview" dropdown menu in a user interface. The dropdown has the label "Select a provider" at the top, with a list of options below it. The options include "Anthropic" (highlighted in blue), "Azure," "Gemini," "OpenAI," "Ollama," and "OpenRouter." A gear icon is displayed next to the "Anthropic" option.](images/1_99/byok.png)
+![A screenshot of a "Manage Models - Preview" dropdown menu in a user interface. The dropdown has the label "Select a provider" at the top, with a list of options below it. The options include "Anthropic" (highlighted in blue), "Azure," "Gemini," "OpenAI," "Ollama," and "OpenRouter." A gear icon is displayed next to the "Anthropic" option.](https://code.visualstudio.com/assets/updates/1_99/byok.png)
 
 ### Reusable prompt files
 
@@ -193,7 +193,7 @@ Last iteration, Copilot Vision was enabled for `GPT-4o`. Check our [release note
 
 This release, you can attach images from any browser via drag and drop. Images drag and dropped from browsers must have the correct url extension, with `.jpg`, `.png`, `.gif`, `.webp`, or `.bmp`.
 
-<video src="images/1_99/image-url-dnd.mp4" title="Video that shows an image from Chrome being dragged into the chat panel." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/image-url-dnd.mp4" title="Video that shows an image from Chrome being dragged into the chat panel." autoplay loop controls muted></video>
 
 ## Configure the editor
 
@@ -201,7 +201,7 @@ This release, you can attach images from any browser via drag and drop. Images d
 
 We have streamlined the chat experience in VS Code into a single unified Chat view. Instead of having to move between separate views and lose the context of a conversation, you can now easily switch between the different chat modes.
 
-![Screenshot that shows the chat mode picker in the Chat view.](images/1_99/chat-modes.png)
+![Screenshot that shows the chat mode picker in the Chat view.](https://code.visualstudio.com/assets/updates/1_99/chat-modes.png)
 
 Depending on your scenario, use either of these modes, and freely move mid-conversation:
 
@@ -219,7 +219,7 @@ Previously, you'd have to press a button or run a command to build and start usi
 
 Keep in mind that remote workspaces indexes are currently only available for code stored on GitHub. To use a remote workspace index, make sure your workspace contains a git project with a GitHub remote. You can use the [Copilot status menu](#copilot-status-menu) to see the type of index currently being used:
 
-![Screenshot that shows the workspace index status in the Copilot Status Bar menu.](images/1_99/copilot-workspace-index-remote.png)
+![Screenshot that shows the workspace index status in the Copilot Status Bar menu.](https://code.visualstudio.com/assets/updates/1_99/copilot-workspace-index-remote.png)
 
 To manage load, we are slowly rolling out instant indexing over the next few weeks, so you may not see it right away. You can still run the `GitHub Copilot: Build remote index command` command to start using a remote index when instant indexing is not yet enabled for you.
 
@@ -229,13 +229,13 @@ The Copilot status menu, accessible from the Status Bar, is now enabled for all 
 
 - View [workspace index](https://code.visualstudio.com/docs/copilot/reference/workspace-context) status information at any time.
 
-    ![Screenshot that shows the workspace index status of a workspace in the Copilot menu.](images/1_99/copilot-worksspace-index-local-status.png)
+    ![Screenshot that shows the workspace index status of a workspace in the Copilot menu.](https://code.visualstudio.com/assets/updates/1_99/copilot-worksspace-index-local-status.png)
 
 - View if code completions are enabled for the active editor.
 
     A new icon reflects the status, so that you can quickly see if code completions are enabled or not.
 
-    ![Screenshot that shows the Copilot status icon when completions is disabled.](images/1_99/copilot-disabled-status.png)
+    ![Screenshot that shows the Copilot status icon when completions is disabled.](https://code.visualstudio.com/assets/updates/1_99/copilot-disabled-status.png)
 
 - Enable or disable [code completions and NES](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
 
@@ -245,7 +245,7 @@ The Copilot status menu, accessible from the Status Bar, is now enabled for all 
 
 We are shipping an experimental feature to show functional chat experiences out of the box. This includes the Chat view, editor/terminal inline chat, and quick chat. The first time you send a chat request, we will guide you through signing in and signing up for Copilot Free.
 
-<video src="images/1_99/copilot-ootb.mp4" title="Video that shows Copilot out of the box." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/copilot-ootb.mp4" title="Video that shows Copilot out of the box." autoplay loop controls muted></video>
 
 If you want to see this experience for yourself, enable the `setting(chat.setupFromDialog)` setting.
 
@@ -255,7 +255,7 @@ If you have the prerelease version of the Copilot Chat extension installed in VS
 
 The welcome screen provides options to either switch to the release version of the extension or download [VS Code Insiders](https://code.visualstudio.com/insiders/).
 
-![Screenshot that shows the welcome view of chat, indicating that the pre-release version of the extension is not supported in VS Code stable. A button is shown to switch to the release version, and a secondary link is shown to switch to VS Code Insiders.](images/1_99/welcome-pre-release.png)
+![Screenshot that shows the welcome view of chat, indicating that the pre-release version of the extension is not supported in VS Code stable. A button is shown to switch to the release version, and a secondary link is shown to switch to VS Code Insiders.](https://code.visualstudio.com/assets/updates/1_99/welcome-pre-release.png)
 
 ### Semantic text search improvements (Experimental)
 
@@ -263,17 +263,17 @@ The welcome screen provides options to either switch to the release version of t
 
 AI-powered semantic text search is now enabled by default in the Search view. Use the `kb(search.action.searchWithAI)` keyboard shortcut to trigger a semantic search, which shows you the most relevant results based on your query, on top of the regular search results.
 
-<video src="images/1_99/semantic-search.mp4" title="Video that shows semantic search improvements in Visual Studio Code." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search.mp4" title="Video that shows semantic search improvements in Visual Studio Code." autoplay loop controls muted></video>
 
 You can also reference the semantic search results in your chat prompt by using the `#searchResults` tool. This allows you to ask the LLM to summarize or explain the results, or even generate code based on them.
 
-<video src="images/1_99/semantic-search-results.mp4" title="Video that shows using search results in chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/semantic-search-results.mp4" title="Video that shows using search results in chat view." autoplay loop controls muted></video>
 
 ### Settings editor search updates
 
 By default, the Settings editor search now uses the key-matching algorithm we introduced in the previous release. It also shows additional settings even when the settings ID matches exactly with a known setting.
 
-<video src="images/1_99/settings-search-show-extra.mp4" title="Video that shows searching for 'files.autoSave' and 'mcp' in the Settings editor, both show more than one setting." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/settings-search-show-extra.mp4" title="Video that shows searching for 'files.autoSave' and 'mcp' in the Settings editor, both show more than one setting." autoplay loop controls muted></video>
 
 _Theme: [Light Pink](https://marketplace.visualstudio.com/items?itemName=mgwg.light-pink-theme) (preview on [vscode.dev](https://vscode.dev/editor/theme/mgwg.light-pink-theme))_
 
@@ -298,7 +298,7 @@ We're happy to announce the general availability of Next Edit Suggestions (NES)!
 * Make edit suggestions more compact, less interfering with surrounding code, and easier to read at a glance.
 * Updates to the gutter indicator to make sure that all suggestions are more easily noticeable.
 
-<video src="images/1_99/next-edit-suggestion.mp4" title="Video that shows NES suggesting edits based on the recent changes due by the user." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/next-edit-suggestion.mp4" title="Video that shows NES suggesting edits based on the recent changes due by the user." autoplay loop controls muted></video>
 
 ### AI edits improvements
 
@@ -326,11 +326,11 @@ This setting will be enabled gradually for users in VS Code Stable.
 
 With this update, syntax highlighting for inline suggestions is now enabled by default. Notice in the following screenshot that the code suggestion has syntax coloring applied to it.
 
-![Screenshot of the editor, showing that syntax highlighting is enabled for ghost text.](images/1_99/inlineSuggestionHighlightingEnabled.png)
+![Screenshot of the editor, showing that syntax highlighting is enabled for ghost text.](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingEnabled.png)
 
 If you prefer inline suggestions without syntax highlighting, you can disable it with `setting(editor.inlineSuggest.syntaxHighlightingEnabled:false)`.
 
-![Screenshot of the editor showing that highlighting for ghost text is turned off.](images/1_99/inlineSuggestionHighlightingDisabled.png)
+![Screenshot of the editor showing that highlighting for ghost text is turned off.](https://code.visualstudio.com/assets/updates/1_99/inlineSuggestionHighlightingDisabled.png)
 
 ### Tree-Sitter based syntax highlighting (Preview)
 
@@ -356,19 +356,19 @@ VS Code now provides a dedicated tool for creating new Jupyter notebooks directl
 
 Use the new notebook tool in agent mode or edit mode (make sure to enable the improved edit mode with `setting(chat.edits2.enabled:true)`). If you're using ask mode, type `/newNotebook` in the chat prompt to create a new notebook.
 
-<video src="images/1_99/new-notebook-tool-release-notes.mp4" title="Video showing creation of a new Jupyter notebook using chat in agent mode and the New Notebook tool." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/new-notebook-tool-release-notes.mp4" title="Video showing creation of a new Jupyter notebook using chat in agent mode and the New Notebook tool." autoplay loop controls muted></video>
 
 #### Navigate through AI edits
 
 Use the diff toolbars to iterate through and review each AI edit across cells.
 
-<video src="images/1_99/navigate-notebook-edits.mp4" title="Video showing chat implementing a TODO task and then navigating through those changes." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/navigate-notebook-edits.mp4" title="Video showing chat implementing a TODO task and then navigating through those changes." autoplay loop controls muted></video>
 
 #### Undo AI edits
 
 When focused on a cell container, the **Undo** command reverts the full set of AI changes at the notebook level.
 
-<video src="images/1_99/undo-copilot-notebook-edits.mp4" title="Video showing chat making several edits to a notebook and undoing those edits with ctrl+z." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/undo-copilot-notebook-edits.mp4" title="Video showing chat making several edits to a notebook and undoing those edits with ctrl+z." autoplay loop controls muted></video>
 
 #### Text and image output support in chat
 
@@ -378,11 +378,11 @@ Use the **Add cell output to chat** action, available via the triple-dot menu or
 
 To attach the cell error output as chat context:
 
-<video src="images/1_99/notebook-output-attach.mp4" title="Video that shows attaching an notebook cell error output to chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-attach.mp4" title="Video that shows attaching an notebook cell error output to chat." autoplay loop controls muted></video>
 
 To attach the cell output image as chat context:
 
-<video src="images/1_99/notebook-output-image-demo.mp4" title="Video that shows attaching an notebook cell output image to chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_99/notebook-output-image-demo.mp4" title="Video that shows attaching an notebook cell output image to chat." autoplay loop controls muted></video>
 
 ## Accessibility
 
@@ -410,7 +410,7 @@ This milestone, we have made improvements of the reference picker that is used f
 
 Hide the additional information by toggling the `setting(git.showReferenceDetails:false)` setting.
 
-![Screenshot of the source control references picker showing a list of git branches with details of the last commit, and ahead/behind information.](images/1_99/scm-reference-picker.png)
+![Screenshot of the source control references picker showing a list of git branches with details of the last commit, and ahead/behind information.](https://code.visualstudio.com/assets/updates/1_99/scm-reference-picker.png)
 
 ### Repository Status Bar item
 
@@ -418,7 +418,7 @@ Workspaces that contain multiple repositories now have a Source Control Provider
 
 To hide the Source Control Provider Status Bar item, right-click the Status Bar, and deselect **Source Control Provider** from the context menu.
 
-![Screenshot showing the repository status bar item for workspaces that contain more than one repository.](images/1_99/scm-repository-picker.png)
+![Screenshot showing the repository status bar item for workspaces that contain more than one repository.](https://code.visualstudio.com/assets/updates/1_99/scm-repository-picker.png)
 
 ### Git blame editor decoration improvements
 
@@ -442,7 +442,7 @@ One of the bigger changes is the introduction of the concept of "rich" quality [
 
 IntelliSense now supports subcommands for the `code`, `code-insiders`, and `code-tunnel` CLI. For instance, typing `code tunnel` shows available subcommands like `help`, `kill`, and `prune`, each with descriptive info.
 
-![Screenshot of the terminal window, showing code tunnel has been typed. The suggest widget shows subcommands like help, kill, prune, and others, with descriptions for each command.](images/1_99/terminal-intellisense-code-tunnel.png)
+![Screenshot of the terminal window, showing code tunnel has been typed. The suggest widget shows subcommands like help, kill, prune, and others, with descriptions for each command.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-code-tunnel.png)
 
 We've also added option suggestions for:
 
@@ -452,11 +452,11 @@ We've also added option suggestions for:
 
 These show a list of installed extensions to help complete the command.
 
-![Screenshot of the VSCode terminal with code --uninstall-extension. A list of available extensions is displayed, including vscode-eslint and editorconfig.](images/1_99/terminal-intellisense-extension.png)
+![Screenshot of the VSCode terminal with code --uninstall-extension. A list of available extensions is displayed, including vscode-eslint and editorconfig.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-extension.png)
 
 Additionally, `code --locate-shell-integration-path` now provides shell-specific options such as `bash`, `zsh`, `fish`, and `pwsh`.
 
-![Screenshot of the VSCode terminal showing a command input: code --locate-shell-integration-path with a dropdown menu listing shell options bash, fish, pwsh, and zsh.](images/1_99/terminal-intellisense-locate-shell-integration.png)
+![Screenshot of the VSCode terminal showing a command input: code --locate-shell-integration-path with a dropdown menu listing shell options bash, fish, pwsh, and zsh.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-locate-shell-integration.png)
 
 #### Auto-refresh for global commands
 
@@ -468,7 +468,7 @@ Previously, completions for new tools wouldn’t appear due to caching until the
 
 Terminal suggestions now display contextual information about expected option values, helping you more easily complete commands.
 
-![Screenshot of the terminal showing a command in progress: npm install --omit. The terminal suggest widget displays <package type> to indicate that's the option that's expected.](images/1_99/terminal-intellisense-options.png)
+![Screenshot of the terminal showing a command in progress: npm install --omit. The terminal suggest widget displays <package type> to indicate that's the option that's expected.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-options.png)
 
 #### Rich completions for fish shell
 
@@ -476,29 +476,29 @@ In the last release, we added detailed command completions for bash and zsh. Thi
 
 For example, typing `jobs` in fish displays usage info and options:
 
-![Screenshot of the Visual Studio Code Terminal with a fish terminal showing a user has typed jobs. The suggest widget shown provides information about the jobs command with detailed usage examples and options.](images/1_99/terminal-intellisense-fish.png)
+![Screenshot of the Visual Studio Code Terminal with a fish terminal showing a user has typed jobs. The suggest widget shown provides information about the jobs command with detailed usage examples and options.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-fish.png)
 
 #### File type icons in suggestions
 
 Suggestions in the terminal now include specific icons for different file types, making it easier to distinguish between scripts and binaries at a glance.
 
-![Screenshot of the terminal, showing suggestions for various script files, including code.sh, code-cli.sh, and code-server.js. Icons indicate the specific file type.](images/1_99/terminal-intellisense-icons.png)
+![Screenshot of the terminal, showing suggestions for various script files, including code.sh, code-cli.sh, and code-server.js. Icons indicate the specific file type.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-icons.png)
 
 #### Inline suggestion details
 
 Inline suggestions, displayed as ghost text in the terminal, continue to appear at the top of the suggestions list. In this release, we've added command details to these entries to provide more context before accepting them.
 
-![Screenshot of the terminal, showing the Block command as ghost text in the terminal. The first suggestion is block and it contains usage information.](images/1_99/terminal-intellisense-consolidated.png)
+![Screenshot of the terminal, showing the Block command as ghost text in the terminal. The first suggestion is block and it contains usage information.](https://code.visualstudio.com/assets/updates/1_99/terminal-intellisense-consolidated.png)
 
 ### New simplified and detailed tab hover
 
 By default, the terminal tab shows much less detail now.
 
-![Screenshot of the simple hover showing the terminal name, PID, command line, shell integration quality and actions](images/1_99/terminal-hover-simple.png)
+![Screenshot of the simple hover showing the terminal name, PID, command line, shell integration quality and actions](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-simple.png)
 
 To view everything, there is a **Show Details** button at the bottom of the hover.
 
-![Screenshot of the detailed hover showing extensions that contribute to the environment and detailed shell integration diagnostics](images/1_99/terminal-hover-detailed.png)
+![Screenshot of the detailed hover showing extensions that contribute to the environment and detailed shell integration diagnostics](https://code.visualstudio.com/assets/updates/1_99/terminal-hover-detailed.png)
 
 ### Signed PowerShell shell integration
 


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/aa1e6f8b845986bb7b96de25401c480edf949fc9

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_99.md https://github.com/microsoft/vscode-docs/raw/aa1e6f8b845986bb7b96de25401c480edf949fc9/release-notes/v1_99.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```