### PR TITLE
Translate April 2025 (version 1.100)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+hide:
+  - navigation
+  - toc
+---
+
 # vscode-docs-ja
 
 このサイトは第三者が VS Code ドキュメント (https://code.visualstudio.com/docs) を日本語に翻訳したものです。

--- a/docs/release-notes/v1_100.md
+++ b/docs/release-notes/v1_100.md
@@ -1,0 +1,688 @@
+---
+Order: 109
+TOCTitle: April 2025
+PageTitle: Visual Studio Code April 2025
+MetaDescription: Learn what is new in the Visual Studio Code April 2025 Release (1.100)
+MetaSocialImage: 1_100/release-highlights.png
+Date: 2025-05-08
+DownloadVersion: 1.100.0
+---
+# April 2025 (version 1.100)
+
+_Release date: May 8, 2025_
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the April 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* **Chat**
+  * Custom instructions and reusable prompts ([more...](#prompt-and-instructions-files)).
+  * Smarter results with tools for GitHub, extensions, and notebooks ([more...](#search-code-of-a-github-repository-with-the-githubrepo-tool)).
+  * Image and Streamable HTTP support for MCP ([more...](#mcp-support-for-streamable-http)).
+
+* **Chat performance**
+  * Faster responses on repeat chat requests ([more...](#conversation-summary-and-prompt-caching)).
+  * Faster edits in agent mode ([more...](#faster-agent-mode-edits)).
+
+* **Editor experience**
+  * Improved multi-window support for chat and editors ([more...](#floating-window-modes)).
+  * Staged changes now easier to identify ([more...](#quick-diff-decorations-for-staged-changes)).
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## Chat
+
+### Prompt and instructions files
+
+You can tailor your AI experience in VS Code to your specific coding practices and technology stack by using Markdown-based instructions and prompt files. We've aligned the implementation and usage of these two related concepts, however they each have distinct purposes.
+
+#### Instructions files
+
+**Setting**: `setting(chat.instructionsFilesLocations)`
+
+Instructions files (also known as custom instructions or rules) provide a way to describe common guidelines and context for the AI model in a Markdown file, such as code style rules, or which frameworks to use. Instructions files are not standalone chat requests, but rather provide context that you can apply to a chat request.
+
+Instructions files use the `.instructions.md` file suffix. They can be located in your user data folder or in the workspace. The `setting(chat.instructionsFilesLocations)` setting lists the folders that contain instruction files.
+
+You can manually attach instructions to a specific chat request, or they can be automatically added:
+
+* To add them manually, use the **Add Context** button in the Chat view, and then select **Instructions...**.
+  Alternatively use the **Chat: Attach Instructions...** command from the Command Palette. This brings up a picker that lets you select existing instructions files or create a new one to attach.
+
+* To automatically add instructions to a prompt, add the `applyTo` Front Matter header to the instructions file to indicate which files the instructions apply to. If a chat request contains a file that matches the given glob pattern, the instructions file is automatically attached.
+
+  The following example provides instructions for TypeScript files (`applyTo: '**/*.ts'`):
+
+  ````md
+  ---
+  applyTo: '**/*.ts'
+  ---
+  Place curly braces on separate lines for multi-line blocks:
+  if (condition)
+  {
+    doSomething();
+  }
+  else
+  {
+    doSomethingElse();
+  }
+  ````
+
+You can create instruction files with the **Chat: New Instructions File...** command. Moreover, the files created in the _user data_ folder can be automatically synchronized across multiple user machines through the Settings Sync service. Make sure to check the **Prompts and Instructions** option in the **Backup and Sync Settings...** dialog.
+
+Learn more about [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_instruction-files) in our documentation.
+
+#### Prompt files
+
+**Setting**: `setting(chat.promptFilesLocations)`
+
+Prompt files describe a standalone, complete chat request, including the prompt text, chat mode, and tools to use. Prompt files are useful for creating reusable chat requests for common tasks. For example, you can add a prompt file for creating a front-end component, or to perform a security review.
+
+Prompt files use the `.prompt.md` file suffix. They can be located in your user data folder or in the workspace. The `setting(chat.promptFilesLocations)` setting lists the folder where prompt files are looked for.
+
+There are several ways to run a prompt file:
+
+* Type `/` in the chat input field, followed by the prompt file name.
+  ![Screenshot that shows running a prompt in the Chat view with a slash command.](images/1_100/run-prompt-as-slash-command.png)
+
+* Open the prompt file in an editor and press the 'Play' button in the editor tool bar. This enables you to quickly iterate on the prompt and run it without having to switch back to the Chat view.
+  ![Screenshot that shows running a prompt by using the play button in the editor.](images/1_100/run-prompt-from-play-button.png)
+
+* Use the **Chat: Run Prompt File...** command from the Command Palette.
+
+Prompt files can have the following Front Matter metadata headers to indicate how they should be run:
+
+* `mode`: the chat mode to use when invoking the prompt (`ask`, `edit`, or `agent` mode).
+* `tools`: if the `mode` is `agent`, the list of tools that are available for the prompt.
+
+The following example shows a prompt file for generating release notes, that runs in agent mode, and can use a set of tools:
+
+```md
+---
+mode: 'agent'
+tools: ['getCurrentMilestone', 'getReleaseFeatures', 'file_search', 'semantic_search', 'read_file', 'insert_edit_into_file', 'create_file', 'replace_string_in_file', 'fetch_webpage', 'vscode_search_extensions_internal']
+---
+Generate release notes for the features I worked in the current release and update them in the release notes file. Use [release notes writing instructions file](.github/instructions/release-notes-writing.instructions.md) as a guide.
+```
+
+To create a prompt file, use the **Chat: New Prompt File...** command from the Command Palette.
+
+Learn more about [prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental) in our documentation.
+
+#### Improvements and notes
+
+* Instructions and prompt files now have their own language IDs, configurable in the _language mode_ dialog for any file open document ("Prompt" and "Instructions" respectively). This allows, for instance, using untitled documents as temporary prompt files before saving them as files to disk.
+* We renamed the **Chat: Use Prompt** command to **Chat: Run Prompt**. Furthermore, the command now runs the selected prompt _immediately_, as opposed to attaching it as chat context as it did before.
+* Both file types now also support the `description` metadata in their headers, providing a common place for short and user-friendly prompt summaries. In the future, this header is planned to be used along with the `applyTo` header as the rule that determines if the file needs to be auto-included with chat requests (for example, `description: 'Code style rules for front-end components written in TypeScript.'`)
+
+### Faster agent mode edits
+
+We've implemented support for OpenAI's apply patch editing format (GPT 4.1 and o4-mini) and Anthropic’s replace string tool (Claude Sonnet 3.7 and 3.5) in agent mode. This means that you benefit from significantly faster edits, especially in large files.
+
+The update for OpenAI models is on by default in VS Code Insiders and gradually rolling out to Stable. The Anthropic update is available for all users in both Stable and Insiders.
+
+### Base model in chat
+
+We're gradually rolling out GPT-4.1 as the default base model in chat in VS Code. You can use the model switcher in the Chat view to change to another model at any time.
+
+### Search code of a GitHub repository with the `#githubRepo` tool
+
+Imagine you need to ask a question about a GitHub repository, but you don't have it open in your editor. For example, you want to know how a specific function is implemented in the `microsoft/vscode` repository.
+
+You can now use the `#githubRepo` tool to search for code snippets in any GitHub repository that you have access to. This tool takes a `user/repo` as extra input. For example, "how to implement factory pattern in TS #githubRepo microsoft/vscode".
+
+You can also use [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) to hint when and how to use this tool, as shown in the following example:
+
+```md
+---
+applyTo: '**'
+---
+Use the `#githubRepo` tool with `microsoft/vscode` to find relevant code snippets in the VS Code codebase.
+Use the `#githubRepo` tool with `microsoft/typescript` to answer questions about how TypeScript is implemented.
+```
+
+![Screenshot showing using the #githubRepo tool in agent mode with hints from instructions files.](images/1_100/github-repo-tool-example.png)
+
+If you want to ask about the repo you are currently working on, you can just use the [`#codebase` tool](https://code.visualstudio.com/docs/copilot/reference/workspace-context#_making-copilot-chat-an-expert-in-your-workspace).
+
+Also, the `#githubRepo` tool is only for searching for relevant code snippets. The [GitHub MCP server](https://github.com/github/github-mcp-server?tab=readme-ov-file#github-mcp-server) provides tools for working with GitHub issues and pull requests. Learn more about [adding MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server).
+
+### Find Marketplace extensions with the extensions tool
+
+Use the extensions tool (`#extensions`) in chat to find extensions from the Marketplace. Based on your chat prompt, the tool is automatically invoked, or you can explicitly reference it in your prompt with `#extensions`. The tool returns a list of extensions that match your query. You can install extensions directly from the results.
+
+<video src="images/1_100/extensions-agent-tool.mp4" title="Video that shows using the extensions tool to display popular Java extensions." autoplay loop controls muted></video>
+
+### Improvements to the web page fetch tool
+
+Last month, we introduced the fetch tool (`#fetch`) for retrieving the contents of a web page right from chat, and include it as context for your prompt. If you missed that release note, check out [the initial release of the fetch tool](https://code.visualstudio.com/updates/v1_99#fetch-tool) release note and examples.
+
+This iteration, we have made several big changes to the tool including:
+
+* **Entire page as context**: We now add the entire page as context, rather than a subset. With larger context windows, we have the ability to give the model the entire page. For example, it's now possible to ask summarization questions that require as much of the page as possible. If you _do_ manage to fill up the context window, the fetch tool is smart enough to exclude the less relevant sections of the page. That way, you don't exceed the context window limit, while still keeping the important parts.
+* **A standardized page format (Markdown)**: Previously, we formatted fetched webpages in a custom hierarchical format that did the job, but was sometimes hard to reason with because of its custom nature. We now convert fetched webpages into Markdown, a standardized language. This improves the reliability of the *relevancy detection* and is a format that most language models know deeply, so they can reason with it more easily.
+
+We'd love to hear how you use the fetch tool and if there are any capabilities you'd like to see from it!
+
+### Chat input improvements
+
+We have made several improvements to the chat input box:
+
+* **Attachments**: when you reference context in the prompt text with `#`, they now also appear as an attachment pill. This makes it simpler to understand what's being sent to the language model.
+* **Context picker**: we streamlined the context picker to make it simpler to pick files, folders, and other attachment types.
+* **Done button**: we heard your feedback about the "Done"-button and we removed it! No more confusion about unexpected session endings. Now, we only start a new session when you create a new chat (`kb(workbench.action.chat.newChat)`).
+
+### Chat mode keyboard shortcuts
+
+The keyboard shortcut `kb(workbench.action.chat.open)` still just opens the Chat view, but the `kb(workbench.action.chat.openAgent)` shortcut now opens the Chat view and switches to [agent mode](vscode://GitHub.Copilot-Chat/chat?mode=agent). If you'd like to set up keyboard shortcuts for other chat modes, there is a command for each mode:
+
+* `workbench.action.chat.openAgent`
+* `workbench.action.chat.openEdit`
+* `workbench.action.chat.openAsk`
+
+### Autofix diagnostics from agent mode edits
+
+**Setting**: `setting(github.copilot.chat.agent.autoFix)`
+
+If a file edit in agent mode introduces new errors, agent mode can now detect them, and automatically propose a follow-up edit. This means that you don't have to send a follow-up prompt to ask agent mode to fix any errors. You can disable this behavior with `setting(github.copilot.chat.agent.autoFix)`.
+
+### Handling of undo and manual edits in agent mode
+
+Previously, making manual edits during an agent mode session could confuse the model. Now, the agent is prompted about your changes, and should re-read files when necessary before editing files that might have changed.
+
+### Conversation summary and prompt caching
+
+We've made some changes to how our agent mode prompt is built to optimize for prompt caching. Prompt caching is a way to speed up model responses by maintaining a stable prefix for the prompt. The next request is able to resume from that prefix, and the result is that each request should be a bit faster. This is especially effective in a repetitive series of requests with large context, like you typically have in agent mode.
+
+When your conversation gets long, or your context gets very large, you might see a "Summarized conversation history" message in your agent mode session:
+
+![Screenshot showing a summarized conversation message in the Chat view.](images/1_100/summarized-conversation.png)
+
+Instead of keeping the whole conversation as a FIFO, breaking the cache, we compress the conversation so far into a summary of the most important information and the current state of your task. This keeps the prompt prefix stable, and your responses fast.
+
+### MCP support for Streamable HTTP
+
+This release adds support for the new Streamable HTTP transport for Model Context Protocol servers. Streamable HTTP servers are configured just like existing SSE servers, and our implementation is backwards-compatible with SSE servers:
+
+```json
+{
+  "servers": {
+    "my-mcp-server": {
+      "url": "http://localhost:3000/mcp"
+    }
+  }
+}
+```
+
+Learn more about [MCP support in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+
+### MCP support for image output
+
+We now support MCP servers that generate images as part of their tool output.
+
+Note that not all language models support reading images from tool output. For example, although GPT-4.1 has vision capability, it does not currently support reading images from tools.
+
+### Enhanced input, output, and progress from MCP servers
+
+We have enhanced the UI that shows MCP server tool input and output, and have also added support for MCP's new progress messages.
+
+<video src="images/1_100/mcp-confirm.mp4" autoplay loop controls muted></video>
+_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+
+### MCP config generation uses inputs
+
+To help keep your secrets secure, AI-assisted configurations generated by the **MCP: Add Server** command now generate `inputs` for any secrets, rather than inlining them into the resulting configuration.
+
+### Inline chat V2 (Preview)
+
+**Setting**: `setting(inlineChat.enableV2:true)`
+
+We have been working on a revamped version of inline chat `kb(inlineChat.start)`. Its theme is still "bringing chat into code", but behind the scenes it uses the same logic as chat edits. This means better use of the available context and a better code-editing strategy. You can enable inline chat v2 via `setting(inlineChat.enableV2:true)`
+
+Further, there is now a more lightweight UX that can optionally be enabled. With the `setting(inlineChat.hideOnRequest:true)` setting, inline chat hides as soon as a request is made. It then minimizes into the chat-editing overlay, which enables accepting or discarding changes, or restoring the inline chat control.
+
+<video src="images/1_100/inlinechat2.mp4" title="Video that shows inline chat v2 and hide-on-request in action." autoplay loop controls muted></video>
+
+### Select and attach UI elements to chat (Experimental)
+
+**Setting**: `setting(chat.sendElementsToChat.enabled)`
+
+While you're developing a web application, you might want to ask chat about specific UI elements of a web page. You can now use the built-in Simple Browser to attach UI elements as context to chat.
+
+After opening any locally-hosted site via the built-in Simple Browser (launch it with the **Simple Browser: Show** command), a new toolbar is now shown where you can select **Start** to select any element in the site that you want. This attaches a screenshot of the selected element, and the HTML and CSS of the element.
+
+<video src="images/1_100/ui-element-selection-demo.mp4" title="Video showing the full flow of the UI element selection experimental feature. In the demo, we attach a hero from a webpage and ask chat to add a background image to that hero." autoplay loop controls muted></video>
+
+Configure what is attached to chat with:
+
+* `setting(chat.sendElementsToChat.attachCSS)`: enable or disable attaching the associated CSS
+* `setting(chat.sendElementsToChat.attachImages)`: enable or disable attaching the screenshot of the selected element
+
+This experimental feature is enabled by default for all Simple Browsers, but can be disabled with `setting(chat.sendElementsToChat.enabled)`.
+
+### Create and launch tasks in agent mode (Experimental)
+
+**Setting**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
+
+In the previous release, we introduced the `setting(github.copilot.chat.newWorkspaceCreation.enabled)` (Experimental) setting to enable workspace creation with agent mode.
+
+Now, at the end of this creation flow, you are prompted to create and run a task for launching your app or project. This streamlines the project launch process and enables easy task reuse.
+
+## Accessibility
+
+### Merge editor improvements
+
+The merge editor is now more accessible. To learn about available actions, open the accessibility help dialog within the merge editor (`kb(editor.action.accessibilityHelp)`). Key actions include `Merge Editor: Complete Merge` (`kb(mergeEditor.acceptMerge)`) and `Toggle Between Merge Editor Inputs` (`kb(mergeEditor.toggleBetweenInputs)`). The currently focused input is also now announced to assistive technologies.
+
+### Next edit suggestion enhancements
+
+The new setting `setting(accessibility.signals.nextEditSuggestion)` notifies you when a predicted suggestion is available. Review and accept suggestions through the accessible view (`kb(editor.action.accessibleView)`). Additionally, `setting(accessibility.signals.diffLineAdded)` and `setting(accessibility.signals.diffLineRemoved)` provide audio cues during navigation to make diff review accessible.
+
+### Review Copilot user requests from the accessible view
+
+When in [agent mode](vscode://GitHub.Copilot-Chat/chat?mode=agent), tool invocations or terminal commands sometimes require user permission to run. Review these actions within the accessible view (`kb(editor.action.accessibleView)`).
+
+### Unique accessibility sounds
+
+`setting(accessibility.signals.save.sound)` now has its own distinct sound and no longer shares audio with `setting(accessibility.signals.terminalCommandSucceeded.sound)`.
+
+## Editor Experience
+
+### Floating window modes
+
+Floating windows in VS Code allow you to move editors and certain views out of the main window into a smaller window for lightweight multi-window setups. There are two new modes a floating window can have:
+
+* Compact: we hide certain UI elements to make more room for the actual content
+* Always-on-top: the window stays on top of all other windows until you leave this mode
+
+Here is an example of how to turn a floating editor window into compact mode:
+
+<video src="images/1_100/floating-compact.mp4" title="Video that shows floating window compact mode." autoplay loop controls muted></video>
+
+We use compact mode by default for when you create a chat in a new window. Combined with the option to have the window always on top, you can always keep the Chat view around for asking questions!
+
+<video src="images/1_100/floating-pinned.mp4" title="Video that shows floating window always on top." autoplay loop controls muted></video>
+
+We introduced new commands if you prefer to use keyboard shortcuts for these actions:
+
+* `workbench.action.toggleWindowAlwaysOnTop`: to toggle always on top mode
+* `workbench.action.enableWindowAlwaysOnTop`: to set the floating window always on top
+* `workbench.action.disableWindowAlwaysOnTop`: to set the floating window to normal
+* `workbench.action.toggleCompactAuxiliaryWindow`: to toggle compact mode
+* `workbench.action.enableCompactAuxiliaryWindow`: to enable compact mode
+* `workbench.action.disableCompactAuxiliaryWindow`: to disable compact mode
+
+> **Note:** even in compact mode you can create complex editor layouts and open other editors.
+
+### Secondary Side Bar default visibility
+
+**Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
+
+By default, the Secondary Side Bar is hidden when you open a new workspace or window. With the new setting `setting(workbench.secondarySideBar.defaultVisibility)`, you can control if the Secondary Side Bar should open automatically in new workspaces or windows. You can pick from:
+
+* `hidden`: this is the default and keeps the Secondary Side Bar hidden
+* `visibleInWorkspace`: this opens the Secondary Side Bar if you open a folder or multi-root workspace
+* `visible`: this always opens the Secondary Side Bar
+
+Note that after a workspace or window has been opened, the visibility becomes a workspace state and overrides the setting value. If you close the Secondary Side Bar, it will remain closed in that workspace or window.
+
+### Mandatory extension signature verification
+
+Extension signature verification is now required on all platforms: Windows, macOS, and Linux. Previously, this verification was only mandatory on Windows and macOS. With this release, Linux now also enforces extension signature verification, ensuring that all extensions are properly validated before installation.
+
+This change further strengthens security by preventing the installation of potentially malicious extensions. For more information, see the [Extension Signing](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_the-extension-signature-cannot-be-verified-by-vs-code).
+
+> **Note:** Mandatory extension signature verification remains disabled on Linux ARM32 builds due to [issue #248308](https://github.com/microsoft/vscode/issues/248308). This is expected to be resolved in the next release.
+
+### Learn more links for malicious extensions
+
+When an extension is identified as malicious, VS Code now provides links to additional information explaining why the extension was flagged. These "Learn More" links connect users to GitHub issues or documentation with details about the security concerns, helping you better understand the potential risks.
+
+### Prevent installation of Copilot Chat pre-release versions in VS Code stable
+
+VS Code now prevents the installation of the pre-release version of the Copilot Chat extension in VS Code Stable. This helps avoid situations where you inadvertently install the Copilot Chat pre-release version and get stuck in a broken state. This means that you can only install the Copilot Chat extension pre-release version in the Insiders build of VS Code.
+
+### Command to open a view without focus
+
+Views (tree views and webview views) can now be opened without focusing them. This is useful for extensions and keyboard shortcuts that want to open a view but not take focus away from the current editor. The command is `your-view-id.open`, and it takes a property bag argument: `{ preserveFocus: boolean}`.
+
+### Semantic text search with keyword suggestions (Experimental)
+
+**Setting**: `setting(github.copilot.chat.search.keywordSuggestions:true)`
+
+Semantic text search now supports AI-powered keyword suggestions. By enabling this feature, you will start seeing relevant references or definitions that might help you find the code you are looking for.
+
+<video src="images/1_100/ai-keywords.mp4" title="Video that shows AI-powered keyword suggestions in Visual Studio Code." autoplay loop controls muted></video>
+
+## Code Editing
+
+### New Next Edit Suggestions (NES) model
+
+**Setting**: `setting(github.copilot.nextEditSuggestions.enabled)`
+
+We're excited to introduce a new model powering NES, designed to provide faster and more contextually relevant code recommendations. This updated model offers improved performance, delivering suggestions with reduced latency, and offering suggestions that are less intrusive and align more closely with your recent edits. This update is part of our ongoing commitment to refining AI-assisted development tools within Visual Studio Code.
+
+### Import suggestions
+
+**Setting**: `setting(github.copilot.nextEditSuggestions.fixes:true)`
+
+Next Edit Suggestions (NES) can now automatically suggest adding missing import statements in JavaScript and TypeScript files. Enable this feature by setting `setting(github.copilot.nextEditSuggestions.fixes:true)`. We plan to further enhance this capability by supporting imports from additional languages in future updates.
+
+![Screenshot showing NES suggesting an import statement.](images/1_100/nes-import.png)
+
+### Generate alt text in HTML or Markdown
+
+You can now generate or update existing alt text in HTML and Markdown files. Navigate to any line containing an embedded image and trigger the quick fix via `kb(editor.action.quickFix)` or by selecting the lightbulb icon.
+
+![Screenshot that shows generating alt text for an image html element.](images/1_100/generate-alt-text.png)
+
+### Variable line heights
+
+It is now possible to define variable line heights on a monaco editor by setting the line height value in the `IModelDecorationOptions` type. If two line heights are set on a line, the maximum of the two is used on the line.
+
+Note that for simplicity for now, the line height is set only on the first line of the corresponding decoration range. In the following screen recording, lines 24 and 32 are rendered with a larger line height than the default one.
+
+<video src="images/1_100/variable-line-heights.mp4" title="Video that shows variable line heights in the editor." autoplay loop controls muted></video>
+
+This work is not yet available to extensions, but will roll out after some more testing.
+
+## Notebooks
+
+### Find and replace history persistence
+
+The Notebook Find control now supports persistent history for both the find and replace input fields. This persists across reloads, and is controlled by the settings `setting(editor.find.history)` and `setting(editor.find.replaceHistory)`.
+
+### Drag and drop cell outputs to chat
+
+To enhance existing support for cell output usage within chat, outputs are now able to be dragged into the Chat view for a seamless attachment experience. Currently, only image and textual outputs are supported. Outputs with an image mime type are directly draggable, however to avoid clashing with text selection, textual outputs require holding the `kbstyle(alt)` modifier key to enable dragging. We are exploring UX improvements in the coming releases.
+
+<video src="images/1_100/output-dnd.mp4" title="Video that shows multiple cell outputs being attached as chat context via drag and drop." autoplay loop controls muted></video>
+
+### Notebook tools for agent mode
+
+#### Run cell
+
+Chat now has an LLM tool to run notebook cells, which allows the agent to perform updates based on cell run results or perform its own data exploration as it builds out a notebook.
+
+<video src="images/1_100/agent-notebook-run-edit-loop.mp4" title="Video that shows copilot running notebook cells, making updates based on an error, and retrying those cells." autoplay loop controls muted></video>
+
+#### Get kernel state
+
+The agent can find out which cells have been executed in the current kernel session, and read the active variables by using the Kernel State tool.
+
+#### List/Install packages
+
+The Jupyter extension contributes tools for listing and installing packages into the environment that's being used as the notebook's kernel. The operation is delegated to the Python Environments extension if available; otherwise, it attempts to use the pip package manager.
+
+## Source Control
+
+### Quick diff decorations for staged changes
+
+To address a long-time feature request, this milestone we have added quick diff editor decorations for staged changes. Now you can view your staged changes directly from the editor, without needing to open the Source Control view.
+
+<video src="images/1_100/staged-changes-diff-decorations.mp4" title="Video that shows managing staged changed from an editor by using diff decorations." autoplay loop controls muted></video>
+
+You can customize the color of the staged changes quick diff decorations by using the following theme tokens: `editorGutter.addedSecondaryBackground`, `editorGutter.modifiedSecondaryBackground`, `editorGutter.deletedSecondaryBackground`.
+
+If you do not want to see quick diff decorations for staged changes, you can hide them by using the **Diff Decorations** submenu that is available in the editor gutter context menu.
+
+## Debugging
+
+### Disassembly view context menu
+
+Thanks to a community contribution, we now have a context menu in the disassembly view.
+
+![Screenshot that shows the context menu in the Disassembly view.](images/1_100/disassembly-context.png)
+
+### JavaScript debugger Network view
+
+Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
+
+## Languages
+
+### Show browser support for CSS and HTML
+
+When hovering over a CSS property, HTML element, or HTML attribute, you now see a summary of how well that property or element is supported across browsers using [Baseline](https://developer.mozilla.org/docs/Glossary/Baseline/Compatibility).
+
+![Screenshot that shows baseline browser support in the CSS hover.](images/1_100/css-baseline.png)
+
+### Default syntax highlighting for `.*.env` files
+
+Files with name format `.*.env` are now syntax highlighted as `.ini` files.
+
+### Expandable hovers for JavaScript and TypeScript (Experimental)
+
+**Setting**: `setting(typescript.experimental.expandableHover)`
+
+We've continued to iterate on the expandable hover feature for JavaScript and TypeScript. This feature lets you use a `+` and `-` in the hover control to show more or less type information.
+
+<video src="images/1_100/expandable-hover.mp4" title="Video that shows TypeScript expandable hover." autoplay loop controls muted></video>
+
+This feature is still experimental but you can try it today by enabling `setting(typescript.experimental.expandableHover)`. You must be using TypeScript version 5.9 or above, for example by installing the [TypeScript nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next).
+
+## Remote Development
+
+The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+
+### Dev container instructions files
+
+Dev Container features and images now include instructions files describing their tools and configuration. VS Code chat can automatically use this context, improving the relevance and accuracy of its suggestions during development.
+
+## Contributions to extensions
+
+### Python
+
+#### Branch coverage support
+
+Branch coverage is now supported in the Testing Explorer for Python! Note that your `coveragepy` version must be >= 7.7 for this feature. You can upgrade coverage by running `pip install coverage==7.7`.
+
+<video src="images/1_100/python-branch-coverage.mp4" title="Video showing branch coverage run using the Test Explorer and branch coverage displayed." autoplay loop controls muted></video>
+
+#### Python Environments Quick Create command
+
+The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension has added support for Quick Create, making the environment creation process more seamless. Quick Create minimizes the input needed from you to create new virtual environments by detecting the latest Python version on your machine to create the virtual environment and install any workspace dependencies with a single click. This will create a `.venv` in your workspace for venv-based environments, and `.conda`  for-conda based environments. You can access Quick Create via the **Python: Create Environment** command in the Command Palette.
+
+![Screenshot showing Quick Create in the Python: Create Environment quick pick.](images/1_100/python-envs-quick-create.png)
+
+#### Python Environments chat tools
+
+The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) now includes two chat tools: “Get Python Environment Information” and “Install Python Package”. To use these tools, you can either directly reference them in your prompt by adding `#pythonGetEnvironmentInfo` `#pythonInstallPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information based on file or workspace context, and handle package installation with accurate environment resolution.
+
+<video src="images/1_100/python-get-env-tool.mp4" title="Video demoing the get environment information tool call implicitly by the model in agent mode." autoplay loop controls muted></video>
+
+<video src="images/1_100/python-install-pkg-tool.mp4" title="Video demoing the get install package tool call for numpy version 2.2." autoplay loop controls muted></video>
+
+#### Color picker when using Pylance
+
+Pylance can now display an interactive color swatch directly in the editor for recognized color values in Python files, making it easier to visualize and pick colors on the fly. To try it out, you can enable `setting(python.analysis.enableColorPicker:true)`. Supported formats include #RGB (like "#001122") and #RGBA (like "#001122FF").
+
+![Screenshot showing the color swatch displayed in the editor next to #RGB color format.](images/1_100/pylance-color-picker.png)
+
+#### AI Code Actions: Convert Format String (Experimental)
+
+When using Pylance, there's a new experimental AI Code Action for converting string concatenations to f-string or format(). To try it out, select the **Convert to f-string with Copilot** or the **Convert to format() call with Copilot** Code Actions through the light bulb when selecting a symbol in the string you wish to convert, or through `kbstyle(Ctrl + .)`/`kbstyle(Cmd + .)`.
+
+![Screenshot showing the convert strings Code Actions, powered by AI.](images/1_100/pylance-convert-string.png)
+
+This experience is enabled via the following setting:
+
+```json
+"python.analysis.aiCodeActions": {"convertFormatString": true}
+```
+
+Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let AI handle the implementation. If you want, you can then use Pylance's **Move Symbol** Code Actions to move it to a different file.
+
+### GitHub Pull Requests and Issues
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+
+* Ask questions in chat about the active pull request, such as "Address all comments in the #activePullRequest".
+* View issues in a webview, just like you can view pull requests.
+* Polish and alignment of the "Pull Requests", "Issues", and "Notifications" views.
+* Prepared for the release of GitHub's Project Padawan by enabling assignment of issues to Copilot, @-mentioning of Copilot, and ensuring it will be displayed properly in the UI.
+
+Review the [changelog for the 0.110.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01100) release of the extension to learn about the other highlights.
+
+## Extension Authoring
+
+### Text Encodings
+
+We finalized the API for working with text encodings in VS Code.
+
+Specifically, this new API allows you to:
+
+* Get the current `encoding` of a `TextDocument`
+* Open a `TextDocument` with a specific `encoding`
+* Encode a `string` to a `Uint8Array` with a specific `encoding`
+* Decode a `Uint8Array` to a `string` using a specific `encoding`
+
+### ESM support for extensions
+
+The NodeJS extension host now supports extensions that use JavaScript-modules (ESM). All it needs is the `"type": "module"` entry in your extension's `package.json` file. With that, the JavaScript code can use `import` and `export` statements, including the special module `import('vscode')`. Find a sample here: <https://github.com/jrieken/vscode-esm-sample-extension>.
+
+Note that ESM support isn't for the web worker extension host yet. There are some technical challenges that need to be overcome first. We'll post updates on <https://github.com/microsoft/vscode/issues/130367>. Stay tuned!
+
+## Proposed APIs
+
+### Tool calling for images
+
+Last iteration, we added a [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts) so that extensions can attach images and send vision requests to the language model. This iteration, we've expanded on this API to allow tool call results to include images as well.
+
+Check out [this API proposal issue](https://github.com/microsoft/vscode/issues/245104) to see a usage example and to stay up to date with the status of this API.
+
+### MCP servers contributed by extensions
+
+Extensions are able to programmatically contribute extensions to the editor by using the new [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts). This is an alternative to users hardcoding configuration for each server in their settings or `mcp.json`.
+
+If this API is interesting to you, check out [its sample](https://github.com/microsoft/vscode-extension-samples/tree/main/mcp-extension-sample/) and [the API proposal issue](https://github.com/microsoft/vscode/issues/243522) to stay up to date with the status of this API.
+
+### MCP Tool Annotations
+
+VS Code will now display the human-readable names of MCP servers with tools configured with the appropriate [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations). Additionally, tools marked with `readOnlyHint: true` in their annotations will be allowed to run without requiring user confirmation.
+
+## Notable fixes
+
+* [244939](https://github.com/microsoft/vscode/issues/244939) - Personal Microsoft accounts logs out very quickly (few mins to few hours)
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@ahojukka5 (Jukka Aho)](https://github.com/ahojukka5): Update chatExecuteActions.ts [PR #246494](https://github.com/microsoft/vscode/pull/246494)
+* [@alexweininger (Alex Weininger)](https://github.com/alexweininger): fix: handle cancellation errors inside edit session identity provider [PR #247450](https://github.com/microsoft/vscode/pull/247450)
+* [@andrewbranch (Andrew Branch)](https://github.com/andrewbranch): Allow disabling built-in TS/JS extension in favor of tsgo [PR #246858](https://github.com/microsoft/vscode/pull/246858)
+* [@BABA983 (BABA)](https://github.com/BABA983): A command to accept all combination [PR #225132](https://github.com/microsoft/vscode/pull/225132)
+* [@batsev](https://github.com/batsev): Git - validate branch name before creation [PR #245029](https://github.com/microsoft/vscode/pull/245029)
+* [@brthom (Ben Thomas)](https://github.com/brthom): Fix test items sorting in Testing Explorer to use natural file order [PR #246352](https://github.com/microsoft/vscode/pull/246352)
+* [@bytemain (Jiacheng)](https://github.com/bytemain)
+  * fix: correct filtering logic for file-based recommendations [PR #245062](https://github.com/microsoft/vscode/pull/245062)
+  * refactor(nls): use then for JSON parsing [PR #247013](https://github.com/microsoft/vscode/pull/247013)
+* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): git: make Letter/Text/Color semantically consistency [PR #245889](https://github.com/microsoft/vscode/pull/245889)
+* [@eps1lon (Sebastian "Sebbie" Silbermann)](https://github.com/eps1lon): Deemphasize old JSX transform [PR #246738](https://github.com/microsoft/vscode/pull/246738)
+* [@futurist (James Yang)](https://github.com/futurist): fix: runCommand type [PR #246198](https://github.com/microsoft/vscode/pull/246198)
+* [@gabritto (Gabriela Araujo Britto)](https://github.com/gabritto)
+  * [typescript-language-features] Re-add expandable hover [PR #246899](https://github.com/microsoft/vscode/pull/246899)
+  * [typescript-language-features] make expandable hover true by default [PR #247343](https://github.com/microsoft/vscode/pull/247343)
+* [@guiserle (guiserle)](https://github.com/guiserle): config: Resolve variables returned by commands [PR #246641](https://github.com/microsoft/vscode/pull/246641)
+* [@huntertran (Tuan Tran Van)](https://github.com/huntertran): Replace single line break with double line break for commit description in git blame hover popup [PR #245779](https://github.com/microsoft/vscode/pull/245779)
+* [@johnscollins98 (John Collins)](https://github.com/johnscollins98): #245665 fix early task exit with empty promptString input [PR #246834](https://github.com/microsoft/vscode/pull/246834)
+* [@KapitanOczywisty](https://github.com/KapitanOczywisty): Fix html derivative grammar consuming php code, fixes #237262 [PR #245076](https://github.com/microsoft/vscode/pull/245076)
+* [@luantranminh (Tran Minh Luan)](https://github.com/luantranminh): argv: update description for `add-mcp` [PR #246473](https://github.com/microsoft/vscode/pull/246473)
+* [@manabu-nakamura (nakamura)](https://github.com/manabu-nakamura)
+  * tooltip text of close button is internationalized [PR #245190](https://github.com/microsoft/vscode/pull/245190)
+  * tooltip text for close button is internationalized (2) [PR #245333](https://github.com/microsoft/vscode/pull/245333)
+  * normalize ellipsis [PR #246447](https://github.com/microsoft/vscode/pull/246447)
+* [@mdanish-kh (Muhammad Danish)](https://github.com/mdanish-kh): Update WinGet configuration file location & extension [PR #242241](https://github.com/microsoft/vscode/pull/242241)
+* [@mkhuzaima (Muhammad Khuzaima Umair)](https://github.com/mkhuzaima): Set DragData when directory is dragged [PR #243656](https://github.com/microsoft/vscode/pull/243656)
+* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): fix: remove necessary async declaration [PR #247213](https://github.com/microsoft/vscode/pull/247213)
+* [@nknguyenhc (Nguyen)](https://github.com/nknguyenhc): Goto definition for built-in symbols in HTML script [PR #244074](https://github.com/microsoft/vscode/pull/244074)
+* [@noahbowman (Noah)](https://github.com/noahbowman): #188711 - Walkthrough Focus-Visible Outline [PR #247650](https://github.com/microsoft/vscode/pull/247650)
+* [@pedrofrazaopacheco (Pedro Frazão Pacheco)](https://github.com/pedrofrazaopacheco): Fixes microsoft/vscode#240654: Avoid encoding reserved chars in JSON schema URL [PR #244934](https://github.com/microsoft/vscode/pull/244934)
+* [@pisv (Vladimir Piskarev)](https://github.com/pisv): Merge Editor: fix a bug in `LineRange.join(other)` [PR #227585](https://github.com/microsoft/vscode/pull/227585)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+  * Fix template.expression brackets #190564 [PR #245786](https://github.com/microsoft/vscode/pull/245786)
+  * YAML auto trigger code completion in strings #239679 [PR #246939](https://github.com/microsoft/vscode/pull/246939)
+* [@s-rigaud (Samuel Rigaud)](https://github.com/s-rigaud)
+  * test: fix typos [PR #247259](https://github.com/microsoft/vscode/pull/247259)
+  * fix: vscode-dts typos [PR #247263](https://github.com/microsoft/vscode/pull/247263)
+  * fix: toggleApplicationScope typo [PR #247264](https://github.com/microsoft/vscode/pull/247264)
+* [@sfaut](https://github.com/sfaut): Fix PHP f* files functions signatures [PR #246964](https://github.com/microsoft/vscode/pull/246964)
+* [@thegecko (Rob Moran)](https://github.com/thegecko): Add disassembly view context menu [PR #212500](https://github.com/microsoft/vscode/pull/212500)
+* [@theskcd](https://github.com/theskcd): [vscode] Decorations from #file is much better and does not break on new line [PR #231948](https://github.com/microsoft/vscode/pull/231948)
+* [@tjcork (tjcork)](https://github.com/tjcork): Use parameter expansion to fetch envs for envVarCollections in shellIntegration-bash.sh [PR #245264](https://github.com/microsoft/vscode/pull/245264)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): tsb: small build improvements [PR #237450](https://github.com/microsoft/vscode/pull/237450)
+* [@Victuracor (Victuracor)](https://github.com/Victuracor): Fix a typo in extensions/typescript-language-features/package.nls.json [PR #245713](https://github.com/microsoft/vscode/pull/245713)
+* [@whistlegraph (jeffrey)](https://github.com/whistlegraph): fixes issue #662 (enables Pointer Lock Web API) [PR #210875](https://github.com/microsoft/vscode/pull/210875)
+* [@wolfgang42 (Wolfgang Faust)](https://github.com/wolfgang42): feat: markdown-basics snippets: quote all lines [PR #246871](https://github.com/microsoft/vscode/pull/246871)
+* [@zobo (Damjan Cvetko)](https://github.com/zobo): Also replace keys in object within variable substitution [PR #245989](https://github.com/microsoft/vscode/pull/245989)
+
+Contributions to `vscode-css-languageservice`:
+
+* [@AlterNT (NTPS)](https://github.com/AlterNT): Support `@scope` [PR #434](https://github.com/microsoft/vscode-css-languageservice/pull/434)
+* [@rviscomi (Rick Viscomi)](https://github.com/rviscomi): Add Baseline status to hovercards [PR #428](https://github.com/microsoft/vscode-css-languageservice/pull/428)
+
+Contributions to `vscode-js-debug`:
+
+* [@mikaelwaltersson (Mikael Waltersson)](https://github.com/mikaelwaltersson): Fix expansion of "floating" WASM variables in repl/watch + readMemory when WASM memory is SharedArrayBuffer [PR #2199](https://github.com/microsoft/vscode-js-debug/pull/2199)
+
+Contributions to `vscode-json-languageservice`:
+
+* [@fengzilong (MO)](https://github.com/fengzilong): feat: make newJSONDocument and JSONDocument consistent [PR #259](https://github.com/microsoft/vscode-json-languageservice/pull/259)
+
+Contributions to `vscode-jupyter`:
+
+* [@alexfanqi (Alex Fan)](https://github.com/alexfanqi): change the scope of excludeUserSitePackages to window [PR #16377](https://github.com/microsoft/vscode-jupyter/pull/16377)
+* [@realDuang (Duang)](https://github.com/realDuang): fix: repair python code escaping path in environment service [PR #16518](https://github.com/microsoft/vscode-jupyter/pull/16518)
+
+Contributions to `vscode-mypy`:
+
+* [@tdscheper (Tommy Scheper)](https://github.com/tdscheper): When cwd config option is ${nearestConfig}, look for all of mypy.ini, .mypy.ini, pyproject.toml, setup.cfg [PR #357](https://github.com/microsoft/vscode-mypy/pull/357)
+
+Contributions to `vscode-notebook-renderers`:
+
+* [@marthacryan (Martha Cryan)](https://github.com/marthacryan): Update plotly.js version to 3.0.0 [PR #230](https://github.com/microsoft/vscode-notebook-renderers/pull/230)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@kabel (Kevin Abel)](https://github.com/kabel): Fix merge email confirmation when git config fails [PR #6797](https://github.com/microsoft/vscode-pull-request-github/pull/6797)
+* [@timrogers (Tim Rogers)](https://github.com/timrogers): When `copilot-swe-agent` is the author of a comment, render with the Copilot identity [PR #6794](https://github.com/microsoft/vscode-pull-request-github/pull/6794)
+
+Contributions to `vscode-python-debugger`:
+
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Allow autoReload in attach configurations [PR #676](https://github.com/microsoft/vscode-python-debugger/pull/676)
+
+Contributions to `vscode-python-environments`:
+
+* [@InSyncWithFoo (InSync)](https://github.com/InSyncWithFoo): fix: clarify that `showSkipOption` also applies to uninstallations [PR #288](https://github.com/microsoft/vscode-python-environments/pull/288)
+
+Contributions to `language-server-protocol`:
+
+* [@hippietrail (Andrew Dunbar)](https://github.com/hippietrail): several grammar fixes [PR #2123](https://github.com/microsoft/language-server-protocol/pull/2123)
+* [@imbant (imbant)](https://github.com/imbant): Ensure document state synchronization before client requests [PR #2017](https://github.com/microsoft/language-server-protocol/pull/2017)
+* [@ocfbnj](https://github.com/ocfbnj): Add thrift-ls for Thrift [PR #2128](https://github.com/microsoft/language-server-protocol/pull/2128)
+* [@rtorralba (rtorralba)](https://github.com/rtorralba)
+  * Add ZX Basic language server to the implementors list [PR #2121](https://github.com/microsoft/language-server-protocol/pull/2121)
+  * Replace ZX Basic with Boriel Basic language server into the implement… [PR #2125](https://github.com/microsoft/language-server-protocol/pull/2125)
+
+Contributions to `monaco-editor`:
+
+* [@RoccoC (Rocco Cataldo)](https://github.com/RoccoC): Update webpack plugin to support module workers [PR #4742](https://github.com/microsoft/monaco-editor/pull/4742)
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_100.md
+++ b/docs/release-notes/v1_100.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_100/release-highlights.png
 Date: 2025-05-08
 DownloadVersion: 1.100.0
 ---
-# April 2025 (version 1.100)
+# April 2025 (version 1.100) {#april-2025-version-1100}
 
 _Release date: May 8, 2025_
 
@@ -33,13 +33,13 @@ Welcome to the April 2025 release of Visual Studio Code. There are many updates 
 >If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 **Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
 
-## Chat
+## Chat {#chat}
 
-### Prompt and instructions files
+### Prompt and instructions files {#prompt-and-instructions-files}
 
 You can tailor your AI experience in VS Code to your specific coding practices and technology stack by using Markdown-based instructions and prompt files. We've aligned the implementation and usage of these two related concepts, however they each have distinct purposes.
 
-#### Instructions files
+#### Instructions files {#instructions-files}
 
 **Setting**: `setting(chat.instructionsFilesLocations)`
 
@@ -75,7 +75,7 @@ You can create instruction files with the **Chat: New Instructions File...** com
 
 Learn more about [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_instruction-files) in our documentation.
 
-#### Prompt files
+#### Prompt files {#prompt-files}
 
 **Setting**: `setting(chat.promptFilesLocations)`
 
@@ -112,23 +112,23 @@ To create a prompt file, use the **Chat: New Prompt File...** command from the C
 
 Learn more about [prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental) in our documentation.
 
-#### Improvements and notes
+#### Improvements and notes {#improvements-and-notes}
 
 * Instructions and prompt files now have their own language IDs, configurable in the _language mode_ dialog for any file open document ("Prompt" and "Instructions" respectively). This allows, for instance, using untitled documents as temporary prompt files before saving them as files to disk.
 * We renamed the **Chat: Use Prompt** command to **Chat: Run Prompt**. Furthermore, the command now runs the selected prompt _immediately_, as opposed to attaching it as chat context as it did before.
 * Both file types now also support the `description` metadata in their headers, providing a common place for short and user-friendly prompt summaries. In the future, this header is planned to be used along with the `applyTo` header as the rule that determines if the file needs to be auto-included with chat requests (for example, `description: 'Code style rules for front-end components written in TypeScript.'`)
 
-### Faster agent mode edits
+### Faster agent mode edits {#faster-agent-mode-edits}
 
 We've implemented support for OpenAI's apply patch editing format (GPT 4.1 and o4-mini) and Anthropic’s replace string tool (Claude Sonnet 3.7 and 3.5) in agent mode. This means that you benefit from significantly faster edits, especially in large files.
 
 The update for OpenAI models is on by default in VS Code Insiders and gradually rolling out to Stable. The Anthropic update is available for all users in both Stable and Insiders.
 
-### Base model in chat
+### Base model in chat {#base-model-in-chat}
 
 We're gradually rolling out GPT-4.1 as the default base model in chat in VS Code. You can use the model switcher in the Chat view to change to another model at any time.
 
-### Search code of a GitHub repository with the `#githubRepo` tool
+### Search code of a GitHub repository with the `#githubRepo` tool {#search-code-of-a-github-repository-with-the-githubrepo-tool}
 
 Imagine you need to ask a question about a GitHub repository, but you don't have it open in your editor. For example, you want to know how a specific function is implemented in the `microsoft/vscode` repository.
 
@@ -150,13 +150,13 @@ If you want to ask about the repo you are currently working on, you can just use
 
 Also, the `#githubRepo` tool is only for searching for relevant code snippets. The [GitHub MCP server](https://github.com/github/github-mcp-server?tab=readme-ov-file#github-mcp-server) provides tools for working with GitHub issues and pull requests. Learn more about [adding MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server).
 
-### Find Marketplace extensions with the extensions tool
+### Find Marketplace extensions with the extensions tool {#find-marketplace-extensions-with-the-extensions-tool}
 
 Use the extensions tool (`#extensions`) in chat to find extensions from the Marketplace. Based on your chat prompt, the tool is automatically invoked, or you can explicitly reference it in your prompt with `#extensions`. The tool returns a list of extensions that match your query. You can install extensions directly from the results.
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/extensions-agent-tool.mp4" title="Video that shows using the extensions tool to display popular Java extensions." autoplay loop controls muted></video>
 
-### Improvements to the web page fetch tool
+### Improvements to the web page fetch tool {#improvements-to-the-web-page-fetch-tool}
 
 Last month, we introduced the fetch tool (`#fetch`) for retrieving the contents of a web page right from chat, and include it as context for your prompt. If you missed that release note, check out [the initial release of the fetch tool](https://code.visualstudio.com/updates/v1_99#fetch-tool) release note and examples.
 
@@ -167,7 +167,7 @@ This iteration, we have made several big changes to the tool including:
 
 We'd love to hear how you use the fetch tool and if there are any capabilities you'd like to see from it!
 
-### Chat input improvements
+### Chat input improvements {#chat-input-improvements}
 
 We have made several improvements to the chat input box:
 
@@ -175,7 +175,7 @@ We have made several improvements to the chat input box:
 * **Context picker**: we streamlined the context picker to make it simpler to pick files, folders, and other attachment types.
 * **Done button**: we heard your feedback about the "Done"-button and we removed it! No more confusion about unexpected session endings. Now, we only start a new session when you create a new chat (`kb(workbench.action.chat.newChat)`).
 
-### Chat mode keyboard shortcuts
+### Chat mode keyboard shortcuts {#chat-mode-keyboard-shortcuts}
 
 The keyboard shortcut `kb(workbench.action.chat.open)` still just opens the Chat view, but the `kb(workbench.action.chat.openAgent)` shortcut now opens the Chat view and switches to [agent mode](vscode://GitHub.Copilot-Chat/chat?mode=agent). If you'd like to set up keyboard shortcuts for other chat modes, there is a command for each mode:
 
@@ -183,17 +183,17 @@ The keyboard shortcut `kb(workbench.action.chat.open)` still just opens the Chat
 * `workbench.action.chat.openEdit`
 * `workbench.action.chat.openAsk`
 
-### Autofix diagnostics from agent mode edits
+### Autofix diagnostics from agent mode edits {#autofix-diagnostics-from-agent-mode-edits}
 
 **Setting**: `setting(github.copilot.chat.agent.autoFix)`
 
 If a file edit in agent mode introduces new errors, agent mode can now detect them, and automatically propose a follow-up edit. This means that you don't have to send a follow-up prompt to ask agent mode to fix any errors. You can disable this behavior with `setting(github.copilot.chat.agent.autoFix)`.
 
-### Handling of undo and manual edits in agent mode
+### Handling of undo and manual edits in agent mode {#handling-of-undo-and-manual-edits-in-agent-mode}
 
 Previously, making manual edits during an agent mode session could confuse the model. Now, the agent is prompted about your changes, and should re-read files when necessary before editing files that might have changed.
 
-### Conversation summary and prompt caching
+### Conversation summary and prompt caching {#conversation-summary-and-prompt-caching}
 
 We've made some changes to how our agent mode prompt is built to optimize for prompt caching. Prompt caching is a way to speed up model responses by maintaining a stable prefix for the prompt. The next request is able to resume from that prefix, and the result is that each request should be a bit faster. This is especially effective in a repetitive series of requests with large context, like you typically have in agent mode.
 
@@ -203,7 +203,7 @@ When your conversation gets long, or your context gets very large, you might see
 
 Instead of keeping the whole conversation as a FIFO, breaking the cache, we compress the conversation so far into a summary of the most important information and the current state of your task. This keeps the prompt prefix stable, and your responses fast.
 
-### MCP support for Streamable HTTP
+### MCP support for Streamable HTTP {#mcp-support-for-streamable-http}
 
 This release adds support for the new Streamable HTTP transport for Model Context Protocol servers. Streamable HTTP servers are configured just like existing SSE servers, and our implementation is backwards-compatible with SSE servers:
 
@@ -219,24 +219,24 @@ This release adds support for the new Streamable HTTP transport for Model Contex
 
 Learn more about [MCP support in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
 
-### MCP support for image output
+### MCP support for image output {#mcp-support-for-image-output}
 
 We now support MCP servers that generate images as part of their tool output.
 
 Note that not all language models support reading images from tool output. For example, although GPT-4.1 has vision capability, it does not currently support reading images from tools.
 
-### Enhanced input, output, and progress from MCP servers
+### Enhanced input, output, and progress from MCP servers {#enhanced-input-output-and-progress-from-mcp-servers}
 
 We have enhanced the UI that shows MCP server tool input and output, and have also added support for MCP's new progress messages.
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/mcp-confirm.mp4" autoplay loop controls muted></video>
 _Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
 
-### MCP config generation uses inputs
+### MCP config generation uses inputs {#mcp-config-generation-uses-inputs}
 
 To help keep your secrets secure, AI-assisted configurations generated by the **MCP: Add Server** command now generate `inputs` for any secrets, rather than inlining them into the resulting configuration.
 
-### Inline chat V2 (Preview)
+### Inline chat V2 (Preview) {#inline-chat-v2-preview}
 
 **Setting**: `setting(inlineChat.enableV2:true)`
 
@@ -246,7 +246,7 @@ Further, there is now a more lightweight UX that can optionally be enabled. With
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/inlinechat2.mp4" title="Video that shows inline chat v2 and hide-on-request in action." autoplay loop controls muted></video>
 
-### Select and attach UI elements to chat (Experimental)
+### Select and attach UI elements to chat (Experimental) {#select-and-attach-ui-elements-to-chat-experimental}
 
 **Setting**: `setting(chat.sendElementsToChat.enabled)`
 
@@ -263,7 +263,7 @@ Configure what is attached to chat with:
 
 This experimental feature is enabled by default for all Simple Browsers, but can be disabled with `setting(chat.sendElementsToChat.enabled)`.
 
-### Create and launch tasks in agent mode (Experimental)
+### Create and launch tasks in agent mode (Experimental) {#create-and-launch-tasks-in-agent-mode-experimental}
 
 **Setting**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
 
@@ -271,27 +271,27 @@ In the previous release, we introduced the `setting(github.copilot.chat.newWorks
 
 Now, at the end of this creation flow, you are prompted to create and run a task for launching your app or project. This streamlines the project launch process and enables easy task reuse.
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Merge editor improvements
+### Merge editor improvements {#merge-editor-improvements}
 
 The merge editor is now more accessible. To learn about available actions, open the accessibility help dialog within the merge editor (`kb(editor.action.accessibilityHelp)`). Key actions include `Merge Editor: Complete Merge` (`kb(mergeEditor.acceptMerge)`) and `Toggle Between Merge Editor Inputs` (`kb(mergeEditor.toggleBetweenInputs)`). The currently focused input is also now announced to assistive technologies.
 
-### Next edit suggestion enhancements
+### Next edit suggestion enhancements {#next-edit-suggestion-enhancements}
 
 The new setting `setting(accessibility.signals.nextEditSuggestion)` notifies you when a predicted suggestion is available. Review and accept suggestions through the accessible view (`kb(editor.action.accessibleView)`). Additionally, `setting(accessibility.signals.diffLineAdded)` and `setting(accessibility.signals.diffLineRemoved)` provide audio cues during navigation to make diff review accessible.
 
-### Review Copilot user requests from the accessible view
+### Review Copilot user requests from the accessible view {#review-copilot-user-requests-from-the-accessible-view}
 
 When in [agent mode](vscode://GitHub.Copilot-Chat/chat?mode=agent), tool invocations or terminal commands sometimes require user permission to run. Review these actions within the accessible view (`kb(editor.action.accessibleView)`).
 
-### Unique accessibility sounds
+### Unique accessibility sounds {#unique-accessibility-sounds}
 
 `setting(accessibility.signals.save.sound)` now has its own distinct sound and no longer shares audio with `setting(accessibility.signals.terminalCommandSucceeded.sound)`.
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Floating window modes
+### Floating window modes {#floating-window-modes}
 
 Floating windows in VS Code allow you to move editors and certain views out of the main window into a smaller window for lightweight multi-window setups. There are two new modes a floating window can have:
 
@@ -317,7 +317,7 @@ We introduced new commands if you prefer to use keyboard shortcuts for these act
 
 > **Note:** even in compact mode you can create complex editor layouts and open other editors.
 
-### Secondary Side Bar default visibility
+### Secondary Side Bar default visibility {#secondary-side-bar-default-visibility}
 
 **Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
 
@@ -329,7 +329,7 @@ By default, the Secondary Side Bar is hidden when you open a new workspace or wi
 
 Note that after a workspace or window has been opened, the visibility becomes a workspace state and overrides the setting value. If you close the Secondary Side Bar, it will remain closed in that workspace or window.
 
-### Mandatory extension signature verification
+### Mandatory extension signature verification {#mandatory-extension-signature-verification}
 
 Extension signature verification is now required on all platforms: Windows, macOS, and Linux. Previously, this verification was only mandatory on Windows and macOS. With this release, Linux now also enforces extension signature verification, ensuring that all extensions are properly validated before installation.
 
@@ -337,19 +337,19 @@ This change further strengthens security by preventing the installation of poten
 
 > **Note:** Mandatory extension signature verification remains disabled on Linux ARM32 builds due to [issue #248308](https://github.com/microsoft/vscode/issues/248308). This is expected to be resolved in the next release.
 
-### Learn more links for malicious extensions
+### Learn more links for malicious extensions {#learn-more-links-for-malicious-extensions}
 
 When an extension is identified as malicious, VS Code now provides links to additional information explaining why the extension was flagged. These "Learn More" links connect users to GitHub issues or documentation with details about the security concerns, helping you better understand the potential risks.
 
-### Prevent installation of Copilot Chat pre-release versions in VS Code stable
+### Prevent installation of Copilot Chat pre-release versions in VS Code stable {#prevent-installation-of-copilot-chat-pre-release-versions-in-vs-code-stable}
 
 VS Code now prevents the installation of the pre-release version of the Copilot Chat extension in VS Code Stable. This helps avoid situations where you inadvertently install the Copilot Chat pre-release version and get stuck in a broken state. This means that you can only install the Copilot Chat extension pre-release version in the Insiders build of VS Code.
 
-### Command to open a view without focus
+### Command to open a view without focus {#command-to-open-a-view-without-focus}
 
 Views (tree views and webview views) can now be opened without focusing them. This is useful for extensions and keyboard shortcuts that want to open a view but not take focus away from the current editor. The command is `your-view-id.open`, and it takes a property bag argument: `{ preserveFocus: boolean}`.
 
-### Semantic text search with keyword suggestions (Experimental)
+### Semantic text search with keyword suggestions (Experimental) {#semantic-text-search-with-keyword-suggestions-experimental}
 
 **Setting**: `setting(github.copilot.chat.search.keywordSuggestions:true)`
 
@@ -357,15 +357,15 @@ Semantic text search now supports AI-powered keyword suggestions. By enabling th
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/ai-keywords.mp4" title="Video that shows AI-powered keyword suggestions in Visual Studio Code." autoplay loop controls muted></video>
 
-## Code Editing
+## Code Editing {#code-editing}
 
-### New Next Edit Suggestions (NES) model
+### New Next Edit Suggestions (NES) model {#new-next-edit-suggestions-nes-model}
 
 **Setting**: `setting(github.copilot.nextEditSuggestions.enabled)`
 
 We're excited to introduce a new model powering NES, designed to provide faster and more contextually relevant code recommendations. This updated model offers improved performance, delivering suggestions with reduced latency, and offering suggestions that are less intrusive and align more closely with your recent edits. This update is part of our ongoing commitment to refining AI-assisted development tools within Visual Studio Code.
 
-### Import suggestions
+### Import suggestions {#import-suggestions}
 
 **Setting**: `setting(github.copilot.nextEditSuggestions.fixes:true)`
 
@@ -373,13 +373,13 @@ Next Edit Suggestions (NES) can now automatically suggest adding missing import 
 
 ![Screenshot showing NES suggesting an import statement.](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
 
-### Generate alt text in HTML or Markdown
+### Generate alt text in HTML or Markdown {#generate-alt-text-in-html-or-markdown}
 
 You can now generate or update existing alt text in HTML and Markdown files. Navigate to any line containing an embedded image and trigger the quick fix via `kb(editor.action.quickFix)` or by selecting the lightbulb icon.
 
 ![Screenshot that shows generating alt text for an image html element.](https://code.visualstudio.com/assets/updates/1_100/generate-alt-text.png)
 
-### Variable line heights
+### Variable line heights {#variable-line-heights}
 
 It is now possible to define variable line heights on a monaco editor by setting the line height value in the `IModelDecorationOptions` type. If two line heights are set on a line, the maximum of the two is used on the line.
 
@@ -389,37 +389,37 @@ Note that for simplicity for now, the line height is set only on the first line 
 
 This work is not yet available to extensions, but will roll out after some more testing.
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Find and replace history persistence
+### Find and replace history persistence {#find-and-replace-history-persistence}
 
 The Notebook Find control now supports persistent history for both the find and replace input fields. This persists across reloads, and is controlled by the settings `setting(editor.find.history)` and `setting(editor.find.replaceHistory)`.
 
-### Drag and drop cell outputs to chat
+### Drag and drop cell outputs to chat {#drag-and-drop-cell-outputs-to-chat}
 
 To enhance existing support for cell output usage within chat, outputs are now able to be dragged into the Chat view for a seamless attachment experience. Currently, only image and textual outputs are supported. Outputs with an image mime type are directly draggable, however to avoid clashing with text selection, textual outputs require holding the `kbstyle(alt)` modifier key to enable dragging. We are exploring UX improvements in the coming releases.
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/output-dnd.mp4" title="Video that shows multiple cell outputs being attached as chat context via drag and drop." autoplay loop controls muted></video>
 
-### Notebook tools for agent mode
+### Notebook tools for agent mode {#notebook-tools-for-agent-mode}
 
-#### Run cell
+#### Run cell {#run-cell}
 
 Chat now has an LLM tool to run notebook cells, which allows the agent to perform updates based on cell run results or perform its own data exploration as it builds out a notebook.
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/agent-notebook-run-edit-loop.mp4" title="Video that shows copilot running notebook cells, making updates based on an error, and retrying those cells." autoplay loop controls muted></video>
 
-#### Get kernel state
+#### Get kernel state {#get-kernel-state}
 
 The agent can find out which cells have been executed in the current kernel session, and read the active variables by using the Kernel State tool.
 
-#### List/Install packages
+#### List/Install packages {#listinstall-packages}
 
 The Jupyter extension contributes tools for listing and installing packages into the environment that's being used as the notebook's kernel. The operation is delegated to the Python Environments extension if available; otherwise, it attempts to use the pip package manager.
 
-## Source Control
+## Source Control {#source-control}
 
-### Quick diff decorations for staged changes
+### Quick diff decorations for staged changes {#quick-diff-decorations-for-staged-changes}
 
 To address a long-time feature request, this milestone we have added quick diff editor decorations for staged changes. Now you can view your staged changes directly from the editor, without needing to open the Source Control view.
 
@@ -429,31 +429,31 @@ You can customize the color of the staged changes quick diff decorations by usin
 
 If you do not want to see quick diff decorations for staged changes, you can hide them by using the **Diff Decorations** submenu that is available in the editor gutter context menu.
 
-## Debugging
+## Debugging {#debugging}
 
-### Disassembly view context menu
+### Disassembly view context menu {#disassembly-view-context-menu}
 
 Thanks to a community contribution, we now have a context menu in the disassembly view.
 
 ![Screenshot that shows the context menu in the Disassembly view.](https://code.visualstudio.com/assets/updates/1_100/disassembly-context.png)
 
-### JavaScript debugger Network view
+### JavaScript debugger Network view {#javascript-debugger-network-view}
 
 Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
 
-## Languages
+## Languages {#languages}
 
-### Show browser support for CSS and HTML
+### Show browser support for CSS and HTML {#show-browser-support-for-css-and-html}
 
 When hovering over a CSS property, HTML element, or HTML attribute, you now see a summary of how well that property or element is supported across browsers using [Baseline](https://developer.mozilla.org/docs/Glossary/Baseline/Compatibility).
 
 ![Screenshot that shows baseline browser support in the CSS hover.](https://code.visualstudio.com/assets/updates/1_100/css-baseline.png)
 
-### Default syntax highlighting for `.*.env` files
+### Default syntax highlighting for `.*.env` files {#default-syntax-highlighting-for--env-files}
 
 Files with name format `.*.env` are now syntax highlighted as `.ini` files.
 
-### Expandable hovers for JavaScript and TypeScript (Experimental)
+### Expandable hovers for JavaScript and TypeScript (Experimental) {#expandable-hovers-for-javascript-and-typescript-experimental}
 
 **Setting**: `setting(typescript.experimental.expandableHover)`
 
@@ -463,31 +463,31 @@ We've continued to iterate on the expandable hover feature for JavaScript and Ty
 
 This feature is still experimental but you can try it today by enabling `setting(typescript.experimental.expandableHover)`. You must be using TypeScript version 5.9 or above, for example by installing the [TypeScript nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next).
 
-## Remote Development
+## Remote Development {#remote-development}
 
 The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
 
-### Dev container instructions files
+### Dev container instructions files {#dev-container-instructions-files}
 
 Dev Container features and images now include instructions files describing their tools and configuration. VS Code chat can automatically use this context, improving the relevance and accuracy of its suggestions during development.
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### Python
+### Python {#python}
 
-#### Branch coverage support
+#### Branch coverage support {#branch-coverage-support}
 
 Branch coverage is now supported in the Testing Explorer for Python! Note that your `coveragepy` version must be >= 7.7 for this feature. You can upgrade coverage by running `pip install coverage==7.7`.
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/python-branch-coverage.mp4" title="Video showing branch coverage run using the Test Explorer and branch coverage displayed." autoplay loop controls muted></video>
 
-#### Python Environments Quick Create command
+#### Python Environments Quick Create command {#python-environments-quick-create-command}
 
 The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension has added support for Quick Create, making the environment creation process more seamless. Quick Create minimizes the input needed from you to create new virtual environments by detecting the latest Python version on your machine to create the virtual environment and install any workspace dependencies with a single click. This will create a `.venv` in your workspace for venv-based environments, and `.conda`  for-conda based environments. You can access Quick Create via the **Python: Create Environment** command in the Command Palette.
 
 ![Screenshot showing Quick Create in the Python: Create Environment quick pick.](https://code.visualstudio.com/assets/updates/1_100/python-envs-quick-create.png)
 
-#### Python Environments chat tools
+#### Python Environments chat tools {#python-environments-chat-tools}
 
 The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) now includes two chat tools: “Get Python Environment Information” and “Install Python Package”. To use these tools, you can either directly reference them in your prompt by adding `#pythonGetEnvironmentInfo` `#pythonInstallPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information based on file or workspace context, and handle package installation with accurate environment resolution.
 
@@ -495,13 +495,13 @@ The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/python-install-pkg-tool.mp4" title="Video demoing the get install package tool call for numpy version 2.2." autoplay loop controls muted></video>
 
-#### Color picker when using Pylance
+#### Color picker when using Pylance {#color-picker-when-using-pylance}
 
 Pylance can now display an interactive color swatch directly in the editor for recognized color values in Python files, making it easier to visualize and pick colors on the fly. To try it out, you can enable `setting(python.analysis.enableColorPicker:true)`. Supported formats include #RGB (like "#001122") and #RGBA (like "#001122FF").
 
 ![Screenshot showing the color swatch displayed in the editor next to #RGB color format.](https://code.visualstudio.com/assets/updates/1_100/pylance-color-picker.png)
 
-#### AI Code Actions: Convert Format String (Experimental)
+#### AI Code Actions: Convert Format String (Experimental) {#ai-code-actions-convert-format-string-experimental}
 
 When using Pylance, there's a new experimental AI Code Action for converting string concatenations to f-string or format(). To try it out, select the **Convert to f-string with Copilot** or the **Convert to format() call with Copilot** Code Actions through the light bulb when selecting a symbol in the string you wish to convert, or through `kbstyle(Ctrl + .)`/`kbstyle(Cmd + .)`.
 
@@ -515,7 +515,7 @@ This experience is enabled via the following setting:
 
 Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let AI handle the implementation. If you want, you can then use Pylance's **Move Symbol** Code Actions to move it to a different file.
 
-### GitHub Pull Requests and Issues
+### GitHub Pull Requests and Issues {#github-pull-requests-and-issues}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
 
@@ -526,9 +526,9 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 Review the [changelog for the 0.110.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01100) release of the extension to learn about the other highlights.
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### Text Encodings
+### Text Encodings {#text-encodings}
 
 We finalized the API for working with text encodings in VS Code.
 
@@ -539,39 +539,39 @@ Specifically, this new API allows you to:
 * Encode a `string` to a `Uint8Array` with a specific `encoding`
 * Decode a `Uint8Array` to a `string` using a specific `encoding`
 
-### ESM support for extensions
+### ESM support for extensions {#esm-support-for-extensions}
 
 The NodeJS extension host now supports extensions that use JavaScript-modules (ESM). All it needs is the `"type": "module"` entry in your extension's `package.json` file. With that, the JavaScript code can use `import` and `export` statements, including the special module `import('vscode')`. Find a sample here: <https://github.com/jrieken/vscode-esm-sample-extension>.
 
 Note that ESM support isn't for the web worker extension host yet. There are some technical challenges that need to be overcome first. We'll post updates on <https://github.com/microsoft/vscode/issues/130367>. Stay tuned!
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Tool calling for images
+### Tool calling for images {#tool-calling-for-images}
 
 Last iteration, we added a [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts) so that extensions can attach images and send vision requests to the language model. This iteration, we've expanded on this API to allow tool call results to include images as well.
 
 Check out [this API proposal issue](https://github.com/microsoft/vscode/issues/245104) to see a usage example and to stay up to date with the status of this API.
 
-### MCP servers contributed by extensions
+### MCP servers contributed by extensions {#mcp-servers-contributed-by-extensions}
 
 Extensions are able to programmatically contribute extensions to the editor by using the new [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts). This is an alternative to users hardcoding configuration for each server in their settings or `mcp.json`.
 
 If this API is interesting to you, check out [its sample](https://github.com/microsoft/vscode-extension-samples/tree/main/mcp-extension-sample/) and [the API proposal issue](https://github.com/microsoft/vscode/issues/243522) to stay up to date with the status of this API.
 
-### MCP Tool Annotations
+### MCP Tool Annotations {#mcp-tool-annotations}
 
 VS Code will now display the human-readable names of MCP servers with tools configured with the appropriate [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations). Additionally, tools marked with `readOnlyHint: true` in their annotations will be allowed to run without requiring user confirmation.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [244939](https://github.com/microsoft/vscode/issues/244939) - Personal Microsoft accounts logs out very quickly (few mins to few hours)
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -580,7 +580,7 @@ Contributions to our issue tracking:
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull requests
+### Pull requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_100.md
+++ b/docs/release-notes/v1_100.md
@@ -86,10 +86,10 @@ Prompt files use the `.prompt.md` file suffix. They can be located in your user 
 There are several ways to run a prompt file:
 
 * Type `/` in the chat input field, followed by the prompt file name.
-  ![Screenshot that shows running a prompt in the Chat view with a slash command.](images/1_100/run-prompt-as-slash-command.png)
+  ![Screenshot that shows running a prompt in the Chat view with a slash command.](https://code.visualstudio.com/assets/updates/1_100/run-prompt-as-slash-command.png)
 
 * Open the prompt file in an editor and press the 'Play' button in the editor tool bar. This enables you to quickly iterate on the prompt and run it without having to switch back to the Chat view.
-  ![Screenshot that shows running a prompt by using the play button in the editor.](images/1_100/run-prompt-from-play-button.png)
+  ![Screenshot that shows running a prompt by using the play button in the editor.](https://code.visualstudio.com/assets/updates/1_100/run-prompt-from-play-button.png)
 
 * Use the **Chat: Run Prompt File...** command from the Command Palette.
 
@@ -144,7 +144,7 @@ Use the `#githubRepo` tool with `microsoft/vscode` to find relevant code snippet
 Use the `#githubRepo` tool with `microsoft/typescript` to answer questions about how TypeScript is implemented.
 ```
 
-![Screenshot showing using the #githubRepo tool in agent mode with hints from instructions files.](images/1_100/github-repo-tool-example.png)
+![Screenshot showing using the #githubRepo tool in agent mode with hints from instructions files.](https://code.visualstudio.com/assets/updates/1_100/github-repo-tool-example.png)
 
 If you want to ask about the repo you are currently working on, you can just use the [`#codebase` tool](https://code.visualstudio.com/docs/copilot/reference/workspace-context#_making-copilot-chat-an-expert-in-your-workspace).
 
@@ -154,7 +154,7 @@ Also, the `#githubRepo` tool is only for searching for relevant code snippets. T
 
 Use the extensions tool (`#extensions`) in chat to find extensions from the Marketplace. Based on your chat prompt, the tool is automatically invoked, or you can explicitly reference it in your prompt with `#extensions`. The tool returns a list of extensions that match your query. You can install extensions directly from the results.
 
-<video src="images/1_100/extensions-agent-tool.mp4" title="Video that shows using the extensions tool to display popular Java extensions." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/extensions-agent-tool.mp4" title="Video that shows using the extensions tool to display popular Java extensions." autoplay loop controls muted></video>
 
 ### Improvements to the web page fetch tool
 
@@ -199,7 +199,7 @@ We've made some changes to how our agent mode prompt is built to optimize for pr
 
 When your conversation gets long, or your context gets very large, you might see a "Summarized conversation history" message in your agent mode session:
 
-![Screenshot showing a summarized conversation message in the Chat view.](images/1_100/summarized-conversation.png)
+![Screenshot showing a summarized conversation message in the Chat view.](https://code.visualstudio.com/assets/updates/1_100/summarized-conversation.png)
 
 Instead of keeping the whole conversation as a FIFO, breaking the cache, we compress the conversation so far into a summary of the most important information and the current state of your task. This keeps the prompt prefix stable, and your responses fast.
 
@@ -229,7 +229,7 @@ Note that not all language models support reading images from tool output. For e
 
 We have enhanced the UI that shows MCP server tool input and output, and have also added support for MCP's new progress messages.
 
-<video src="images/1_100/mcp-confirm.mp4" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/mcp-confirm.mp4" autoplay loop controls muted></video>
 _Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
 
 ### MCP config generation uses inputs
@@ -244,7 +244,7 @@ We have been working on a revamped version of inline chat `kb(inlineChat.start)`
 
 Further, there is now a more lightweight UX that can optionally be enabled. With the `setting(inlineChat.hideOnRequest:true)` setting, inline chat hides as soon as a request is made. It then minimizes into the chat-editing overlay, which enables accepting or discarding changes, or restoring the inline chat control.
 
-<video src="images/1_100/inlinechat2.mp4" title="Video that shows inline chat v2 and hide-on-request in action." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/inlinechat2.mp4" title="Video that shows inline chat v2 and hide-on-request in action." autoplay loop controls muted></video>
 
 ### Select and attach UI elements to chat (Experimental)
 
@@ -254,7 +254,7 @@ While you're developing a web application, you might want to ask chat about spec
 
 After opening any locally-hosted site via the built-in Simple Browser (launch it with the **Simple Browser: Show** command), a new toolbar is now shown where you can select **Start** to select any element in the site that you want. This attaches a screenshot of the selected element, and the HTML and CSS of the element.
 
-<video src="images/1_100/ui-element-selection-demo.mp4" title="Video showing the full flow of the UI element selection experimental feature. In the demo, we attach a hero from a webpage and ask chat to add a background image to that hero." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/ui-element-selection-demo.mp4" title="Video showing the full flow of the UI element selection experimental feature. In the demo, we attach a hero from a webpage and ask chat to add a background image to that hero." autoplay loop controls muted></video>
 
 Configure what is attached to chat with:
 
@@ -300,11 +300,11 @@ Floating windows in VS Code allow you to move editors and certain views out of t
 
 Here is an example of how to turn a floating editor window into compact mode:
 
-<video src="images/1_100/floating-compact.mp4" title="Video that shows floating window compact mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/floating-compact.mp4" title="Video that shows floating window compact mode." autoplay loop controls muted></video>
 
 We use compact mode by default for when you create a chat in a new window. Combined with the option to have the window always on top, you can always keep the Chat view around for asking questions!
 
-<video src="images/1_100/floating-pinned.mp4" title="Video that shows floating window always on top." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/floating-pinned.mp4" title="Video that shows floating window always on top." autoplay loop controls muted></video>
 
 We introduced new commands if you prefer to use keyboard shortcuts for these actions:
 
@@ -355,7 +355,7 @@ Views (tree views and webview views) can now be opened without focusing them. Th
 
 Semantic text search now supports AI-powered keyword suggestions. By enabling this feature, you will start seeing relevant references or definitions that might help you find the code you are looking for.
 
-<video src="images/1_100/ai-keywords.mp4" title="Video that shows AI-powered keyword suggestions in Visual Studio Code." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/ai-keywords.mp4" title="Video that shows AI-powered keyword suggestions in Visual Studio Code." autoplay loop controls muted></video>
 
 ## Code Editing
 
@@ -371,13 +371,13 @@ We're excited to introduce a new model powering NES, designed to provide faster 
 
 Next Edit Suggestions (NES) can now automatically suggest adding missing import statements in JavaScript and TypeScript files. Enable this feature by setting `setting(github.copilot.nextEditSuggestions.fixes:true)`. We plan to further enhance this capability by supporting imports from additional languages in future updates.
 
-![Screenshot showing NES suggesting an import statement.](images/1_100/nes-import.png)
+![Screenshot showing NES suggesting an import statement.](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
 
 ### Generate alt text in HTML or Markdown
 
 You can now generate or update existing alt text in HTML and Markdown files. Navigate to any line containing an embedded image and trigger the quick fix via `kb(editor.action.quickFix)` or by selecting the lightbulb icon.
 
-![Screenshot that shows generating alt text for an image html element.](images/1_100/generate-alt-text.png)
+![Screenshot that shows generating alt text for an image html element.](https://code.visualstudio.com/assets/updates/1_100/generate-alt-text.png)
 
 ### Variable line heights
 
@@ -385,7 +385,7 @@ It is now possible to define variable line heights on a monaco editor by setting
 
 Note that for simplicity for now, the line height is set only on the first line of the corresponding decoration range. In the following screen recording, lines 24 and 32 are rendered with a larger line height than the default one.
 
-<video src="images/1_100/variable-line-heights.mp4" title="Video that shows variable line heights in the editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/variable-line-heights.mp4" title="Video that shows variable line heights in the editor." autoplay loop controls muted></video>
 
 This work is not yet available to extensions, but will roll out after some more testing.
 
@@ -399,7 +399,7 @@ The Notebook Find control now supports persistent history for both the find and 
 
 To enhance existing support for cell output usage within chat, outputs are now able to be dragged into the Chat view for a seamless attachment experience. Currently, only image and textual outputs are supported. Outputs with an image mime type are directly draggable, however to avoid clashing with text selection, textual outputs require holding the `kbstyle(alt)` modifier key to enable dragging. We are exploring UX improvements in the coming releases.
 
-<video src="images/1_100/output-dnd.mp4" title="Video that shows multiple cell outputs being attached as chat context via drag and drop." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/output-dnd.mp4" title="Video that shows multiple cell outputs being attached as chat context via drag and drop." autoplay loop controls muted></video>
 
 ### Notebook tools for agent mode
 
@@ -407,7 +407,7 @@ To enhance existing support for cell output usage within chat, outputs are now a
 
 Chat now has an LLM tool to run notebook cells, which allows the agent to perform updates based on cell run results or perform its own data exploration as it builds out a notebook.
 
-<video src="images/1_100/agent-notebook-run-edit-loop.mp4" title="Video that shows copilot running notebook cells, making updates based on an error, and retrying those cells." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/agent-notebook-run-edit-loop.mp4" title="Video that shows copilot running notebook cells, making updates based on an error, and retrying those cells." autoplay loop controls muted></video>
 
 #### Get kernel state
 
@@ -423,7 +423,7 @@ The Jupyter extension contributes tools for listing and installing packages into
 
 To address a long-time feature request, this milestone we have added quick diff editor decorations for staged changes. Now you can view your staged changes directly from the editor, without needing to open the Source Control view.
 
-<video src="images/1_100/staged-changes-diff-decorations.mp4" title="Video that shows managing staged changed from an editor by using diff decorations." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/staged-changes-diff-decorations.mp4" title="Video that shows managing staged changed from an editor by using diff decorations." autoplay loop controls muted></video>
 
 You can customize the color of the staged changes quick diff decorations by using the following theme tokens: `editorGutter.addedSecondaryBackground`, `editorGutter.modifiedSecondaryBackground`, `editorGutter.deletedSecondaryBackground`.
 
@@ -435,7 +435,7 @@ If you do not want to see quick diff decorations for staged changes, you can hid
 
 Thanks to a community contribution, we now have a context menu in the disassembly view.
 
-![Screenshot that shows the context menu in the Disassembly view.](images/1_100/disassembly-context.png)
+![Screenshot that shows the context menu in the Disassembly view.](https://code.visualstudio.com/assets/updates/1_100/disassembly-context.png)
 
 ### JavaScript debugger Network view
 
@@ -447,7 +447,7 @@ Recent versions of Node.js have enhanced its network debugging capabilities. The
 
 When hovering over a CSS property, HTML element, or HTML attribute, you now see a summary of how well that property or element is supported across browsers using [Baseline](https://developer.mozilla.org/docs/Glossary/Baseline/Compatibility).
 
-![Screenshot that shows baseline browser support in the CSS hover.](images/1_100/css-baseline.png)
+![Screenshot that shows baseline browser support in the CSS hover.](https://code.visualstudio.com/assets/updates/1_100/css-baseline.png)
 
 ### Default syntax highlighting for `.*.env` files
 
@@ -459,7 +459,7 @@ Files with name format `.*.env` are now syntax highlighted as `.ini` files.
 
 We've continued to iterate on the expandable hover feature for JavaScript and TypeScript. This feature lets you use a `+` and `-` in the hover control to show more or less type information.
 
-<video src="images/1_100/expandable-hover.mp4" title="Video that shows TypeScript expandable hover." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/expandable-hover.mp4" title="Video that shows TypeScript expandable hover." autoplay loop controls muted></video>
 
 This feature is still experimental but you can try it today by enabling `setting(typescript.experimental.expandableHover)`. You must be using TypeScript version 5.9 or above, for example by installing the [TypeScript nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next).
 
@@ -479,33 +479,33 @@ Dev Container features and images now include instructions files describing thei
 
 Branch coverage is now supported in the Testing Explorer for Python! Note that your `coveragepy` version must be >= 7.7 for this feature. You can upgrade coverage by running `pip install coverage==7.7`.
 
-<video src="images/1_100/python-branch-coverage.mp4" title="Video showing branch coverage run using the Test Explorer and branch coverage displayed." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/python-branch-coverage.mp4" title="Video showing branch coverage run using the Test Explorer and branch coverage displayed." autoplay loop controls muted></video>
 
 #### Python Environments Quick Create command
 
 The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension has added support for Quick Create, making the environment creation process more seamless. Quick Create minimizes the input needed from you to create new virtual environments by detecting the latest Python version on your machine to create the virtual environment and install any workspace dependencies with a single click. This will create a `.venv` in your workspace for venv-based environments, and `.conda`  for-conda based environments. You can access Quick Create via the **Python: Create Environment** command in the Command Palette.
 
-![Screenshot showing Quick Create in the Python: Create Environment quick pick.](images/1_100/python-envs-quick-create.png)
+![Screenshot showing Quick Create in the Python: Create Environment quick pick.](https://code.visualstudio.com/assets/updates/1_100/python-envs-quick-create.png)
 
 #### Python Environments chat tools
 
 The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) now includes two chat tools: “Get Python Environment Information” and “Install Python Package”. To use these tools, you can either directly reference them in your prompt by adding `#pythonGetEnvironmentInfo` `#pythonInstallPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information based on file or workspace context, and handle package installation with accurate environment resolution.
 
-<video src="images/1_100/python-get-env-tool.mp4" title="Video demoing the get environment information tool call implicitly by the model in agent mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/python-get-env-tool.mp4" title="Video demoing the get environment information tool call implicitly by the model in agent mode." autoplay loop controls muted></video>
 
-<video src="images/1_100/python-install-pkg-tool.mp4" title="Video demoing the get install package tool call for numpy version 2.2." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/python-install-pkg-tool.mp4" title="Video demoing the get install package tool call for numpy version 2.2." autoplay loop controls muted></video>
 
 #### Color picker when using Pylance
 
 Pylance can now display an interactive color swatch directly in the editor for recognized color values in Python files, making it easier to visualize and pick colors on the fly. To try it out, you can enable `setting(python.analysis.enableColorPicker:true)`. Supported formats include #RGB (like "#001122") and #RGBA (like "#001122FF").
 
-![Screenshot showing the color swatch displayed in the editor next to #RGB color format.](images/1_100/pylance-color-picker.png)
+![Screenshot showing the color swatch displayed in the editor next to #RGB color format.](https://code.visualstudio.com/assets/updates/1_100/pylance-color-picker.png)
 
 #### AI Code Actions: Convert Format String (Experimental)
 
 When using Pylance, there's a new experimental AI Code Action for converting string concatenations to f-string or format(). To try it out, select the **Convert to f-string with Copilot** or the **Convert to format() call with Copilot** Code Actions through the light bulb when selecting a symbol in the string you wish to convert, or through `kbstyle(Ctrl + .)`/`kbstyle(Cmd + .)`.
 
-![Screenshot showing the convert strings Code Actions, powered by AI.](images/1_100/pylance-convert-string.png)
+![Screenshot showing the convert strings Code Actions, powered by AI.](https://code.visualstudio.com/assets/updates/1_100/pylance-convert-string.png)
 
 This experience is enabled via the following setting:
 

--- a/docs/release-notes/v1_100.md
+++ b/docs/release-notes/v1_100.md
@@ -1,66 +1,66 @@
 ---
 Order: 109
-TOCTitle: April 2025
-PageTitle: Visual Studio Code April 2025
-MetaDescription: Learn what is new in the Visual Studio Code April 2025 Release (1.100)
+TOCTitle: 2025 年 4 月
+PageTitle: Visual Studio Code 2025 年 4 月
+MetaDescription: Visual Studio Code 2025 年 4 月リリース (1.100) の新機能について説明します。
 MetaSocialImage: 1_100/release-highlights.png
 Date: 2025-05-08
 DownloadVersion: 1.100.0
 ---
-# April 2025 (version 1.100) {#april-2025-version-1100}
+# 2025 年 4 月 (バージョン 1.100) {#april-2025-version-1100}
 
-_Release date: May 8, 2025_
+_リリース日: 2025 年 5 月 8 日_
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the April 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2025 年 4 月リリースへようこそ。このバージョンには多くの更新があり、皆様に気に入っていただけることを願っています。主なハイライトは次のとおりです:
 
-* **Chat**
-  * Custom instructions and reusable prompts ([more...](#prompt-and-instructions-files)).
-  * Smarter results with tools for GitHub, extensions, and notebooks ([more...](#search-code-of-a-github-repository-with-the-githubrepo-tool)).
-  * Image and Streamable HTTP support for MCP ([more...](#mcp-support-for-streamable-http)).
+* **チャット**
+  * カスタム指示と再利用可能なプロンプト ([詳細...](#prompt-and-instructions-files))。
+  * GitHub、拡張機能、ノートブック用のツールによるよりスマートな結果 ([詳細...](#search-code-of-a-github-repository-with-the-githubrepo-tool))。
+  * MCP の画像およびストリーマブル HTTP サポート ([詳細...](#mcp-support-for-streamable-http))。
 
-* **Chat performance**
-  * Faster responses on repeat chat requests ([more...](#conversation-summary-and-prompt-caching)).
-  * Faster edits in agent mode ([more...](#faster-agent-mode-edits)).
+* **チャットパフォーマンス**
+  * チャット要求の繰り返しに対する応答の高速化 ([詳細...](#conversation-summary-and-prompt-caching))。
+  * エージェントモードでの編集の高速化 ([詳細...](#faster-agent-mode-edits))。
 
-* **Editor experience**
-  * Improved multi-window support for chat and editors ([more...](#floating-window-modes)).
-  * Staged changes now easier to identify ([more...](#quick-diff-decorations-for-staged-changes)).
+* **エディターエクスペリエンス**
+  * チャットとエディターのマルチウィンドウサポートの改善 ([詳細...](#floating-window-modes))。
+  * ステージされた変更の識別が容易に ([詳細...](#quick-diff-decorations-for-staged-changes))。
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+>これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** 新機能をできるだけ早く試したいですか？夜間の [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、利用可能になり次第、最新のアップデートを試すことができます。
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Prompt and instructions files {#prompt-and-instructions-files}
+### プロンプトファイルと指示ファイル {#prompt-and-instructions-files}
 
-You can tailor your AI experience in VS Code to your specific coding practices and technology stack by using Markdown-based instructions and prompt files. We've aligned the implementation and usage of these two related concepts, however they each have distinct purposes.
+Markdown ベースの指示ファイルとプロンプトファイルを使用することで、特定のコーディングプラクティスやテクノロジースタックに合わせて VS Code の AI エクスペリエンスを調整できます。これら 2 つの関連する概念の実装と使用法を整合させましたが、それぞれ異なる目的を持っています。
 
-#### Instructions files {#instructions-files}
+#### 指示ファイル {#instructions-files}
 
-**Setting**: `setting(chat.instructionsFilesLocations)`
+**設定**: `setting(chat.instructionsFilesLocations)`
 
-Instructions files (also known as custom instructions or rules) provide a way to describe common guidelines and context for the AI model in a Markdown file, such as code style rules, or which frameworks to use. Instructions files are not standalone chat requests, but rather provide context that you can apply to a chat request.
+指示ファイル (カスタム指示またはルールとも呼ばれます) は、コードスタイルルールや使用するフレームワークなど、AI モデルの一般的なガイドラインとコンテキストを Markdown ファイルで記述する方法を提供します。指示ファイルはスタンドアロンのチャット要求ではなく、チャット要求に適用できるコンテキストを提供します。
 
-Instructions files use the `.instructions.md` file suffix. They can be located in your user data folder or in the workspace. The `setting(chat.instructionsFilesLocations)` setting lists the folders that contain instruction files.
+指示ファイルは `.instructions.md` ファイルサフィックスを使用します。ユーザーデータフォルダーまたはワークスペースに配置できます。`setting(chat.instructionsFilesLocations)` 設定には、指示ファイルを含むフォルダーが一覧表示されます。
 
-You can manually attach instructions to a specific chat request, or they can be automatically added:
+特定のチャット要求に手動で指示を添付することも、自動的に追加することもできます:
 
-* To add them manually, use the **Add Context** button in the Chat view, and then select **Instructions...**.
-  Alternatively use the **Chat: Attach Instructions...** command from the Command Palette. This brings up a picker that lets you select existing instructions files or create a new one to attach.
+* 手動で追加するには、チャットビューの **コンテキストの追加** ボタンを使用し、**指示...** を選択します。
+  または、コマンドパレットから **チャット: 指示の添付...** コマンドを使用します。これにより、既存の指示ファイルを選択したり、添付する新しい指示ファイルを作成したりできるピッカーが表示されます。
 
-* To automatically add instructions to a prompt, add the `applyTo` Front Matter header to the instructions file to indicate which files the instructions apply to. If a chat request contains a file that matches the given glob pattern, the instructions file is automatically attached.
+* プロンプトに指示を自動的に追加するには、指示ファイルに `applyTo` フロントマターヘッダーを追加して、指示が適用されるファイルを示します。チャット要求に指定された glob パターンに一致するファイルが含まれている場合、指示ファイルは自動的に添付されます。
 
-  The following example provides instructions for TypeScript files (`applyTo: '**/*.ts'`):
+  次の例は、TypeScript ファイル (`applyTo: '**/*.ts'`) の指示を提供します:
 
   ````md
   ---
   applyTo: '**/*.ts'
   ---
-  Place curly braces on separate lines for multi-line blocks:
+  複数行ブロックの場合、波括弧を別々の行に配置します:
   if (condition)
   {
     doSomething();
@@ -71,141 +71,141 @@ You can manually attach instructions to a specific chat request, or they can be 
   }
   ````
 
-You can create instruction files with the **Chat: New Instructions File...** command. Moreover, the files created in the _user data_ folder can be automatically synchronized across multiple user machines through the Settings Sync service. Make sure to check the **Prompts and Instructions** option in the **Backup and Sync Settings...** dialog.
+**チャット: 新しい指示ファイル...** コマンドを使用して指示ファイルを作成できます。さらに、_ユーザーデータ_ フォルダーに作成されたファイルは、設定同期サービスを介して複数のユーザーマシン間で自動的に同期できます。**バックアップと同期設定...** ダイアログで **プロンプトと指示** オプションを必ず確認してください。
 
-Learn more about [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_instruction-files) in our documentation.
+ドキュメントの [指示ファイル](https://code.visualstudio.com/docs/copilot/copilot-customization#_instruction-files) の詳細をご覧ください。
 
-#### Prompt files {#prompt-files}
+#### プロンプトファイル {#prompt-files}
 
-**Setting**: `setting(chat.promptFilesLocations)`
+**設定**: `setting(chat.promptFilesLocations)`
 
-Prompt files describe a standalone, complete chat request, including the prompt text, chat mode, and tools to use. Prompt files are useful for creating reusable chat requests for common tasks. For example, you can add a prompt file for creating a front-end component, or to perform a security review.
+プロンプトファイルは、プロンプトテキスト、チャットモード、使用するツールなど、スタンドアロンの完全なチャット要求を記述します。プロンプトファイルは、一般的なタスクの再利用可能なチャット要求を作成するのに役立ちます。たとえば、フロントエンドコンポーネントを作成したり、セキュリティレビューを実行したりするためのプロンプトファイルを追加できます。
 
-Prompt files use the `.prompt.md` file suffix. They can be located in your user data folder or in the workspace. The `setting(chat.promptFilesLocations)` setting lists the folder where prompt files are looked for.
+プロンプトファイルは `.prompt.md` ファイルサフィックスを使用します。ユーザーデータフォルダーまたはワークスペースに配置できます。`setting(chat.promptFilesLocations)` 設定には、プロンプトファイルが検索されるフォルダーが一覧表示されます。
 
-There are several ways to run a prompt file:
+プロンプトファイルを実行するには、いくつかの方法があります:
 
-* Type `/` in the chat input field, followed by the prompt file name.
-  ![Screenshot that shows running a prompt in the Chat view with a slash command.](https://code.visualstudio.com/assets/updates/1_100/run-prompt-as-slash-command.png)
+* チャット入力フィールドに `/` と入力し、続けてプロンプトファイル名を入力します。
+  ![チャットビューでスラッシュコマンドを使用してプロンプトを実行しているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/run-prompt-as-slash-command.png)
 
-* Open the prompt file in an editor and press the 'Play' button in the editor tool bar. This enables you to quickly iterate on the prompt and run it without having to switch back to the Chat view.
-  ![Screenshot that shows running a prompt by using the play button in the editor.](https://code.visualstudio.com/assets/updates/1_100/run-prompt-from-play-button.png)
+* エディターでプロンプトファイルを開き、エディターツールバーの「再生」ボタンを押します。これにより、プロンプトをすばやく反復処理し、チャットビューに切り替えることなく実行できます。
+  ![エディターの再生ボタンを使用してプロンプトを実行しているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/run-prompt-from-play-button.png)
 
-* Use the **Chat: Run Prompt File...** command from the Command Palette.
+* コマンドパレットから **チャット: プロンプトファイルの実行...** コマンドを使用します。
 
-Prompt files can have the following Front Matter metadata headers to indicate how they should be run:
+プロンプトファイルには、実行方法を示すために次のフロントマターメタデータヘッダーを含めることができます:
 
-* `mode`: the chat mode to use when invoking the prompt (`ask`, `edit`, or `agent` mode).
-* `tools`: if the `mode` is `agent`, the list of tools that are available for the prompt.
+* `mode`: プロンプトを呼び出すときに使用するチャットモード (`ask`、`edit`、または `agent` モード)。
+* `tools`: `mode` が `agent` の場合、プロンプトで使用できるツールのリスト。
 
-The following example shows a prompt file for generating release notes, that runs in agent mode, and can use a set of tools:
+次の例は、リリースノートを生成するためのプロンプトファイルを示しています。これはエージェントモードで実行され、一連のツールを使用できます:
 
 ```md
 ---
 mode: 'agent'
 tools: ['getCurrentMilestone', 'getReleaseFeatures', 'file_search', 'semantic_search', 'read_file', 'insert_edit_into_file', 'create_file', 'replace_string_in_file', 'fetch_webpage', 'vscode_search_extensions_internal']
 ---
-Generate release notes for the features I worked in the current release and update them in the release notes file. Use [release notes writing instructions file](.github/instructions/release-notes-writing.instructions.md) as a guide.
+現在のリリースで作業した機能のリリースノートを生成し、リリースノートファイルで更新します。[リリースノート作成指示ファイル](.github/instructions/release-notes-writing.instructions.md) をガイドとして使用してください。
 ```
 
-To create a prompt file, use the **Chat: New Prompt File...** command from the Command Palette.
+プロンプトファイルを作成するには、コマンドパレットから **チャット: 新しいプロンプトファイル...** コマンドを使用します。
 
-Learn more about [prompt files](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental) in our documentation.
+ドキュメントの [プロンプトファイル](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental) の詳細をご覧ください。
 
-#### Improvements and notes {#improvements-and-notes}
+#### 改善点と注意点 {#improvements-and-notes}
 
-* Instructions and prompt files now have their own language IDs, configurable in the _language mode_ dialog for any file open document ("Prompt" and "Instructions" respectively). This allows, for instance, using untitled documents as temporary prompt files before saving them as files to disk.
-* We renamed the **Chat: Use Prompt** command to **Chat: Run Prompt**. Furthermore, the command now runs the selected prompt _immediately_, as opposed to attaching it as chat context as it did before.
-* Both file types now also support the `description` metadata in their headers, providing a common place for short and user-friendly prompt summaries. In the future, this header is planned to be used along with the `applyTo` header as the rule that determines if the file needs to be auto-included with chat requests (for example, `description: 'Code style rules for front-end components written in TypeScript.'`)
+* 指示ファイルとプロンプトファイルには、開いているドキュメントの _言語モード_ ダイアログで構成可能な独自の言語 ID があります (それぞれ「プロンプト」と「指示」)。これにより、たとえば、無題のドキュメントをディスクにファイルとして保存する前に一時的なプロンプトファイルとして使用できます。
+* **チャット: プロンプトの使用** コマンドを **チャット: プロンプトの実行** に名前変更しました。さらに、このコマンドは、以前のようにチャットコンテキストとして添付するのではなく、選択したプロンプトを _すぐに_ 実行するようになりました。
+* 両方のファイルタイプで、ヘッダーに `description` メタデータもサポートされるようになり、短くユーザーフレンドリーなプロンプトの概要を記述する共通の場所が提供されます。将来的には、このヘッダーは `applyTo` ヘッダーとともに、ファイルをチャット要求に自動的に含める必要があるかどうかを決定するルールとして使用される予定です (例: `description: 'TypeScript で記述されたフロントエンドコンポーネントのコードスタイルルール。'`)
 
-### Faster agent mode edits {#faster-agent-mode-edits}
+### エージェントモード編集の高速化 {#faster-agent-mode-edits}
 
-We've implemented support for OpenAI's apply patch editing format (GPT 4.1 and o4-mini) and Anthropic’s replace string tool (Claude Sonnet 3.7 and 3.5) in agent mode. This means that you benefit from significantly faster edits, especially in large files.
+OpenAI のパッチ適用編集形式 (GPT 4.1 および o4-mini) と Anthropic の文字列置換ツール (Claude Sonnet 3.7 および 3.5) のエージェントモードでのサポートを実装しました。これにより、特に大きなファイルで編集が大幅に高速化されます。
 
-The update for OpenAI models is on by default in VS Code Insiders and gradually rolling out to Stable. The Anthropic update is available for all users in both Stable and Insiders.
+OpenAI モデルのアップデートは VS Code Insiders でデフォルトでオンになっており、Stable に段階的に展開されています。Anthropic のアップデートは、Stable と Insiders の両方ですべてのユーザーが利用できます。
 
-### Base model in chat {#base-model-in-chat}
+### チャットのベースモデル {#base-model-in-chat}
 
-We're gradually rolling out GPT-4.1 as the default base model in chat in VS Code. You can use the model switcher in the Chat view to change to another model at any time.
+VS Code のチャットのデフォルトベースモデルとして GPT-4.1 を段階的に展開しています。チャットビューのモデルスイッチャーを使用して、いつでも別のモデルに変更できます。
 
-### Search code of a GitHub repository with the `#githubRepo` tool {#search-code-of-a-github-repository-with-the-githubrepo-tool}
+### `#githubRepo` ツールを使用した GitHub リポジトリのコード検索 {#search-code-of-a-github-repository-with-the-githubrepo-tool}
 
-Imagine you need to ask a question about a GitHub repository, but you don't have it open in your editor. For example, you want to know how a specific function is implemented in the `microsoft/vscode` repository.
+GitHub リポジトリについて質問する必要があるが、エディターで開いていないとします。たとえば、`microsoft/vscode` リポジトリで特定の関数がどのように実装されているかを知りたいとします。
 
-You can now use the `#githubRepo` tool to search for code snippets in any GitHub repository that you have access to. This tool takes a `user/repo` as extra input. For example, "how to implement factory pattern in TS #githubRepo microsoft/vscode".
+`#githubRepo` ツールを使用して、アクセス権のある GitHub リポジトリのコードスニペットを検索できるようになりました。このツールは、追加の入力として `user/repo` を取ります。たとえば、「TS #githubRepo microsoft/vscode でファクトリパターンを実装する方法」などです。
 
-You can also use [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) to hint when and how to use this tool, as shown in the following example:
+次の例に示すように、[カスタム指示](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) を使用して、このツールをいつどのように使用するかをヒントとして示すこともできます:
 
 ```md
 ---
 applyTo: '**'
 ---
-Use the `#githubRepo` tool with `microsoft/vscode` to find relevant code snippets in the VS Code codebase.
-Use the `#githubRepo` tool with `microsoft/typescript` to answer questions about how TypeScript is implemented.
+VS Code コードベースで関連するコードスニペットを見つけるには、`microsoft/vscode` で `#githubRepo` ツールを使用します。
+TypeScript がどのように実装されているかについての質問に答えるには、`microsoft/typescript` で `#githubRepo` ツールを使用します。
 ```
 
-![Screenshot showing using the #githubRepo tool in agent mode with hints from instructions files.](https://code.visualstudio.com/assets/updates/1_100/github-repo-tool-example.png)
+![指示ファイルからのヒントを使用してエージェントモードで #githubRepo ツールを使用しているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/github-repo-tool-example.png)
 
-If you want to ask about the repo you are currently working on, you can just use the [`#codebase` tool](https://code.visualstudio.com/docs/copilot/reference/workspace-context#_making-copilot-chat-an-expert-in-your-workspace).
+現在作業中のリポジトリについて質問したい場合は、[`#codebase` ツール](https://code.visualstudio.com/docs/copilot/reference/workspace-context#_making-copilot-chat-an-expert-in-your-workspace) を使用できます。
 
-Also, the `#githubRepo` tool is only for searching for relevant code snippets. The [GitHub MCP server](https://github.com/github/github-mcp-server?tab=readme-ov-file#github-mcp-server) provides tools for working with GitHub issues and pull requests. Learn more about [adding MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server).
+また、`#githubRepo` ツールは関連するコードスニペットの検索専用です。[GitHub MCP サーバー](https://github.com/github/github-mcp-server?tab=readme-ov-file#github-mcp-server) は、GitHub の issue とプルリクエストを操作するためのツールを提供します。[VS Code での MCP サーバーの追加](https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server) の詳細をご覧ください。
 
-### Find Marketplace extensions with the extensions tool {#find-marketplace-extensions-with-the-extensions-tool}
+### 拡張機能ツールを使用した Marketplace 拡張機能の検索 {#find-marketplace-extensions-with-the-extensions-tool}
 
-Use the extensions tool (`#extensions`) in chat to find extensions from the Marketplace. Based on your chat prompt, the tool is automatically invoked, or you can explicitly reference it in your prompt with `#extensions`. The tool returns a list of extensions that match your query. You can install extensions directly from the results.
+チャットで拡張機能ツール (`#extensions`) を使用して、Marketplace から拡張機能を見つけます。チャットプロンプトに基づいて、ツールは自動的に呼び出されるか、プロンプトで `#extensions` を使用して明示的に参照できます。ツールは、クエリに一致する拡張機能のリストを返します。結果から直接拡張機能をインストールできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/extensions-agent-tool.mp4" title="Video that shows using the extensions tool to display popular Java extensions." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/extensions-agent-tool.mp4" title="拡張機能ツールを使用して人気の Java 拡張機能を表示するビデオ。" autoplay loop controls muted></video>
 
-### Improvements to the web page fetch tool {#improvements-to-the-web-page-fetch-tool}
+### Web ページ取得ツールの改善 {#improvements-to-the-web-page-fetch-tool}
 
-Last month, we introduced the fetch tool (`#fetch`) for retrieving the contents of a web page right from chat, and include it as context for your prompt. If you missed that release note, check out [the initial release of the fetch tool](https://code.visualstudio.com/updates/v1_99#fetch-tool) release note and examples.
+先月、チャットから Web ページのコンテンツを取得し、プロンプトのコンテキストとして含めるための取得ツール (`#fetch`) を導入しました。そのリリースノートを見逃した場合は、[取得ツールの初期リリース](https://code.visualstudio.com/updates/v1_99#fetch-tool) のリリースノートと例を確認してください。
 
-This iteration, we have made several big changes to the tool including:
+今回のイテレーションでは、このツールにいくつかの大きな変更を加えました。
 
-* **Entire page as context**: We now add the entire page as context, rather than a subset. With larger context windows, we have the ability to give the model the entire page. For example, it's now possible to ask summarization questions that require as much of the page as possible. If you _do_ manage to fill up the context window, the fetch tool is smart enough to exclude the less relevant sections of the page. That way, you don't exceed the context window limit, while still keeping the important parts.
-* **A standardized page format (Markdown)**: Previously, we formatted fetched webpages in a custom hierarchical format that did the job, but was sometimes hard to reason with because of its custom nature. We now convert fetched webpages into Markdown, a standardized language. This improves the reliability of the *relevancy detection* and is a format that most language models know deeply, so they can reason with it more easily.
+* **コンテキストとしてのページ全体**: サブセットではなく、ページ全体をコンテキストとして追加するようになりました。コンテキストウィンドウが大きくなったことで、モデルにページ全体を提供できるようになりました。たとえば、ページの可能な限り多くの部分を必要とする要約の質問をすることが可能になりました。コンテキストウィンドウを使い果たした場合でも、取得ツールはページの関連性の低いセクションを除外するのに十分賢いです。これにより、重要な部分を維持しながら、コンテキストウィンドウの制限を超えることはありません。
+* **標準化されたページ形式 (Markdown)**: 以前は、取得した Web ページをカスタムの階層形式でフォーマットしていました。これは機能しましたが、カスタムの性質のために理解するのが難しい場合がありました。取得した Web ページを標準化された言語である Markdown に変換するようになりました。これにより、*関連性検出* の信頼性が向上し、ほとんどの言語モデルが深く知っている形式であるため、より簡単に推論できます。
 
-We'd love to hear how you use the fetch tool and if there are any capabilities you'd like to see from it!
+取得ツールの使用方法や、そこから見たい機能があれば、ぜひお聞かせください。
 
-### Chat input improvements {#chat-input-improvements}
+### チャット入力の改善 {#chat-input-improvements}
 
-We have made several improvements to the chat input box:
+チャット入力ボックスにいくつかの改善を加えました:
 
-* **Attachments**: when you reference context in the prompt text with `#`, they now also appear as an attachment pill. This makes it simpler to understand what's being sent to the language model.
-* **Context picker**: we streamlined the context picker to make it simpler to pick files, folders, and other attachment types.
-* **Done button**: we heard your feedback about the "Done"-button and we removed it! No more confusion about unexpected session endings. Now, we only start a new session when you create a new chat (`kb(workbench.action.chat.newChat)`).
+* **添付ファイル**: プロンプトテキストで `#` を使用してコンテキストを参照すると、添付ファイルピルとしても表示されるようになりました。これにより、言語モデルに送信される内容をより簡単に理解できるようになります。
+* **コンテキストピッカー**: コンテキストピッカーを合理化し、ファイル、フォルダー、その他の添付ファイルタイプをより簡単に選択できるようにしました。
+* **完了ボタン**: 「完了」ボタンに関するフィードバックをいただき、削除しました！予期しないセッション終了に関する混乱はもうありません。新しいチャットを作成したときにのみ新しいセッションを開始します (`kb(workbench.action.chat.newChat)`)。
 
-### Chat mode keyboard shortcuts {#chat-mode-keyboard-shortcuts}
+### チャットモードのキーボードショートカット {#chat-mode-keyboard-shortcuts}
 
-The keyboard shortcut `kb(workbench.action.chat.open)` still just opens the Chat view, but the `kb(workbench.action.chat.openAgent)` shortcut now opens the Chat view and switches to [agent mode](vscode://GitHub.Copilot-Chat/chat?mode=agent). If you'd like to set up keyboard shortcuts for other chat modes, there is a command for each mode:
+キーボードショートカット `kb(workbench.action.chat.open)` は引き続きチャットビューを開くだけですが、`kb(workbench.action.chat.openAgent)` ショートカットはチャットビューを開き、[エージェントモード](vscode://GitHub.Copilot-Chat/chat?mode=agent) に切り替えるようになりました。他のチャットモードのキーボードショートカットを設定したい場合は、各モードにコマンドがあります:
 
 * `workbench.action.chat.openAgent`
 * `workbench.action.chat.openEdit`
 * `workbench.action.chat.openAsk`
 
-### Autofix diagnostics from agent mode edits {#autofix-diagnostics-from-agent-mode-edits}
+### エージェントモード編集からの診断の自動修正 {#autofix-diagnostics-from-agent-mode-edits}
 
-**Setting**: `setting(github.copilot.chat.agent.autoFix)`
+**設定**: `setting(github.copilot.chat.agent.autoFix)`
 
-If a file edit in agent mode introduces new errors, agent mode can now detect them, and automatically propose a follow-up edit. This means that you don't have to send a follow-up prompt to ask agent mode to fix any errors. You can disable this behavior with `setting(github.copilot.chat.agent.autoFix)`.
+エージェントモードでのファイル編集で新しいエラーが発生した場合、エージェントモードはそれらを検出し、自動的にフォローアップ編集を提案できるようになりました。つまり、エージェントモードにエラーの修正を依頼するためにフォローアッププロンプトを送信する必要はありません。この動作は `setting(github.copilot.chat.agent.autoFix)` で無効にできます。
 
-### Handling of undo and manual edits in agent mode {#handling-of-undo-and-manual-edits-in-agent-mode}
+### エージェントモードでの元に戻す操作と手動編集の処理 {#handling-of-undo-and-manual-edits-in-agent-mode}
 
-Previously, making manual edits during an agent mode session could confuse the model. Now, the agent is prompted about your changes, and should re-read files when necessary before editing files that might have changed.
+以前は、エージェントモードセッション中に手動編集を行うと、モデルが混乱する可能性がありました。現在、エージェントは変更についてプロンプトを表示し、変更された可能性のあるファイルを編集する前に必要に応じてファイルを再読み込みする必要があります。
 
-### Conversation summary and prompt caching {#conversation-summary-and-prompt-caching}
+### 会話の要約とプロンプトのキャッシュ {#conversation-summary-and-prompt-caching}
 
-We've made some changes to how our agent mode prompt is built to optimize for prompt caching. Prompt caching is a way to speed up model responses by maintaining a stable prefix for the prompt. The next request is able to resume from that prefix, and the result is that each request should be a bit faster. This is especially effective in a repetitive series of requests with large context, like you typically have in agent mode.
+プロンプトのキャッシュを最適化するために、エージェントモードのプロンプトの構築方法にいくつかの変更を加えました。プロンプトのキャッシュは、プロンプトの安定したプレフィックスを維持することでモデルの応答を高速化する方法です。次の要求はそのプレフィックスから再開でき、その結果、各要求が少し高速になります。これは、通常エージェントモードで行うような、大きなコンテキストを持つ反復的な一連の要求で特に効果的です。
 
-When your conversation gets long, or your context gets very large, you might see a "Summarized conversation history" message in your agent mode session:
+会話が長くなったり、コンテキストが非常に大きくなったりすると、エージェントモードセッションに「要約された会話履歴」メッセージが表示されることがあります:
 
-![Screenshot showing a summarized conversation message in the Chat view.](https://code.visualstudio.com/assets/updates/1_100/summarized-conversation.png)
+![チャットビューに要約された会話メッセージが表示されているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/summarized-conversation.png)
 
-Instead of keeping the whole conversation as a FIFO, breaking the cache, we compress the conversation so far into a summary of the most important information and the current state of your task. This keeps the prompt prefix stable, and your responses fast.
+会話全体を FIFO として保持し、キャッシュを壊すのではなく、これまでの会話を最も重要な情報とタスクの現在の状態の要約に圧縮します。これにより、プロンプトプレフィックスが安定し、応答が高速になります。
 
-### MCP support for Streamable HTTP {#mcp-support-for-streamable-http}
+### ストリーマブル HTTP の MCP サポート {#mcp-support-for-streamable-http}
 
-This release adds support for the new Streamable HTTP transport for Model Context Protocol servers. Streamable HTTP servers are configured just like existing SSE servers, and our implementation is backwards-compatible with SSE servers:
+このリリースでは、モデルコンテキストプロトコルサーバー用の新しいストリーマブル HTTP トランスポートのサポートが追加されました。ストリーマブル HTTP サーバーは既存の SSE サーバーと同様に構成され、当社の実装は SSE サーバーと下位互換性があります:
 
 ```json
 {
@@ -217,472 +217,472 @@ This release adds support for the new Streamable HTTP transport for Model Contex
 }
 ```
 
-Learn more about [MCP support in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).
+[VS Code での MCP サポート](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) の詳細をご覧ください。
 
-### MCP support for image output {#mcp-support-for-image-output}
+### 画像出力の MCP サポート {#mcp-support-for-image-output}
 
-We now support MCP servers that generate images as part of their tool output.
+ツール出力の一部として画像を生成する MCP サーバーをサポートするようになりました。
 
-Note that not all language models support reading images from tool output. For example, although GPT-4.1 has vision capability, it does not currently support reading images from tools.
+すべての言語モデルがツール出力からの画像の読み取りをサポートしているわけではないことに注意してください。たとえば、GPT-4.1 には視覚機能がありますが、現在ツールからの画像の読み取りはサポートしていません。
 
-### Enhanced input, output, and progress from MCP servers {#enhanced-input-output-and-progress-from-mcp-servers}
+### MCP サーバーからの入力、出力、進行状況の強化 {#enhanced-input-output-and-progress-from-mcp-servers}
 
-We have enhanced the UI that shows MCP server tool input and output, and have also added support for MCP's new progress messages.
+MCP サーバーツールの入力と出力を表示する UI を強化し、MCP の新しい進行状況メッセージのサポートも追加しました。
 
 <video src="https://code.visualstudio.com/assets/updates/1_100/mcp-confirm.mp4" autoplay loop controls muted></video>
-_Theme: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) (preview on [vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong))_
+_テーマ: [Codesong](https://marketplace.visualstudio.com/items?itemName=connor4312.codesong) ([vscode.dev](https://vscode.dev/editor/theme/connor4312.codesong) でプレビュー)_
 
-### MCP config generation uses inputs {#mcp-config-generation-uses-inputs}
+### MCP 設定生成で入力を使用 {#mcp-config-generation-uses-inputs}
 
-To help keep your secrets secure, AI-assisted configurations generated by the **MCP: Add Server** command now generate `inputs` for any secrets, rather than inlining them into the resulting configuration.
+シークレットを安全に保つために、**MCP: サーバーの追加** コマンドによって生成された AI 支援構成では、シークレットを結果の構成にインライン化するのではなく、シークレットの `inputs` を生成するようになりました。
 
-### Inline chat V2 (Preview) {#inline-chat-v2-preview}
+### インラインチャット V2 (プレビュー) {#inline-chat-v2-preview}
 
-**Setting**: `setting(inlineChat.enableV2:true)`
+**設定**: `setting(inlineChat.enableV2:true)`
 
-We have been working on a revamped version of inline chat `kb(inlineChat.start)`. Its theme is still "bringing chat into code", but behind the scenes it uses the same logic as chat edits. This means better use of the available context and a better code-editing strategy. You can enable inline chat v2 via `setting(inlineChat.enableV2:true)`
+インラインチャット `kb(inlineChat.start)` の改良版に取り組んできました。そのテーマは依然として「チャットをコードに取り込む」ですが、内部的にはチャット編集と同じロジックを使用しています。これは、利用可能なコンテキストのより良い使用と、より良いコード編集戦略を意味します。`setting(inlineChat.enableV2:true)` を介してインラインチャット v2 を有効にできます。
 
-Further, there is now a more lightweight UX that can optionally be enabled. With the `setting(inlineChat.hideOnRequest:true)` setting, inline chat hides as soon as a request is made. It then minimizes into the chat-editing overlay, which enables accepting or discarding changes, or restoring the inline chat control.
+さらに、オプションで有効にできる、より軽量な UX が追加されました。`setting(inlineChat.hideOnRequest:true)` 設定を使用すると、要求が行われるとすぐにインラインチャットが非表示になります。その後、チャット編集オーバーレイに最小化され、変更の受け入れまたは破棄、またはインラインチャットコントロールの復元が可能になります。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/inlinechat2.mp4" title="Video that shows inline chat v2 and hide-on-request in action." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/inlinechat2.mp4" title="インラインチャット v2 とリクエスト時に非表示にする機能の動作を示すビデオ。" autoplay loop controls muted></video>
 
-### Select and attach UI elements to chat (Experimental) {#select-and-attach-ui-elements-to-chat-experimental}
+### UI 要素を選択してチャットに添付 (実験的) {#select-and-attach-ui-elements-to-chat-experimental}
 
-**Setting**: `setting(chat.sendElementsToChat.enabled)`
+**設定**: `setting(chat.sendElementsToChat.enabled)`
 
-While you're developing a web application, you might want to ask chat about specific UI elements of a web page. You can now use the built-in Simple Browser to attach UI elements as context to chat.
+Web アプリケーションを開発している間、Web ページの特定の UI 要素についてチャットに質問したい場合があります。組み込みの簡易ブラウザーを使用して、UI 要素をコンテキストとしてチャットに添付できるようになりました。
 
-After opening any locally-hosted site via the built-in Simple Browser (launch it with the **Simple Browser: Show** command), a new toolbar is now shown where you can select **Start** to select any element in the site that you want. This attaches a screenshot of the selected element, and the HTML and CSS of the element.
+組み込みの簡易ブラウザー (**簡易ブラウザー: 表示** コマンドで起動) を介してローカルでホストされているサイトを開くと、新しいツールバーが表示され、そこで **開始** を選択して、サイト内の任意の要素を選択できます。これにより、選択した要素のスクリーンショットと、要素の HTML および CSS が添付されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/ui-element-selection-demo.mp4" title="Video showing the full flow of the UI element selection experimental feature. In the demo, we attach a hero from a webpage and ask chat to add a background image to that hero." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/ui-element-selection-demo.mp4" title="UI 要素選択実験機能の全フローを示すビデオ。デモでは、Web ページからヒーローを添付し、チャットにそのヒーローに背景画像を追加するように依頼します。" autoplay loop controls muted></video>
 
-Configure what is attached to chat with:
+チャットに添付するものを次のように構成します:
 
-* `setting(chat.sendElementsToChat.attachCSS)`: enable or disable attaching the associated CSS
-* `setting(chat.sendElementsToChat.attachImages)`: enable or disable attaching the screenshot of the selected element
+* `setting(chat.sendElementsToChat.attachCSS)`: 関連する CSS の添付を有効または無効にします
+* `setting(chat.sendElementsToChat.attachImages)`: 選択した要素のスクリーンショットの添付を有効または無効にします
 
-This experimental feature is enabled by default for all Simple Browsers, but can be disabled with `setting(chat.sendElementsToChat.enabled)`.
+この実験的な機能は、すべての簡易ブラウザーでデフォルトで有効になっていますが、`setting(chat.sendElementsToChat.enabled)` で無効にできます。
 
-### Create and launch tasks in agent mode (Experimental) {#create-and-launch-tasks-in-agent-mode-experimental}
+### エージェントモードでのタスクの作成と起動 (実験的) {#create-and-launch-tasks-in-agent-mode-experimental}
 
-**Setting**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
+**設定**: `setting(github.copilot.chat.newWorkspaceCreation.enabled)`
 
-In the previous release, we introduced the `setting(github.copilot.chat.newWorkspaceCreation.enabled)` (Experimental) setting to enable workspace creation with agent mode.
+前回のリリースでは、エージェントモードでのワークスペース作成を有効にする `setting(github.copilot.chat.newWorkspaceCreation.enabled)` (実験的) 設定を導入しました。
 
-Now, at the end of this creation flow, you are prompted to create and run a task for launching your app or project. This streamlines the project launch process and enables easy task reuse.
+現在、この作成フローの最後に、アプリまたはプロジェクトを起動するためのタスクを作成して実行するように求められます。これにより、プロジェクトの起動プロセスが合理化され、タスクの再利用が容易になります。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Merge editor improvements {#merge-editor-improvements}
+### マージエディターの改善 {#merge-editor-improvements}
 
-The merge editor is now more accessible. To learn about available actions, open the accessibility help dialog within the merge editor (`kb(editor.action.accessibilityHelp)`). Key actions include `Merge Editor: Complete Merge` (`kb(mergeEditor.acceptMerge)`) and `Toggle Between Merge Editor Inputs` (`kb(mergeEditor.toggleBetweenInputs)`). The currently focused input is also now announced to assistive technologies.
+マージエディターがよりアクセシブルになりました。利用可能なアクションについては、マージエディター内でアクセシビリティヘルプダイアログ (`kb(editor.action.accessibilityHelp)`) を開いてください。主なアクションには、`マージエディター: マージの完了` (`kb(mergeEditor.acceptMerge)`) と `マージエディター入力間の切り替え` (`kb(mergeEditor.toggleBetweenInputs)`) があります。現在フォーカスされている入力も、支援技術に通知されるようになりました。
 
-### Next edit suggestion enhancements {#next-edit-suggestion-enhancements}
+### 次の編集候補の機能強化 {#next-edit-suggestion-enhancements}
 
-The new setting `setting(accessibility.signals.nextEditSuggestion)` notifies you when a predicted suggestion is available. Review and accept suggestions through the accessible view (`kb(editor.action.accessibleView)`). Additionally, `setting(accessibility.signals.diffLineAdded)` and `setting(accessibility.signals.diffLineRemoved)` provide audio cues during navigation to make diff review accessible.
+新しい設定 `setting(accessibility.signals.nextEditSuggestion)` は、予測された候補が利用可能になったときに通知します。アクセシブルビュー (`kb(editor.action.accessibleView)`) を介して候補を確認し、受け入れます。さらに、`setting(accessibility.signals.diffLineAdded)` と `setting(accessibility.signals.diffLineRemoved)` は、ナビゲーション中に音声キューを提供し、差分レビューをアクセシブルにします。
 
-### Review Copilot user requests from the accessible view {#review-copilot-user-requests-from-the-accessible-view}
+### アクセシブルビューから Copilot ユーザーリクエストを確認 {#review-copilot-user-requests-from-the-accessible-view}
 
-When in [agent mode](vscode://GitHub.Copilot-Chat/chat?mode=agent), tool invocations or terminal commands sometimes require user permission to run. Review these actions within the accessible view (`kb(editor.action.accessibleView)`).
+[エージェントモード](vscode://GitHub.Copilot-Chat/chat?mode=agent) では、ツールの呼び出しやターミナルコマンドの実行にユーザーの許可が必要になる場合があります。これらのアクションをアクセシブルビュー (`kb(editor.action.accessibleView)`) 内で確認します。
 
-### Unique accessibility sounds {#unique-accessibility-sounds}
+### ユニークなアクセシビリティサウンド {#unique-accessibility-sounds}
 
-`setting(accessibility.signals.save.sound)` now has its own distinct sound and no longer shares audio with `setting(accessibility.signals.terminalCommandSucceeded.sound)`.
+`setting(accessibility.signals.save.sound)` は独自の明確なサウンドを持つようになり、`setting(accessibility.signals.terminalCommandSucceeded.sound)` とオーディオを共有しなくなりました。
 
-## Editor Experience {#editor-experience}
+## エディターエクスペリエンス {#editor-experience}
 
-### Floating window modes {#floating-window-modes}
+### フローティングウィンドウモード {#floating-window-modes}
 
-Floating windows in VS Code allow you to move editors and certain views out of the main window into a smaller window for lightweight multi-window setups. There are two new modes a floating window can have:
+VS Code のフローティングウィンドウを使用すると、エディターと特定のビューをメインウィンドウから小さなウィンドウに移動して、軽量なマルチウィンドウ設定を行うことができます。フローティングウィンドウには、次の 2 つの新しいモードがあります:
 
-* Compact: we hide certain UI elements to make more room for the actual content
-* Always-on-top: the window stays on top of all other windows until you leave this mode
+* コンパクト: 特定の UI 要素を非表示にして、実際のコンテンツ用のスペースを増やします
+* 常に手前に表示: このモードを終了するまで、ウィンドウは他のすべてのウィンドウの上に表示されたままになります
 
-Here is an example of how to turn a floating editor window into compact mode:
+フローティングエディターウィンドウをコンパクトモードにする方法の例を次に示します:
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/floating-compact.mp4" title="Video that shows floating window compact mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/floating-compact.mp4" title="フローティングウィンドウのコンパクトモードを示すビデオ。" autoplay loop controls muted></video>
 
-We use compact mode by default for when you create a chat in a new window. Combined with the option to have the window always on top, you can always keep the Chat view around for asking questions!
+新しいウィンドウでチャットを作成する場合、デフォルトでコンパクトモードを使用します。ウィンドウを常に手前に表示するオプションと組み合わせることで、質問をするために常にチャットビューを表示しておくことができます！
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/floating-pinned.mp4" title="Video that shows floating window always on top." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/floating-pinned.mp4" title="フローティングウィンドウを常に手前に表示するビデオ。" autoplay loop controls muted></video>
 
-We introduced new commands if you prefer to use keyboard shortcuts for these actions:
+これらのアクションにキーボードショートカットを使用したい場合は、新しいコマンドを導入しました:
 
-* `workbench.action.toggleWindowAlwaysOnTop`: to toggle always on top mode
-* `workbench.action.enableWindowAlwaysOnTop`: to set the floating window always on top
-* `workbench.action.disableWindowAlwaysOnTop`: to set the floating window to normal
-* `workbench.action.toggleCompactAuxiliaryWindow`: to toggle compact mode
-* `workbench.action.enableCompactAuxiliaryWindow`: to enable compact mode
-* `workbench.action.disableCompactAuxiliaryWindow`: to disable compact mode
+* `workbench.action.toggleWindowAlwaysOnTop`: 常に手前に表示モードを切り替えます
+* `workbench.action.enableWindowAlwaysOnTop`: フローティングウィンドウを常に手前に表示するように設定します
+* `workbench.action.disableWindowAlwaysOnTop`: フローティングウィンドウを通常に設定します
+* `workbench.action.toggleCompactAuxiliaryWindow`: コンパクトモードを切り替えます
+* `workbench.action.enableCompactAuxiliaryWindow`: コンパクトモードを有効にします
+* `workbench.action.disableCompactAuxiliaryWindow`: コンパクトモードを無効にします
 
-> **Note:** even in compact mode you can create complex editor layouts and open other editors.
+> **注意:** コンパクトモードでも、複雑なエディターレイアウトを作成したり、他のエディターを開いたりできます。
 
-### Secondary Side Bar default visibility {#secondary-side-bar-default-visibility}
+### セカンダリサイドバーのデフォルト表示 {#secondary-side-bar-default-visibility}
 
-**Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
+**設定**: `setting(workbench.secondarySideBar.defaultVisibility)`
 
-By default, the Secondary Side Bar is hidden when you open a new workspace or window. With the new setting `setting(workbench.secondarySideBar.defaultVisibility)`, you can control if the Secondary Side Bar should open automatically in new workspaces or windows. You can pick from:
+デフォルトでは、新しいワークスペースまたはウィンドウを開くと、セカンダリサイドバーは非表示になります。新しい設定 `setting(workbench.secondarySideBar.defaultVisibility)` を使用すると、新しいワークスペースまたはウィンドウでセカンダリサイドバーを自動的に開くかどうかを制御できます。次の中から選択できます:
 
-* `hidden`: this is the default and keeps the Secondary Side Bar hidden
-* `visibleInWorkspace`: this opens the Secondary Side Bar if you open a folder or multi-root workspace
-* `visible`: this always opens the Secondary Side Bar
+* `hidden`: これがデフォルトで、セカンダリサイドバーは非表示のままです
+* `visibleInWorkspace`: フォルダーまたはマルチルートワークスペースを開くと、セカンダリサイドバーが開きます
+* `visible`: 常にセカンダリサイドバーが開きます
 
-Note that after a workspace or window has been opened, the visibility becomes a workspace state and overrides the setting value. If you close the Secondary Side Bar, it will remain closed in that workspace or window.
+ワークスペースまたはウィンドウが開かれると、表示設定はワークスペースの状態になり、設定値を上書きすることに注意してください。セカンダリサイドバーを閉じると、そのワークスペースまたはウィンドウでは閉じたままになります。
 
-### Mandatory extension signature verification {#mandatory-extension-signature-verification}
+### 必須の拡張機能署名検証 {#mandatory-extension-signature-verification}
 
-Extension signature verification is now required on all platforms: Windows, macOS, and Linux. Previously, this verification was only mandatory on Windows and macOS. With this release, Linux now also enforces extension signature verification, ensuring that all extensions are properly validated before installation.
+拡張機能の署名検証が、Windows、macOS、Linux のすべてのプラットフォームで必須になりました。以前は、この検証は Windows と macOS でのみ必須でした。このリリースでは、Linux でも拡張機能の署名検証が強制されるようになり、インストール前にすべての拡張機能が適切に検証されるようになります。
 
-This change further strengthens security by preventing the installation of potentially malicious extensions. For more information, see the [Extension Signing](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_the-extension-signature-cannot-be-verified-by-vs-code).
+この変更により、潜在的に悪意のある拡張機能のインストールを防ぐことで、セキュリティがさらに強化されます。詳細については、[拡張機能の署名](https://code.visualstudio.com/docs/configure/extensions/extension-marketplace#_the-extension-signature-cannot-be-verified-by-vs-code) を参照してください。
 
-> **Note:** Mandatory extension signature verification remains disabled on Linux ARM32 builds due to [issue #248308](https://github.com/microsoft/vscode/issues/248308). This is expected to be resolved in the next release.
+> **注意:** [issue #248308](https://github.com/microsoft/vscode/issues/248308) のため、Linux ARM32 ビルドでは必須の拡張機能署名検証が無効のままです。これは次のリリースで解決される予定です。
 
-### Learn more links for malicious extensions {#learn-more-links-for-malicious-extensions}
+### 悪意のある拡張機能の詳細情報リンク {#learn-more-links-for-malicious-extensions}
 
-When an extension is identified as malicious, VS Code now provides links to additional information explaining why the extension was flagged. These "Learn More" links connect users to GitHub issues or documentation with details about the security concerns, helping you better understand the potential risks.
+拡張機能が悪意のあるものとして識別されると、VS Code は拡張機能がフラグ付けされた理由を説明する追加情報へのリンクを提供するようになりました。これらの「詳細情報」リンクは、セキュリティ上の懸念に関する詳細情報を含む GitHub の issue またはドキュメントにユーザーを接続し、潜在的なリスクをよりよく理解するのに役立ちます。
 
-### Prevent installation of Copilot Chat pre-release versions in VS Code stable {#prevent-installation-of-copilot-chat-pre-release-versions-in-vs-code-stable}
+### VS Code 安定版への Copilot Chat プレリリースバージョンのインストール防止 {#prevent-installation-of-copilot-chat-pre-release-versions-in-vs-code-stable}
 
-VS Code now prevents the installation of the pre-release version of the Copilot Chat extension in VS Code Stable. This helps avoid situations where you inadvertently install the Copilot Chat pre-release version and get stuck in a broken state. This means that you can only install the Copilot Chat extension pre-release version in the Insiders build of VS Code.
+VS Code は、VS Code 安定版への Copilot Chat 拡張機能のプレリリースバージョンのインストールを防止するようになりました。これにより、誤って Copilot Chat プレリリースバージョンをインストールして壊れた状態に陥る状況を回避できます。つまり、Copilot Chat 拡張機能プレリリースバージョンは、VS Code の Insiders ビルドにのみインストールできます。
 
-### Command to open a view without focus {#command-to-open-a-view-without-focus}
+### フォーカスなしでビューを開くコマンド {#command-to-open-a-view-without-focus}
 
-Views (tree views and webview views) can now be opened without focusing them. This is useful for extensions and keyboard shortcuts that want to open a view but not take focus away from the current editor. The command is `your-view-id.open`, and it takes a property bag argument: `{ preserveFocus: boolean}`.
+ビュー (ツリービューと Webview ビュー) をフォーカスせずに開くことができるようになりました。これは、ビューを開きたいが現在のエディターからフォーカスを奪いたくない拡張機能やキーボードショートカットに役立ちます。コマンドは `your-view-id.open` で、プロパティバッグ引数 `{ preserveFocus: boolean}` を取ります。
 
-### Semantic text search with keyword suggestions (Experimental) {#semantic-text-search-with-keyword-suggestions-experimental}
+### キーワード候補付きセマンティックテキスト検索 (実験的) {#semantic-text-search-with-keyword-suggestions-experimental}
 
-**Setting**: `setting(github.copilot.chat.search.keywordSuggestions:true)`
+**設定**: `setting(github.copilot.chat.search.keywordSuggestions:true)`
 
-Semantic text search now supports AI-powered keyword suggestions. By enabling this feature, you will start seeing relevant references or definitions that might help you find the code you are looking for.
+セマンティックテキスト検索で、AI を活用したキーワード候補がサポートされるようになりました。この機能を有効にすると、探しているコードを見つけるのに役立つ可能性のある関連する参照や定義が表示されるようになります。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/ai-keywords.mp4" title="Video that shows AI-powered keyword suggestions in Visual Studio Code." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/ai-keywords.mp4" title="Visual Studio Code で AI を活用したキーワード候補を示すビデオ。" autoplay loop controls muted></video>
 
-## Code Editing {#code-editing}
+## コード編集 {#code-editing}
 
-### New Next Edit Suggestions (NES) model {#new-next-edit-suggestions-nes-model}
+### 新しい次の編集候補 (NES) モデル {#new-next-edit-suggestions-nes-model}
 
-**Setting**: `setting(github.copilot.nextEditSuggestions.enabled)`
+**設定**: `setting(github.copilot.nextEditSuggestions.enabled)`
 
-We're excited to introduce a new model powering NES, designed to provide faster and more contextually relevant code recommendations. This updated model offers improved performance, delivering suggestions with reduced latency, and offering suggestions that are less intrusive and align more closely with your recent edits. This update is part of our ongoing commitment to refining AI-assisted development tools within Visual Studio Code.
+より高速で文脈に関連性の高いコード推奨を提供するように設計された、NES を強化する新しいモデルをご紹介します。この更新されたモデルはパフォーマンスが向上し、遅延が短縮された候補を提供し、侵入性が低く、最近の編集内容とより密接に連携する候補を提供します。この更新は、Visual Studio Code 内の AI 支援開発ツールを改良するための継続的な取り組みの一環です。
 
-### Import suggestions {#import-suggestions}
+### インポート候補 {#import-suggestions}
 
-**Setting**: `setting(github.copilot.nextEditSuggestions.fixes:true)`
+**設定**: `setting(github.copilot.nextEditSuggestions.fixes:true)`
 
-Next Edit Suggestions (NES) can now automatically suggest adding missing import statements in JavaScript and TypeScript files. Enable this feature by setting `setting(github.copilot.nextEditSuggestions.fixes:true)`. We plan to further enhance this capability by supporting imports from additional languages in future updates.
+次の編集候補 (NES) で、JavaScript および TypeScript ファイルに不足しているインポートステートメントの追加を自動的に提案できるようになりました。`setting(github.copilot.nextEditSuggestions.fixes:true)` を設定して、この機能を有効にします。今後のアップデートで、追加の言語からのインポートをサポートすることで、この機能をさらに強化する予定です。
 
-![Screenshot showing NES suggesting an import statement.](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
+![NES がインポートステートメントを提案しているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
 
-### Generate alt text in HTML or Markdown {#generate-alt-text-in-html-or-markdown}
+### HTML または Markdown で代替テキストを生成 {#generate-alt-text-in-html-or-markdown}
 
-You can now generate or update existing alt text in HTML and Markdown files. Navigate to any line containing an embedded image and trigger the quick fix via `kb(editor.action.quickFix)` or by selecting the lightbulb icon.
+HTML および Markdown ファイルで既存の代替テキストを生成または更新できるようになりました。埋め込み画像を含む任意の行に移動し、`kb(editor.action.quickFix)` を介して、または電球アイコンを選択してクイックフィックスをトリガーします。
 
-![Screenshot that shows generating alt text for an image html element.](https://code.visualstudio.com/assets/updates/1_100/generate-alt-text.png)
+![画像 html 要素の代替テキストを生成しているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/generate-alt-text.png)
 
-### Variable line heights {#variable-line-heights}
+### 可変行の高さ {#variable-line-heights}
 
-It is now possible to define variable line heights on a monaco editor by setting the line height value in the `IModelDecorationOptions` type. If two line heights are set on a line, the maximum of the two is used on the line.
+`IModelDecorationOptions` 型で行の高さを設定することで、monaco エディターで可変行の高さを定義できるようになりました。行に 2 つの行の高さが設定されている場合、その行では 2 つの最大値が使用されます。
 
-Note that for simplicity for now, the line height is set only on the first line of the corresponding decoration range. In the following screen recording, lines 24 and 32 are rendered with a larger line height than the default one.
+今のところ簡単にするために、行の高さは対応する装飾範囲の最初の行にのみ設定されることに注意してください。次のスクリーンレコーディングでは、24 行目と 32 行目はデフォルトよりも大きな行の高さでレンダリングされています。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/variable-line-heights.mp4" title="Video that shows variable line heights in the editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/variable-line-heights.mp4" title="エディターの可変行の高さを示すビデオ。" autoplay loop controls muted></video>
 
-This work is not yet available to extensions, but will roll out after some more testing.
+この作業はまだ拡張機能では利用できませんが、さらにテストを行った後に展開される予定です。
 
-## Notebooks {#notebooks}
+## ノートブック {#notebooks}
 
-### Find and replace history persistence {#find-and-replace-history-persistence}
+### 検索と置換の履歴の永続化 {#find-and-replace-history-persistence}
 
-The Notebook Find control now supports persistent history for both the find and replace input fields. This persists across reloads, and is controlled by the settings `setting(editor.find.history)` and `setting(editor.find.replaceHistory)`.
+ノートブック検索コントロールで、検索入力フィールドと置換入力フィールドの両方で永続的な履歴がサポートされるようになりました。これはリロード後も永続し、設定 `setting(editor.find.history)` と `setting(editor.find.replaceHistory)` によって制御されます。
 
-### Drag and drop cell outputs to chat {#drag-and-drop-cell-outputs-to-chat}
+### セル出力をチャットにドラッグアンドドロップ {#drag-and-drop-cell-outputs-to-chat}
 
-To enhance existing support for cell output usage within chat, outputs are now able to be dragged into the Chat view for a seamless attachment experience. Currently, only image and textual outputs are supported. Outputs with an image mime type are directly draggable, however to avoid clashing with text selection, textual outputs require holding the `kbstyle(alt)` modifier key to enable dragging. We are exploring UX improvements in the coming releases.
+チャット内でのセル出力の使用に関する既存のサポートを強化するために、出力をチャットビューにドラッグしてシームレスな添付エクスペリエンスを実現できるようになりました。現在、画像とテキスト出力のみがサポートされています。画像 MIME タイプを持つ出力は直接ドラッグできますが、テキスト選択との衝突を避けるために、テキスト出力は `kbstyle(alt)` 修飾キーを押したままにしてドラッグを有効にする必要があります。今後のリリースで UX の改善を検討しています。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/output-dnd.mp4" title="Video that shows multiple cell outputs being attached as chat context via drag and drop." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/output-dnd.mp4" title="ドラッグアンドドロップを介して複数のセル出力がチャットコンテキストとして添付される様子を示すビデオ。" autoplay loop controls muted></video>
 
-### Notebook tools for agent mode {#notebook-tools-for-agent-mode}
+### エージェントモード用のノートブックツール {#notebook-tools-for-agent-mode}
 
-#### Run cell {#run-cell}
+#### セルの実行 {#run-cell}
 
-Chat now has an LLM tool to run notebook cells, which allows the agent to perform updates based on cell run results or perform its own data exploration as it builds out a notebook.
+チャットにノートブックセルを実行するための LLM ツールが追加されました。これにより、エージェントはセル実行結果に基づいて更新を実行したり、ノートブックを構築しながら独自のデータ探索を実行したりできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/agent-notebook-run-edit-loop.mp4" title="Video that shows copilot running notebook cells, making updates based on an error, and retrying those cells." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/agent-notebook-run-edit-loop.mp4" title="Copilot がノートブックセルを実行し、エラーに基づいて更新を行い、それらのセルを再試行する様子を示すビデオ。" autoplay loop controls muted></video>
 
-#### Get kernel state {#get-kernel-state}
+#### カーネル状態の取得 {#get-kernel-state}
 
-The agent can find out which cells have been executed in the current kernel session, and read the active variables by using the Kernel State tool.
+エージェントは、現在のカーネルセッションでどのセルが実行されたかを確認し、カーネル状態ツールを使用してアクティブな変数を読み取ることができます。
 
-#### List/Install packages {#listinstall-packages}
+#### パッケージのリスト/インストール {#listinstall-packages}
 
-The Jupyter extension contributes tools for listing and installing packages into the environment that's being used as the notebook's kernel. The operation is delegated to the Python Environments extension if available; otherwise, it attempts to use the pip package manager.
+Jupyter 拡張機能は、ノートブックのカーネルとして使用されている環境にパッケージをリストおよびインストールするためのツールを提供します。操作は、利用可能な場合は Python Environments 拡張機能に委任されます。それ以外の場合は、pip パッケージマネージャーを使用しようとします。
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Quick diff decorations for staged changes {#quick-diff-decorations-for-staged-changes}
+### ステージされた変更のクイック差分装飾 {#quick-diff-decorations-for-staged-changes}
 
-To address a long-time feature request, this milestone we have added quick diff editor decorations for staged changes. Now you can view your staged changes directly from the editor, without needing to open the Source Control view.
+長年の機能リクエストに対応するため、このマイルストーンでは、ステージされた変更のクイック差分エディター装飾を追加しました。これで、ソース管理ビューを開かなくても、エディターから直接ステージされた変更を表示できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/staged-changes-diff-decorations.mp4" title="Video that shows managing staged changed from an editor by using diff decorations." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/staged-changes-diff-decorations.mp4" title="差分装飾を使用してエディターからステージされた変更を管理する様子を示すビデオ。" autoplay loop controls muted></video>
 
-You can customize the color of the staged changes quick diff decorations by using the following theme tokens: `editorGutter.addedSecondaryBackground`, `editorGutter.modifiedSecondaryBackground`, `editorGutter.deletedSecondaryBackground`.
+次のテーマトークンを使用して、ステージされた変更のクイック差分装飾の色をカスタマイズできます: `editorGutter.addedSecondaryBackground`、`editorGutter.modifiedSecondaryBackground`、`editorGutter.deletedSecondaryBackground`。
 
-If you do not want to see quick diff decorations for staged changes, you can hide them by using the **Diff Decorations** submenu that is available in the editor gutter context menu.
+ステージされた変更のクイック差分装飾を表示したくない場合は、エディターガターのコンテキストメニューで使用できる **差分装飾** サブメニューを使用して非表示にできます。
 
-## Debugging {#debugging}
+## デバッグ {#debugging}
 
-### Disassembly view context menu {#disassembly-view-context-menu}
+### 逆アセンブリビューのコンテキストメニュー {#disassembly-view-context-menu}
 
-Thanks to a community contribution, we now have a context menu in the disassembly view.
+コミュニティの貢献のおかげで、逆アセンブリビューにコンテキストメニューが追加されました。
 
-![Screenshot that shows the context menu in the Disassembly view.](https://code.visualstudio.com/assets/updates/1_100/disassembly-context.png)
+![逆アセンブリビューのコンテキストメニューを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/disassembly-context.png)
 
-### JavaScript debugger Network view {#javascript-debugger-network-view}
+### JavaScript デバッガーネットワークビュー {#javascript-debugger-network-view}
 
-Recent versions of Node.js have enhanced its network debugging capabilities. The [experimental network view](https://code.visualstudio.com/updates/v1_93#experimental-network-view) will be enabled by default on recent versions of Node.js that support it well (v22.14.0 and above).
+最近のバージョンの Node.js では、ネットワークデバッグ機能が強化されています。[実験的なネットワークビュー](https://code.visualstudio.com/updates/v1_93#experimental-network-view) は、それを十分にサポートする最近のバージョンの Node.js (v22.14.0 以降) でデフォルトで有効になります。
 
-## Languages {#languages}
+## 言語 {#languages}
 
-### Show browser support for CSS and HTML {#show-browser-support-for-css-and-html}
+### CSS と HTML のブラウザーサポートの表示 {#show-browser-support-for-css-and-html}
 
-When hovering over a CSS property, HTML element, or HTML attribute, you now see a summary of how well that property or element is supported across browsers using [Baseline](https://developer.mozilla.org/docs/Glossary/Baseline/Compatibility).
+CSS プロパティ、HTML 要素、または HTML 属性にカーソルを合わせると、[ベースライン](https://developer.mozilla.org/docs/Glossary/Baseline/Compatibility) を使用して、そのプロパティまたは要素がブラウザー間でどの程度サポートされているかの概要が表示されるようになりました。
 
-![Screenshot that shows baseline browser support in the CSS hover.](https://code.visualstudio.com/assets/updates/1_100/css-baseline.png)
+![CSS ホバーでのベースラインブラウザーサポートを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/css-baseline.png)
 
-### Default syntax highlighting for `.*.env` files {#default-syntax-highlighting-for--env-files}
+### `.*.env` ファイルのデフォルト構文ハイライト {#default-syntax-highlighting-for--env-files}
 
-Files with name format `.*.env` are now syntax highlighted as `.ini` files.
+名前形式 `.*.env` のファイルは、`.ini` ファイルとして構文ハイライトされるようになりました。
 
-### Expandable hovers for JavaScript and TypeScript (Experimental) {#expandable-hovers-for-javascript-and-typescript-experimental}
+### JavaScript と TypeScript の展開可能なホバー (実験的) {#expandable-hovers-for-javascript-and-typescript-experimental}
 
-**Setting**: `setting(typescript.experimental.expandableHover)`
+**設定**: `setting(typescript.experimental.expandableHover)`
 
-We've continued to iterate on the expandable hover feature for JavaScript and TypeScript. This feature lets you use a `+` and `-` in the hover control to show more or less type information.
+JavaScript と TypeScript の展開可能なホバー機能の反復を継続しました。この機能を使用すると、ホバーコントロールの `+` と `-` を使用して、より多くの型情報を表示したり、少なくしたりできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/expandable-hover.mp4" title="Video that shows TypeScript expandable hover." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/expandable-hover.mp4" title="TypeScript の展開可能なホバーを示すビデオ。" autoplay loop controls muted></video>
 
-This feature is still experimental but you can try it today by enabling `setting(typescript.experimental.expandableHover)`. You must be using TypeScript version 5.9 or above, for example by installing the [TypeScript nightly extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next).
+この機能はまだ実験的ですが、`setting(typescript.experimental.expandableHover)` を有効にすることで今すぐ試すことができます。たとえば、[TypeScript nightly 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-next) をインストールするなどして、TypeScript バージョン 5.9 以降を使用している必要があります。
 
-## Remote Development {#remote-development}
+## リモート開発 {#remote-development}
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[リモート開発拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) を使用すると、[開発コンテナー](https://code.visualstudio.com/docs/devcontainers/containers)、SSH または [リモートトンネル](https://code.visualstudio.com/docs/remote/tunnels) を介したリモートマシン、または [Linux 用 Windows サブシステム](https://learn.microsoft.com/windows/wsl) (WSL) をフル機能の開発環境として使用できます。
 
-### Dev container instructions files {#dev-container-instructions-files}
+### 開発コンテナー指示ファイル {#dev-container-instructions-files}
 
-Dev Container features and images now include instructions files describing their tools and configuration. VS Code chat can automatically use this context, improving the relevance and accuracy of its suggestions during development.
+開発コンテナーの機能とイメージに、ツールと構成を記述した指示ファイルが含まれるようになりました。VS Code チャットはこのコンテキストを自動的に使用できるため、開発中の提案の関連性と精度が向上します。
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### Python {#python}
 
-#### Branch coverage support {#branch-coverage-support}
+#### 分岐カバレッジのサポート {#branch-coverage-support}
 
-Branch coverage is now supported in the Testing Explorer for Python! Note that your `coveragepy` version must be >= 7.7 for this feature. You can upgrade coverage by running `pip install coverage==7.7`.
+Python のテストエクスプローラーで分岐カバレッジがサポートされるようになりました！この機能には `coveragepy` バージョンが >= 7.7 である必要があることに注意してください。`pip install coverage==7.7` を実行してカバレッジをアップグレードできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/python-branch-coverage.mp4" title="Video showing branch coverage run using the Test Explorer and branch coverage displayed." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/python-branch-coverage.mp4" title="テストエクスプローラーを使用して実行された分岐カバレッジと表示された分岐カバレッジを示すビデオ。" autoplay loop controls muted></video>
 
-#### Python Environments Quick Create command {#python-environments-quick-create-command}
+#### Python Environments クイック作成コマンド {#python-environments-quick-create-command}
 
-The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension has added support for Quick Create, making the environment creation process more seamless. Quick Create minimizes the input needed from you to create new virtual environments by detecting the latest Python version on your machine to create the virtual environment and install any workspace dependencies with a single click. This will create a `.venv` in your workspace for venv-based environments, and `.conda`  for-conda based environments. You can access Quick Create via the **Python: Create Environment** command in the Command Palette.
+[Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) 拡張機能にクイック作成のサポートが追加され、環境作成プロセスがよりシームレスになりました。クイック作成は、マシン上の最新の Python バージョンを検出して仮想環境を作成し、ワンクリックでワークスペースの依存関係をインストールすることで、新しい仮想環境を作成するために必要な入力を最小限に抑えます。これにより、venv ベースの環境の場合はワークスペースに `.venv` が作成され、conda ベースの環境の場合は `.conda` が作成されます。コマンドパレットの **Python: 環境の作成** コマンドからクイック作成にアクセスできます。
 
-![Screenshot showing Quick Create in the Python: Create Environment quick pick.](https://code.visualstudio.com/assets/updates/1_100/python-envs-quick-create.png)
+![Python: 環境の作成クイックピックでのクイック作成を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/python-envs-quick-create.png)
 
-#### Python Environments chat tools {#python-environments-chat-tools}
+#### Python Environments チャットツール {#python-environments-chat-tools}
 
-The [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) now includes two chat tools: “Get Python Environment Information” and “Install Python Package”. To use these tools, you can either directly reference them in your prompt by adding `#pythonGetEnvironmentInfo` `#pythonInstallPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information based on file or workspace context, and handle package installation with accurate environment resolution.
+[Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) 拡張機能 (プレビュー) に、「Python 環境情報の取得」と「Python パッケージのインストール」の 2 つのチャットツールが含まれるようになりました。これらのツールを使用するには、プロンプトで `#pythonGetEnvironmentInfo` `#pythonInstallPackage` を追加して直接参照するか、エージェントモードが該当する場合にツールを自動的に呼び出します。これらのツールは、ファイルまたはワークスペースのコンテキストに基づいて適切な環境情報をシームレスに検出し、正確な環境解決でパッケージのインストールを処理します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/python-get-env-tool.mp4" title="Video demoing the get environment information tool call implicitly by the model in agent mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/python-get-env-tool.mp4" title="エージェントモードでモデルによって暗黙的に呼び出される環境情報取得ツールのデモビデオ。" autoplay loop controls muted></video>
 
-<video src="https://code.visualstudio.com/assets/updates/1_100/python-install-pkg-tool.mp4" title="Video demoing the get install package tool call for numpy version 2.2." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_100/python-install-pkg-tool.mp4" title="numpy バージョン 2.2 のインストールパッケージ取得ツールの呼び出しのデモビデオ。" autoplay loop controls muted></video>
 
-#### Color picker when using Pylance {#color-picker-when-using-pylance}
+#### Pylance 使用時のカラーピッカー {#color-picker-when-using-pylance}
 
-Pylance can now display an interactive color swatch directly in the editor for recognized color values in Python files, making it easier to visualize and pick colors on the fly. To try it out, you can enable `setting(python.analysis.enableColorPicker:true)`. Supported formats include #RGB (like "#001122") and #RGBA (like "#001122FF").
+Pylance で、Python ファイル内の認識された色の値に対してインタラクティブなカラースウォッチをエディターに直接表示できるようになり、その場で色を視覚化して選択するのが簡単になりました。試すには、`setting(python.analysis.enableColorPicker:true)` を有効にします。サポートされている形式には、#RGB (「#001122」など) と #RGBA (「#001122FF」など) があります。
 
-![Screenshot showing the color swatch displayed in the editor next to #RGB color format.](https://code.visualstudio.com/assets/updates/1_100/pylance-color-picker.png)
+![#RGB カラー形式の横のエディターに表示されるカラースウォッチを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/pylance-color-picker.png)
 
-#### AI Code Actions: Convert Format String (Experimental) {#ai-code-actions-convert-format-string-experimental}
+#### AI コードアクション: 書式指定文字列の変換 (実験的) {#ai-code-actions-convert-format-string-experimental}
 
-When using Pylance, there's a new experimental AI Code Action for converting string concatenations to f-string or format(). To try it out, select the **Convert to f-string with Copilot** or the **Convert to format() call with Copilot** Code Actions through the light bulb when selecting a symbol in the string you wish to convert, or through `kbstyle(Ctrl + .)`/`kbstyle(Cmd + .)`.
+Pylance を使用する場合、文字列連結を f-string または format() に変換するための新しい実験的な AI コードアクションがあります。試すには、変換したい文字列内のシンボルを選択したときに電球を介して、または `kbstyle(Ctrl + .)`/`kbstyle(Cmd + .)` を介して、**Copilot で f-string に変換** または **Copilot で format() 呼び出しに変換** コードアクションを選択します。
 
-![Screenshot showing the convert strings Code Actions, powered by AI.](https://code.visualstudio.com/assets/updates/1_100/pylance-convert-string.png)
+![AI を活用した文字列変換コードアクションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/pylance-convert-string.png)
 
-This experience is enabled via the following setting:
+このエクスペリエンスは、次の設定によって有効になります:
 
 ```json
 "python.analysis.aiCodeActions": {"convertFormatString": true}
 ```
 
-Then once you define a new symbol, for example, a class or a function, you can select the **Generate Symbol with Copilot** Code Action and let AI handle the implementation. If you want, you can then use Pylance's **Move Symbol** Code Actions to move it to a different file.
+次に、クラスや関数などの新しいシンボルを定義すると、**Copilot でシンボルを生成** コードアクションを選択して、AI に実装を処理させることができます。必要に応じて、Pylance の **シンボルの移動** コードアクションを使用して、別のファイルに移動できます。
 
 ### GitHub Pull Requests and Issues {#github-pull-requests-and-issues}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+プルリクエストと issue の作業、作成、管理を可能にする [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能でさらに進捗がありました。新機能は次のとおりです:
 
-* Ask questions in chat about the active pull request, such as "Address all comments in the #activePullRequest".
-* View issues in a webview, just like you can view pull requests.
-* Polish and alignment of the "Pull Requests", "Issues", and "Notifications" views.
-* Prepared for the release of GitHub's Project Padawan by enabling assignment of issues to Copilot, @-mentioning of Copilot, and ensuring it will be displayed properly in the UI.
+* 「#activePullRequest のすべてのコメントに対応する」など、アクティブなプルリクエストに関するチャットでの質問。
+* プルリクエストを表示できるのと同じように、Webview で issue を表示します。
+* 「プルリクエスト」、「Issue」、「通知」ビューの洗練と調整。
+* Copilot への issue の割り当て、Copilot の @メンションを有効にし、UI に適切に表示されるようにすることで、GitHub の Project Padawan のリリースに備えました。
 
-Review the [changelog for the 0.110.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01100) release of the extension to learn about the other highlights.
+拡張機能の [0.110.0 リリースの変更ログ](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01100) を確認して、その他のハイライトについて学んでください。
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能のオーサリング {#extension-authoring}
 
-### Text Encodings {#text-encodings}
+### テキストエンコーディング {#text-encodings}
 
-We finalized the API for working with text encodings in VS Code.
+VS Code でテキストエンコーディングを操作するための API を最終決定しました。
 
-Specifically, this new API allows you to:
+具体的には、この新しい API を使用すると、次のことができます:
 
-* Get the current `encoding` of a `TextDocument`
-* Open a `TextDocument` with a specific `encoding`
-* Encode a `string` to a `Uint8Array` with a specific `encoding`
-* Decode a `Uint8Array` to a `string` using a specific `encoding`
+* `TextDocument` の現在の `encoding` を取得する
+* 特定の `encoding` で `TextDocument` を開く
+* 特定の `encoding` で `string` を `Uint8Array` にエンコードする
+* 特定の `encoding` を使用して `Uint8Array` を `string` にデコードする
 
-### ESM support for extensions {#esm-support-for-extensions}
+### 拡張機能の ESM サポート {#esm-support-for-extensions}
 
-The NodeJS extension host now supports extensions that use JavaScript-modules (ESM). All it needs is the `"type": "module"` entry in your extension's `package.json` file. With that, the JavaScript code can use `import` and `export` statements, including the special module `import('vscode')`. Find a sample here: <https://github.com/jrieken/vscode-esm-sample-extension>.
+NodeJS 拡張機能ホストで、JavaScript モジュール (ESM) を使用する拡張機能がサポートされるようになりました。必要なのは、拡張機能の `package.json` ファイルの `"type": "module"` エントリだけです。これにより、JavaScript コードで `import` および `export` ステートメント (特別なモジュール `import('vscode')` を含む) を使用できます。サンプルはこちらにあります: <https://github.com/jrieken/vscode-esm-sample-extension>。
 
-Note that ESM support isn't for the web worker extension host yet. There are some technical challenges that need to be overcome first. We'll post updates on <https://github.com/microsoft/vscode/issues/130367>. Stay tuned!
+ESM サポートは、まだ Web ワーカー拡張機能ホスト用ではないことに注意してください。最初に克服する必要のある技術的な課題がいくつかあります。<https://github.com/microsoft/vscode/issues/130367> で最新情報を投稿します。ご期待ください！
 
-## Proposed APIs {#proposed-apis}
+## 提案された API {#proposed-apis}
 
-### Tool calling for images {#tool-calling-for-images}
+### 画像のツール呼び出し {#tool-calling-for-images}
 
-Last iteration, we added a [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts) so that extensions can attach images and send vision requests to the language model. This iteration, we've expanded on this API to allow tool call results to include images as well.
+前回のイテレーションでは、拡張機能が画像を添付して視覚要求を言語モデルに送信できるようにするための [提案された API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts) を追加しました。今回のイテレーションでは、この API を拡張して、ツール呼び出しの結果に画像を含めることができるようにしました。
 
-Check out [this API proposal issue](https://github.com/microsoft/vscode/issues/245104) to see a usage example and to stay up to date with the status of this API.
+使用例とこの API のステータスの最新情報を確認するには、[この API 提案の issue](https://github.com/microsoft/vscode/issues/245104) を確認してください。
 
-### MCP servers contributed by extensions {#mcp-servers-contributed-by-extensions}
+### 拡張機能によって提供される MCP サーバー {#mcp-servers-contributed-by-extensions}
 
-Extensions are able to programmatically contribute extensions to the editor by using the new [proposed API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts). This is an alternative to users hardcoding configuration for each server in their settings or `mcp.json`.
+拡張機能は、新しい [提案された API](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.languageModelDataPart.d.ts) を使用して、エディターにプログラムで拡張機能を提供できます。これは、ユーザーが設定または `mcp.json` で各サーバーの構成をハードコーディングする代わりになります。
 
-If this API is interesting to you, check out [its sample](https://github.com/microsoft/vscode-extension-samples/tree/main/mcp-extension-sample/) and [the API proposal issue](https://github.com/microsoft/vscode/issues/243522) to stay up to date with the status of this API.
+この API に興味がある場合は、[そのサンプル](https://github.com/microsoft/vscode-extension-samples/tree/main/mcp-extension-sample/) と [API 提案の issue](https://github.com/microsoft/vscode/issues/243522) を確認して、この API のステータスの最新情報を確認してください。
 
-### MCP Tool Annotations {#mcp-tool-annotations}
+### MCP ツールアノテーション {#mcp-tool-annotations}
 
-VS Code will now display the human-readable names of MCP servers with tools configured with the appropriate [tool annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations). Additionally, tools marked with `readOnlyHint: true` in their annotations will be allowed to run without requiring user confirmation.
+VS Code は、適切な [ツールアノテーション](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations) で構成されたツールを持つ MCP サーバーの人間が読める名前を表示するようになりました。さらに、アノテーションで `readOnlyHint: true` とマークされたツールは、ユーザーの確認を必要とせずに実行できます。
 
-## Notable fixes {#notable-fixes}
+## 注目すべき修正 {#notable-fixes}
 
-* [244939](https://github.com/microsoft/vscode/issues/244939) - Personal Microsoft accounts logs out very quickly (few mins to few hours)
+* [244939](https://github.com/microsoft/vscode/issues/244939) - 個人の Microsoft アカウントが非常に早く (数分から数時間) ログアウトする
 
-## Thank you {#thank-you}
+## 謝辞 {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆様に心より感謝申し上げます。
 
-### Issue tracking {#issue-tracking}
+### Issue トラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+Issue トラッキングへの貢献:
 
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@ahojukka5 (Jukka Aho)](https://github.com/ahojukka5): Update chatExecuteActions.ts [PR #246494](https://github.com/microsoft/vscode/pull/246494)
-* [@alexweininger (Alex Weininger)](https://github.com/alexweininger): fix: handle cancellation errors inside edit session identity provider [PR #247450](https://github.com/microsoft/vscode/pull/247450)
-* [@andrewbranch (Andrew Branch)](https://github.com/andrewbranch): Allow disabling built-in TS/JS extension in favor of tsgo [PR #246858](https://github.com/microsoft/vscode/pull/246858)
-* [@BABA983 (BABA)](https://github.com/BABA983): A command to accept all combination [PR #225132](https://github.com/microsoft/vscode/pull/225132)
-* [@batsev](https://github.com/batsev): Git - validate branch name before creation [PR #245029](https://github.com/microsoft/vscode/pull/245029)
-* [@brthom (Ben Thomas)](https://github.com/brthom): Fix test items sorting in Testing Explorer to use natural file order [PR #246352](https://github.com/microsoft/vscode/pull/246352)
+* [@ahojukka5 (Jukka Aho)](https://github.com/ahojukka5): chatExecuteActions.ts を更新 [PR #246494](https://github.com/microsoft/vscode/pull/246494)
+* [@alexweininger (Alex Weininger)](https://github.com/alexweininger): 修正: edit session identity provider 内のキャンセルエラーを処理 [PR #247450](https://github.com/microsoft/vscode/pull/247450)
+* [@andrewbranch (Andrew Branch)](https://github.com/andrewbranch): tsgo を優先して組み込み TS/JS 拡張機能を無効にすることを許可 [PR #246858](https://github.com/microsoft/vscode/pull/246858)
+* [@BABA983 (BABA)](https://github.com/BABA983): すべての組み合わせを受け入れるコマンド [PR #225132](https://github.com/microsoft/vscode/pull/225132)
+* [@batsev](https://github.com/batsev): Git - 作成前にブランチ名を検証 [PR #245029](https://github.com/microsoft/vscode/pull/245029)
+* [@brthom (Ben Thomas)](https://github.com/brthom): テストエクスプローラーのテスト項目の並べ替えを修正して自然なファイル順を使用するようにする [PR #246352](https://github.com/microsoft/vscode/pull/246352)
 * [@bytemain (Jiacheng)](https://github.com/bytemain)
-  * fix: correct filtering logic for file-based recommendations [PR #245062](https://github.com/microsoft/vscode/pull/245062)
-  * refactor(nls): use then for JSON parsing [PR #247013](https://github.com/microsoft/vscode/pull/247013)
-* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): git: make Letter/Text/Color semantically consistency [PR #245889](https://github.com/microsoft/vscode/pull/245889)
-* [@eps1lon (Sebastian "Sebbie" Silbermann)](https://github.com/eps1lon): Deemphasize old JSX transform [PR #246738](https://github.com/microsoft/vscode/pull/246738)
-* [@futurist (James Yang)](https://github.com/futurist): fix: runCommand type [PR #246198](https://github.com/microsoft/vscode/pull/246198)
+  * 修正: ファイルベースの推奨事項のフィルタリングロジックを修正 [PR #245062](https://github.com/microsoft/vscode/pull/245062)
+  * リファクタリング (nls): JSON 解析に then を使用 [PR #247013](https://github.com/microsoft/vscode/pull/247013)
+* [@Cecil0o0 (hj)](https://github.com/Cecil0o0): git: Letter/Text/Color を意味的に一貫性のあるものにする [PR #245889](https://github.com/microsoft/vscode/pull/245889)
+* [@eps1lon (Sebastian "Sebbie" Silbermann)](https://github.com/eps1lon): 古い JSX 変換を強調しないようにする [PR #246738](https://github.com/microsoft/vscode/pull/246738)
+* [@futurist (James Yang)](https://github.com/futurist): 修正: runCommand 型 [PR #246198](https://github.com/microsoft/vscode/pull/246198)
 * [@gabritto (Gabriela Araujo Britto)](https://github.com/gabritto)
-  * [typescript-language-features] Re-add expandable hover [PR #246899](https://github.com/microsoft/vscode/pull/246899)
-  * [typescript-language-features] make expandable hover true by default [PR #247343](https://github.com/microsoft/vscode/pull/247343)
-* [@guiserle (guiserle)](https://github.com/guiserle): config: Resolve variables returned by commands [PR #246641](https://github.com/microsoft/vscode/pull/246641)
-* [@huntertran (Tuan Tran Van)](https://github.com/huntertran): Replace single line break with double line break for commit description in git blame hover popup [PR #245779](https://github.com/microsoft/vscode/pull/245779)
-* [@johnscollins98 (John Collins)](https://github.com/johnscollins98): #245665 fix early task exit with empty promptString input [PR #246834](https://github.com/microsoft/vscode/pull/246834)
-* [@KapitanOczywisty](https://github.com/KapitanOczywisty): Fix html derivative grammar consuming php code, fixes #237262 [PR #245076](https://github.com/microsoft/vscode/pull/245076)
-* [@luantranminh (Tran Minh Luan)](https://github.com/luantranminh): argv: update description for `add-mcp` [PR #246473](https://github.com/microsoft/vscode/pull/246473)
+  * [typescript-language-features] 展開可能なホバーを再追加 [PR #246899](https://github.com/microsoft/vscode/pull/246899)
+  * [typescript-language-features] 展開可能なホバーをデフォルトで true にする [PR #247343](https://github.com/microsoft/vscode/pull/247343)
+* [@guiserle (guiserle)](https://github.com/guiserle): config: コマンドによって返される変数を解決 [PR #246641](https://github.com/microsoft/vscode/pull/246641)
+* [@huntertran (Tuan Tran Van)](https://github.com/huntertran): git blame ホバーポップアップのコミット説明の単一行改行を二重行改行に置き換える [PR #245779](https://github.com/microsoft/vscode/pull/245779)
+* [@johnscollins98 (John Collins)](https://github.com/johnscollins98): #245665 空の promptString 入力による早期タスク終了を修正 [PR #246834](https://github.com/microsoft/vscode/pull/246834)
+* [@KapitanOczywisty](https://github.com/KapitanOczywisty): html 派生文法が php コードを消費するのを修正、#237262 を修正 [PR #245076](https://github.com/microsoft/vscode/pull/245076)
+* [@luantranminh (Tran Minh Luan)](https://github.com/luantranminh): argv: `add-mcp` の説明を更新 [PR #246473](https://github.com/microsoft/vscode/pull/246473)
 * [@manabu-nakamura (nakamura)](https://github.com/manabu-nakamura)
-  * tooltip text of close button is internationalized [PR #245190](https://github.com/microsoft/vscode/pull/245190)
-  * tooltip text for close button is internationalized (2) [PR #245333](https://github.com/microsoft/vscode/pull/245333)
-  * normalize ellipsis [PR #246447](https://github.com/microsoft/vscode/pull/246447)
-* [@mdanish-kh (Muhammad Danish)](https://github.com/mdanish-kh): Update WinGet configuration file location & extension [PR #242241](https://github.com/microsoft/vscode/pull/242241)
-* [@mkhuzaima (Muhammad Khuzaima Umair)](https://github.com/mkhuzaima): Set DragData when directory is dragged [PR #243656](https://github.com/microsoft/vscode/pull/243656)
-* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): fix: remove necessary async declaration [PR #247213](https://github.com/microsoft/vscode/pull/247213)
-* [@nknguyenhc (Nguyen)](https://github.com/nknguyenhc): Goto definition for built-in symbols in HTML script [PR #244074](https://github.com/microsoft/vscode/pull/244074)
-* [@noahbowman (Noah)](https://github.com/noahbowman): #188711 - Walkthrough Focus-Visible Outline [PR #247650](https://github.com/microsoft/vscode/pull/247650)
-* [@pedrofrazaopacheco (Pedro Frazão Pacheco)](https://github.com/pedrofrazaopacheco): Fixes microsoft/vscode#240654: Avoid encoding reserved chars in JSON schema URL [PR #244934](https://github.com/microsoft/vscode/pull/244934)
-* [@pisv (Vladimir Piskarev)](https://github.com/pisv): Merge Editor: fix a bug in `LineRange.join(other)` [PR #227585](https://github.com/microsoft/vscode/pull/227585)
+  * 閉じるボタンのツールチップテキストを国際化 [PR #245190](https://github.com/microsoft/vscode/pull/245190)
+  * 閉じるボタンのツールチップテキストを国際化 (2) [PR #245333](https://github.com/microsoft/vscode/pull/245333)
+  * 省略記号を正規化 [PR #246447](https://github.com/microsoft/vscode/pull/246447)
+* [@mdanish-kh (Muhammad Danish)](https://github.com/mdanish-kh): WinGet 構成ファイルの場所と拡張子を更新 [PR #242241](https://github.com/microsoft/vscode/pull/242241)
+* [@mkhuzaima (Muhammad Khuzaima Umair)](https://github.com/mkhuzaima): ディレクトリがドラッグされたときに DragData を設定 [PR #243656](https://github.com/microsoft/vscode/pull/243656)
+* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): 修正: 不要な async 宣言を削除 [PR #247213](https://github.com/microsoft/vscode/pull/247213)
+* [@nknguyenhc (Nguyen)](https://github.com/nknguyenhc): HTML スクリプト内の組み込みシンボルの定義へ移動 [PR #244074](https://github.com/microsoft/vscode/pull/244074)
+* [@noahbowman (Noah)](https://github.com/noahbowman): #188711 - ウォークスルー Focus-Visible アウトライン [PR #247650](https://github.com/microsoft/vscode/pull/247650)
+* [@pedrofrazaopacheco (Pedro Frazão Pacheco)](https://github.com/pedrofrazaopacheco): microsoft/vscode#240654 を修正: JSON スキーマ URL の予約文字のエンコードを回避 [PR #244934](https://github.com/microsoft/vscode/pull/244934)
+* [@pisv (Vladimir Piskarev)](https://github.com/pisv): マージエディター: `LineRange.join(other)` のバグを修正 [PR #227585](https://github.com/microsoft/vscode/pull/227585)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
-  * Fix template.expression brackets #190564 [PR #245786](https://github.com/microsoft/vscode/pull/245786)
-  * YAML auto trigger code completion in strings #239679 [PR #246939](https://github.com/microsoft/vscode/pull/246939)
+  * テンプレート式の括弧 #190564 を修正 [PR #245786](https://github.com/microsoft/vscode/pull/245786)
+  * YAML 文字列内のコード補完の自動トリガー #239679 [PR #246939](https://github.com/microsoft/vscode/pull/246939)
 * [@s-rigaud (Samuel Rigaud)](https://github.com/s-rigaud)
-  * test: fix typos [PR #247259](https://github.com/microsoft/vscode/pull/247259)
-  * fix: vscode-dts typos [PR #247263](https://github.com/microsoft/vscode/pull/247263)
-  * fix: toggleApplicationScope typo [PR #247264](https://github.com/microsoft/vscode/pull/247264)
-* [@sfaut](https://github.com/sfaut): Fix PHP f* files functions signatures [PR #246964](https://github.com/microsoft/vscode/pull/246964)
-* [@thegecko (Rob Moran)](https://github.com/thegecko): Add disassembly view context menu [PR #212500](https://github.com/microsoft/vscode/pull/212500)
-* [@theskcd](https://github.com/theskcd): [vscode] Decorations from #file is much better and does not break on new line [PR #231948](https://github.com/microsoft/vscode/pull/231948)
-* [@tjcork (tjcork)](https://github.com/tjcork): Use parameter expansion to fetch envs for envVarCollections in shellIntegration-bash.sh [PR #245264](https://github.com/microsoft/vscode/pull/245264)
-* [@tmm1 (Aman Karmani)](https://github.com/tmm1): tsb: small build improvements [PR #237450](https://github.com/microsoft/vscode/pull/237450)
-* [@Victuracor (Victuracor)](https://github.com/Victuracor): Fix a typo in extensions/typescript-language-features/package.nls.json [PR #245713](https://github.com/microsoft/vscode/pull/245713)
-* [@whistlegraph (jeffrey)](https://github.com/whistlegraph): fixes issue #662 (enables Pointer Lock Web API) [PR #210875](https://github.com/microsoft/vscode/pull/210875)
-* [@wolfgang42 (Wolfgang Faust)](https://github.com/wolfgang42): feat: markdown-basics snippets: quote all lines [PR #246871](https://github.com/microsoft/vscode/pull/246871)
-* [@zobo (Damjan Cvetko)](https://github.com/zobo): Also replace keys in object within variable substitution [PR #245989](https://github.com/microsoft/vscode/pull/245989)
+  * test: タイプミスを修正 [PR #247259](https://github.com/microsoft/vscode/pull/247259)
+  * fix: vscode-dts のタイプミスを修正 [PR #247263](https://github.com/microsoft/vscode/pull/247263)
+  * fix: toggleApplicationScope のタイプミスを修正 [PR #247264](https://github.com/microsoft/vscode/pull/247264)
+* [@sfaut](https://github.com/sfaut): PHP f* ファイルの関数シグネチャを修正 [PR #246964](https://github.com/microsoft/vscode/pull/246964)
+* [@thegecko (Rob Moran)](https://github.com/thegecko): 逆アセンブリビューのコンテキストメニューを追加 [PR #212500](https://github.com/microsoft/vscode/pull/212500)
+* [@theskcd](https://github.com/theskcd): [vscode] #file からの装飾ははるかに優れており、改行で壊れない [PR #231948](https://github.com/microsoft/vscode/pull/231948)
+* [@tjcork (tjcork)](https://github.com/tjcork): shellIntegration-bash.sh の envVarCollections の環境変数を取得するためにパラメータ展開を使用 [PR #245264](https://github.com/microsoft/vscode/pull/245264)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): tsb: 小さなビルド改善 [PR #237450](https://github.com/microsoft/vscode/pull/237450)
+* [@Victuracor (Victuracor)](https://github.com/Victuracor): extensions/typescript-language-features/package.nls.json のタイプミスを修正 [PR #245713](https://github.com/microsoft/vscode/pull/245713)
+* [@whistlegraph (jeffrey)](https://github.com/whistlegraph): issue #662 を修正 (Pointer Lock Web API を有効にする) [PR #210875](https://github.com/microsoft/vscode/pull/210875)
+* [@wolfgang42 (Wolfgang Faust)](https://github.com/wolfgang42): feat: markdown-basics スニペット: すべての行を引用符で囲む [PR #246871](https://github.com/microsoft/vscode/pull/246871)
+* [@zobo (Damjan Cvetko)](https://github.com/zobo): 変数置換内のオブジェクトのキーも置換 [PR #245989](https://github.com/microsoft/vscode/pull/245989)
 
-Contributions to `vscode-css-languageservice`:
+`vscode-css-languageservice` への貢献:
 
-* [@AlterNT (NTPS)](https://github.com/AlterNT): Support `@scope` [PR #434](https://github.com/microsoft/vscode-css-languageservice/pull/434)
-* [@rviscomi (Rick Viscomi)](https://github.com/rviscomi): Add Baseline status to hovercards [PR #428](https://github.com/microsoft/vscode-css-languageservice/pull/428)
+* [@AlterNT (NTPS)](https://github.com/AlterNT): `@scope` をサポート [PR #434](https://github.com/microsoft/vscode-css-languageservice/pull/434)
+* [@rviscomi (Rick Viscomi)](https://github.com/rviscomi): ホバーカードにベースラインステータスを追加 [PR #428](https://github.com/microsoft/vscode-css-languageservice/pull/428)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@mikaelwaltersson (Mikael Waltersson)](https://github.com/mikaelwaltersson): Fix expansion of "floating" WASM variables in repl/watch + readMemory when WASM memory is SharedArrayBuffer [PR #2199](https://github.com/microsoft/vscode-js-debug/pull/2199)
+* [@mikaelwaltersson (Mikael Waltersson)](https://github.com/mikaelwaltersson): repl/watch での「フローティング」WASM 変数の展開と、WASM メモリが SharedArrayBuffer の場合の readMemory を修正 [PR #2199](https://github.com/microsoft/vscode-js-debug/pull/2199)
 
-Contributions to `vscode-json-languageservice`:
+`vscode-json-languageservice` への貢献:
 
-* [@fengzilong (MO)](https://github.com/fengzilong): feat: make newJSONDocument and JSONDocument consistent [PR #259](https://github.com/microsoft/vscode-json-languageservice/pull/259)
+* [@fengzilong (MO)](https://github.com/fengzilong): feat: newJSONDocument と JSONDocument を一貫性のあるものにする [PR #259](https://github.com/microsoft/vscode-json-languageservice/pull/259)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献:
 
-* [@alexfanqi (Alex Fan)](https://github.com/alexfanqi): change the scope of excludeUserSitePackages to window [PR #16377](https://github.com/microsoft/vscode-jupyter/pull/16377)
-* [@realDuang (Duang)](https://github.com/realDuang): fix: repair python code escaping path in environment service [PR #16518](https://github.com/microsoft/vscode-jupyter/pull/16518)
+* [@alexfanqi (Alex Fan)](https://github.com/alexfanqi): excludeUserSitePackages のスコープを window に変更 [PR #16377](https://github.com/microsoft/vscode-jupyter/pull/16377)
+* [@realDuang (Duang)](https://github.com/realDuang): 修正: 環境サービス内の Python コードエスケープパスを修復 [PR #16518](https://github.com/microsoft/vscode-jupyter/pull/16518)
 
-Contributions to `vscode-mypy`:
+`vscode-mypy` への貢献:
 
-* [@tdscheper (Tommy Scheper)](https://github.com/tdscheper): When cwd config option is ${nearestConfig}, look for all of mypy.ini, .mypy.ini, pyproject.toml, setup.cfg [PR #357](https://github.com/microsoft/vscode-mypy/pull/357)
+* [@tdscheper (Tommy Scheper)](https://github.com/tdscheper): cwd 設定オプションが ${nearestConfig} の場合、mypy.ini、.mypy.ini、pyproject.toml、setup.cfg のすべてを検索 [PR #357](https://github.com/microsoft/vscode-mypy/pull/357)
 
-Contributions to `vscode-notebook-renderers`:
+`vscode-notebook-renderers` への貢献:
 
-* [@marthacryan (Martha Cryan)](https://github.com/marthacryan): Update plotly.js version to 3.0.0 [PR #230](https://github.com/microsoft/vscode-notebook-renderers/pull/230)
+* [@marthacryan (Martha Cryan)](https://github.com/marthacryan): plotly.js のバージョンを 3.0.0 に更新 [PR #230](https://github.com/microsoft/vscode-notebook-renderers/pull/230)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@kabel (Kevin Abel)](https://github.com/kabel): Fix merge email confirmation when git config fails [PR #6797](https://github.com/microsoft/vscode-pull-request-github/pull/6797)
-* [@timrogers (Tim Rogers)](https://github.com/timrogers): When `copilot-swe-agent` is the author of a comment, render with the Copilot identity [PR #6794](https://github.com/microsoft/vscode-pull-request-github/pull/6794)
+* [@kabel (Kevin Abel)](https://github.com/kabel): git config が失敗した場合のマージメール確認を修正 [PR #6797](https://github.com/microsoft/vscode-pull-request-github/pull/6797)
+* [@timrogers (Tim Rogers)](https://github.com/timrogers): `copilot-swe-agent` がコメントの作成者である場合、Copilot ID でレンダリング [PR #6794](https://github.com/microsoft/vscode-pull-request-github/pull/6794)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
-* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Allow autoReload in attach configurations [PR #676](https://github.com/microsoft/vscode-python-debugger/pull/676)
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): アタッチ構成で autoReload を許可 [PR #676](https://github.com/microsoft/vscode-python-debugger/pull/676)
 
-Contributions to `vscode-python-environments`:
+`vscode-python-environments` への貢献:
 
-* [@InSyncWithFoo (InSync)](https://github.com/InSyncWithFoo): fix: clarify that `showSkipOption` also applies to uninstallations [PR #288](https://github.com/microsoft/vscode-python-environments/pull/288)
+* [@InSyncWithFoo (InSync)](https://github.com/InSyncWithFoo): 修正: `showSkipOption` がアンインストールにも適用されることを明確化 [PR #288](https://github.com/microsoft/vscode-python-environments/pull/288)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@hippietrail (Andrew Dunbar)](https://github.com/hippietrail): several grammar fixes [PR #2123](https://github.com/microsoft/language-server-protocol/pull/2123)
-* [@imbant (imbant)](https://github.com/imbant): Ensure document state synchronization before client requests [PR #2017](https://github.com/microsoft/language-server-protocol/pull/2017)
-* [@ocfbnj](https://github.com/ocfbnj): Add thrift-ls for Thrift [PR #2128](https://github.com/microsoft/language-server-protocol/pull/2128)
+* [@hippietrail (Andrew Dunbar)](https://github.com/hippietrail): いくつかの文法修正 [PR #2123](https://github.com/microsoft/language-server-protocol/pull/2123)
+* [@imbant (imbant)](https://github.com/imbant): クライアント要求の前にドキュメント状態の同期を保証 [PR #2017](https://github.com/microsoft/language-server-protocol/pull/2017)
+* [@ocfbnj](https://github.com/ocfbnj): Thrift 用に thrift-ls を追加 [PR #2128](https://github.com/microsoft/language-server-protocol/pull/2128)
 * [@rtorralba (rtorralba)](https://github.com/rtorralba)
-  * Add ZX Basic language server to the implementors list [PR #2121](https://github.com/microsoft/language-server-protocol/pull/2121)
-  * Replace ZX Basic with Boriel Basic language server into the implement… [PR #2125](https://github.com/microsoft/language-server-protocol/pull/2125)
+  * ZX Basic 言語サーバーを実装者リストに追加 [PR #2121](https://github.com/microsoft/language-server-protocol/pull/2121)
+  * ZX Basic を Boriel Basic 言語サーバーに置き換える… [PR #2125](https://github.com/microsoft/language-server-protocol/pull/2125)
 
-Contributions to `monaco-editor`:
+`monaco-editor` への貢献:
 
-* [@RoccoC (Rocco Cataldo)](https://github.com/RoccoC): Update webpack plugin to support module workers [PR #4742](https://github.com/microsoft/monaco-editor/pull/4742)
+* [@RoccoC (Rocco Cataldo)](https://github.com/RoccoC): モジュールワーカーをサポートするように webpack プラグインを更新 [PR #4742](https://github.com/microsoft/monaco-editor/pull/4742)
 
-<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" title="トップへスクロール" aria-label="トップへスクロール" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,16 @@ site_url: https://mtkn1.github.io/vscode-docs-ja/
 repo_url: https://github.com/MtkN1/vscode-docs-ja
 repo_name: MtkN1/vscode-docs-ja
 edit_uri: edit/main/docs/
+nav:
+  - Home: index.md
+  - Release notes:
+    - release-notes/v1_100.md
+    - release-notes/v1_99.md
+    - release-notes/v1_98.md
+    - release-notes/v1_97.md
+    - release-notes/v1_96.md
+    - release-notes/v1_95.md
+    - release-notes/v1_94.md
 theme:
   name: material
   language: ja


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/c31cdb9d81f56dc46d8c4a6818cd34856844e5a6

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_100.md https://github.com/microsoft/vscode-docs/raw/refs/heads/main/release-notes/v1_100.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```