### PR TITLE
Translate May 2025 (version 1.101)

### DIFF
--- a/docs/release-notes/v1_101.md
+++ b/docs/release-notes/v1_101.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_101/release-highlights.png
 Date: 2025-06-12
 DownloadVersion: 1.101.0
 ---
-# May 2025 (version 1.101)
+# May 2025 (version 1.101) {#may-2025-version-1101}
 
 _Release date: June 12, 2025_
 
@@ -33,9 +33,9 @@ Welcome to the May 2025 release of Visual Studio Code. There are many updates in
 >If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 **Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
 
-## Chat
+## Chat {#chat}
 
-### Chat tool sets
+### Chat tool sets {#chat-tool-sets}
 
 VS Code now enables you to define tool sets, either through a proposed API or through the UI. A tool set is a collection of different tools that can be used just like individual tools. Tool sets make it easier to group related tools together, and quickly enable or disable them in agent mode. For instance, the tool set below is for managing GitHub notifications (using the [GitHub MCP server](https://github.com/github/github-mcp-server)).
 
@@ -61,7 +61,7 @@ To use a tool set in a chat query, reference it by #-mentioning its name, like `
 
 Learn more about [tools sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) in our documentation.
 
-### MCP support for prompts
+### MCP support for prompts {#mcp-support-for-prompts}
 
 VS Code's Model Context Protocol support now includes prompt support. Prompts can be defined by MCP servers to generate reusable snippets or tasks for the language model. Prompts are accessible as slash `/` commands in chat, in the format `/mcp.servername.promptname`. You can enter plain text or include command output in prompt variables, and we also support completions when servers provide it.
 
@@ -69,7 +69,7 @@ The following example shows how we generate a prompt using AI, save it using the
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/mcp-prompts.mp4" autoplay loop controls muted></video>
 
-### MCP support for resources
+### MCP support for resources {#mcp-support-for-resources}
 
 VS Code's Model Context Protocol support now includes resource support, which includes support for resource templates. It is available in several places:
 
@@ -81,7 +81,7 @@ Here's an example of attaching resources from the [Gistpad MCP server](https://g
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/mcp-resources.mp4" autoplay loop controls muted></video>
 
-### MCP support for sampling (Experimental)
+### MCP support for sampling (Experimental) {#mcp-support-for-sampling-experimental}
 
 VS Code's Model Context Protocol support now includes sampling, which allows MCP servers to make requests back to the model. You'll be asked to confirm the first time an MCP server makes a sampling request, and you can configure the models the MCP server has access to as well as see a request log by selecting the server in **MCP: List Servers.**
 
@@ -89,7 +89,7 @@ VS Code's Model Context Protocol support now includes sampling, which allows MCP
 
 Sampling support is still preliminary and we plan to expand and improve it in future iterations.
 
-### MCP support for auth
+### MCP support for auth {#mcp-support-for-auth}
 
 VS Code now supports MCP servers that require authentication, allowing you to interact with an MCP server that operates on behalf of your user account for that service.
 
@@ -118,7 +118,7 @@ We have also introduced the command `Authentication: Remove Dynamic Authenticati
 
 Remember, you can use the **MCP: Add Server...** command to add MCP servers. This is the same entry point for servers with authentication.
 
-### MCP development mode
+### MCP development mode {#mcp-development-mode}
 
 You can enable _development mode_ for MCP servers by adding a `dev` key to the server config. This is an object with two properties:
 
@@ -139,7 +139,7 @@ You can enable _development mode_ for MCP servers by adding a `dev` key to the s
 +     },
 ```
 
-### Chat UX improvements
+### Chat UX improvements {#chat-ux-improvements}
 
 We're continuously working to improve the chat user experience in VS Code based on your feedback. One such feedback was that it can be difficult to distinguish between user messages and AI responses in the chat. To address this, we've made the appearance of user messages more distinct.
 
@@ -151,13 +151,13 @@ Finally, attachments from the chat input box are now more navigable.
 
 Learn more about using [chat in VS Code](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) in our documentation.
 
-### Apply edits more efficiently
+### Apply edits more efficiently {#apply-edits-efficiently}
 
 When editing files, VS Code can take two different approaches: it either rewrites the file top to bottom or it makes multiple, smaller edits. Both approaches differ, for example the former can be slower for large files and intermediate states do often not compile successfully. Because of that the UI adopts and conditionally disables auto-save and squiggles, but only when needed.
 
 We have also aligned the keybindings for the **Keep** and **Undo** commands. Keeping and undoing individual changes is now done with `kb(chatEditor.action.acceptHunk)` and `kb(chatEditor.action.undoHunk)`. In the same spirit, we have also aligned the keybinding for keeping and undoing all changes in a file, they are now `kb(chatEditor.action.accept)` and `kb(chatEditor.action.reject)`. This is not just for alignment but also removes prior conflicts with popular editing commands (like **Delete All Left**).
 
-### Implicit context
+### Implicit context {#implicit-context}
 
 We've streamlined and simplified the way that adding your current file as context works in chat. Many people found the "eyeball toggle" that we previously had to be a bit clunky. Now, your current file is offered as a suggested context item. Just select the item to add or remove it from chat context. From prompt input field, press `Shift+Tab, Enter` to quickly do this with the keyboard.
 
@@ -167,11 +167,11 @@ Additionally, in agent mode, we include a hint about your current editor. This d
 
 Learn more about [adding context in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context) in our documentation.
 
-### Fix task configuration errors
+### Fix task configuration errors {#fix-task-configuration-errors}
 
 Configuring tasks and problem matchers can be tricky. Use the **Fix with Github Copilot** action that is offered when there are errors in your task configuration to address them quickly and efficiently.
 
-### Custom chat modes (Preview)
+### Custom chat modes (Preview) {#custom-chat-modes-preview}
 
 By default, the chat view supports three built-in chat modes: Ask, Edit and Agent. Each chat mode comes with a set of base instructions that describe how the LLM should handle a request, as well as the list of tools that can be used for that.
 
@@ -207,15 +207,15 @@ The plan consists of a Markdown document that describes the implementation plan,
 
 > **Note**: The feature is work in progress, but please try it out! Please follow the latest progress in VS Code Insiders and let us know what's not working or is missing.
 
-### Task diagnostic awareness
+### Task diagnostic awareness {#task-diagnostic-awareness}
 
 When the chat agent runs a task, it is now aware of any errors or warnings identified by problem matchers. This diagnostic context allows the chat agent to respond more intelligently to issues as they arise.
 
-### Terminal cwd context
+### Terminal cwd context {#terminal-cwd-context}
 
 When agent mode has opened a terminal and shell integration is active, the chat agent is aware of the current working directory (cwd). This enables more accurate and context-aware command support.
 
-### Floating window improvements
+### Floating window improvements {#floating-window-improvements}
 
 When you move a chat session into a floating window, there are now two new actions available in the title bar:
 
@@ -224,13 +224,13 @@ When you move a chat session into a floating window, there are now two new actio
 
 ![Screenshot of the Chat view in a floating window, highlighting the Dock and New Chat buttons in the title bar.](https://code.visualstudio.com/assets/updates/1_101/chat-floating.png)
 
-### Fetch tool confirmation
+### Fetch tool confirmation {#fetch-tool-confirmation}
 
 The fetch tool enables you to pull information from a web page. We have added a warning message to the confirmation to inform you about potential prompt injection.
 
 ![Screenshot of the fetch tool with a warning about prompt injection.](https://code.visualstudio.com/assets/updates/1_101/fetch-warning.png)
 
-### Customize more built-in tools
+### Customize more built-in tools {#customize-built-in-tools}
 
 It's now possible to enable or disable all built-in tools in agent mode or your custom mode. For example, disable `editFiles` to disallow agent mode to edit files directly, or `runCommands` for running terminal commands.
 
@@ -240,7 +240,7 @@ In agent mode, select the **Configure Tools** button to open the tool picker, an
 
 Some of the entries in this menu represent tool sets that group multiple tools. For example, we give the model multiple tools to edit or create text files and notebooks, which may also differ by model family, and `editFiles` groups all of these.
 
-### Send elements to chat (Experimental)
+### Send elements to chat (Experimental) {#send-elements-to-chat-experimental}
 
 Last milestone, we added a [new experimental feature](https://code.visualstudio.com/updates/v1_100#_select-and-attach-ui-elements-to-chat-experimental) where you could open the Simple Browser and select web elements to add to chat from the embedded browser.
 
@@ -248,34 +248,34 @@ Last milestone, we added a [new experimental feature](https://code.visualstudio.
 
 As we continue to improve this feature, we have added support for selecting web elements in the [Live Preview extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) as well. Check this out by downloading the extension and spinning up a live server from any HTML file.
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### User action required sound
+### User action required sound {#user-action-required-sound}
 
 We’ve added an accessibility signal to indicate when chat requires user action. This is opt-in as we fine tune the sound. You can configure this behavior with `setting(accessibility.signals.chatUserActionRequired)`.
 
-### New code action sounds
+### New code action sounds {#new-code-action-sounds}
 
 We’ve introduced distinct sounds for:
 
 * when a code action is triggered: `setting(accessibility.signals.codeActionTriggered)`
 * when a code action is applied: `setting(accessibility.signals.codeActionApplied)`
 
-### Agent mode accessibility improvements
+### Agent mode accessibility improvements {#agent-mode-accessibility-improvements}
 
 We now include rich information about confirmation dialogs in the accessible view, covering past tool runs, the current tool run, and any pending confirmations. This includes the inputs that will be used.
 
 When a confirmation dialog appears in a response, the action’s title is now included in the ARIA label of the corresponding code block, the response’s ARIA label, and the live alert to provide better context for screen reader users.
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Find as you type
+### Find as you type {#find-as-you-type}
 
 **Setting**: `setting(editor.find.findOnType:true)`
 
 Find-as-you-type has been the default behavior of the Find control, but now you can control whether to keep it that way or disable it so that it will only perform the search after hitting enter.
 
-### Custom menus with native window title bar
+### Custom menus with native window title bar {#custom-menus-native-window-title-bar}
 
 **Setting**: `setting(window.menuStyle)`
 
@@ -285,29 +285,29 @@ You can now specify the menu style that is used for the menu bar and context men
 * `custom`: rendered by VS Code
 * `inherit`: matches the style of the title bar as set by `setting(window.titleBarStyle)` (lets you use a native title bar with a custom menu bar and context menus).
 
-### Linux native window context menu
+### Linux native window context menu {#linux-native-window-context-menu}
 
 We now support the native window context menu when you right-click on the application icon in the custom title bar.
 
 ![Screenshot of the native window context menu over the custom title bar.](https://code.visualstudio.com/assets/updates/1_101/linux-os-title-menu.png)
 
-### Process explorer web support
+### Process explorer web support {#process-explorer-web-support}
 
 The process explorer was converted to use the floating window infrastructure that we have in the workbench for editor windows. As a result, this also means that we now support the process explorer in web when connected to a remote (for example in Codespaces).
 
 ![Screenshot of the VS Code process explorer in a floating window.](https://code.visualstudio.com/assets/updates/1_101/process-explorer.png)
 
-### Windows shell environment discovery
+### Windows shell environment discovery {#windows-shell-environment-discovery}
 
 We have now implemented shell environment discovery for PowerShell on Windows. This means that VS Code inherits any environment configured in the PowerShell profiles, such as the PATH updates that Node.js configures through various version managers.
 
-### Unpublished extension warning
+### Unpublished extension warning {#unpublished-extension-warning}
 
 Installed extensions now show a warning indicator when they're no longer available in the Marketplace, helping you identify potentially problematic extensions that were unpublished or removed.
 
 ![Screenshot of an extension with a warning indicator and a message indicating it's no longer available in the Marketplace.](https://code.visualstudio.com/assets/updates/1_101/pulled-extension.png)
 
-### Settings search suggestions (Preview)
+### Settings search suggestions (Preview) {#settings-search-suggestions-preview}
 
 **Setting**: `setting(workbench.settings.showAISearchToggle:true)`
 
@@ -319,7 +319,7 @@ For the next milestone, we are also considering removing the toggle and changing
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/settings-editor-ai-search.mp4" title="Video showing AI search in the Settings editor that finds the `editor.fontSize` setting when you search 'increase text size'." autoplay loop controls muted></video>
 
-### Search keyword suggestions (Preview)
+### Search keyword suggestions (Preview) {#search-keyword-suggestions-preview}
 
 **Setting**: `setting(search.searchView.keywordSuggestions)`
 
@@ -327,7 +327,7 @@ Last milestone, we introduced [keyword suggestions](https://code.visualstudio.co
 
 We have also moved the setting from the Chat extension into VS Code core, and renamed it from `github.copilot.chat.search.keywordSuggestions` to `setting(search.searchView.keywordSuggestions)`.
 
-### Semantic search behavior options (Preview)
+### Semantic search behavior options (Preview) {#semantic-search-behavior-options-preview}
 
 **Setting**: `setting(search.searchView.semanticSearchBehavior)`
 
@@ -339,7 +339,7 @@ By default, semantic search is only run when you explicitly request it. We have 
 * `runOnEmpty`: run semantic search automatically when the text search returns no results
 * `auto`: always run semantic search in parallel with text search for every search query
 
-### Edit Context
+### Edit Context {#edit-context}
 
 **Setting**: `setting(editor.experimentalEditContextEnabled)`
 
@@ -347,9 +347,9 @@ We have enabled the `setting(editor.experimentalEditContextEnabled)` setting by 
 
 See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/EditContext_API) for more detail on the EditContext API.
 
-## Code Editing
+## Code Editing {#code-editing}
 
-### NES import suggestions
+### NES import suggestions {#nes-import-suggestions}
 
 **Setting**: `setting(github.copilot.nextEditSuggestions.fixes)`
 
@@ -359,13 +359,13 @@ Last month, we introduced support for next edit suggestions to automatically sug
 
 NES is enabled for all VS Code Insiders users, and it will progressively be enabled by default for Stable users during June. You can enable NES yourself via its setting at any time.
 
-### NES acceptance flow
+### NES acceptance flow {#nes-acceptance-flow}
 
 Accepting next edit suggestions is now more seamless with improved keyboard navigation. Once you accept a suggestion, you can continue accepting subsequent suggestions with a single `kbstyle(Tab)` press, as long as you haven't started typing again. Once you start typing, press `kbstyle(Tab)` to first move the cursor to the next suggestion before you can accept it.
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Follow mode for agent cell execution
+### Follow mode for agent cell execution {#follow-mode-agent-cell-execution}
 
 **Setting**: `setting(github.copilot.chat.notebook.followCellExecution.enabled)`
 
@@ -375,9 +375,9 @@ Once the agent has used the run cell tool, the Notebook toolbar is updated with 
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/notebook-follow-mode.mp4" title="Video that shows the AI executing cells in a notebook with follow mode enabled. When the cell is run, the notebook scrolls to reveal it." autoplay loop controls muted></video>
 
-### Notebook tools for agent mode
+### Notebook tools for agent mode {#notebook-tools-agent-mode}
 
-#### Configure notebook
+#### Configure notebook {#configure-notebook}
 
 The [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) contributes tools for configuring the Kernel of a Jupyter Notebook. This tool ensures that a Kernel is selected and is ready for use in the Notebook.
 This involves walking you through the process of creating a Virtual Environment if required (the recommended approach), or prompting you to select an existing Python environment.
@@ -386,19 +386,19 @@ This tool ensures the LLM can perform operations on the Notebook such as running
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/notebook-tools.mp4" title="Video that shows the AI configuring the Python environment, installing dependencies and finally running notebook cells." autoplay loop controls muted></video>
 
-#### Long running agent workflows
+#### Long running agent workflows {#long-running-agent-workflows}
 
 The agent has access to an internal Notebook Summary tool to help keep it on track with an accurate context. That summary is also included when summarizing the conversation history when the context gets too large to keep the agent going through complex operations.
 
-#### Cell preview in run confirmation
+#### Cell preview in run confirmation {#cell-preview-run-confirmation}
 
 A snippet of the code is shown from a notebook cell when the agent requests confirmation to run that cell. The cell links in the Chat view now also enable you to directly navigate to cells in the notebook.
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/run-cell-confirmation.mp4" title="Video showing the AI asking to run a cell including a link to the cell and a preview of its content." autoplay loop controls muted></video>
 
-## Source Control
+## Source Control {#source-control}
 
-### Copilot coding agent integration
+### Copilot coding agent integration {#copilot-coding-agent-integration}
 
 With Copilot coding agent, GitHub Copilot can work independently in the background to complete tasks, just like a human developer. We have expanded the GitHub Pull Requests extension to make it easier to assign and track tasks for the agent from within VS Code.
 
@@ -410,7 +410,7 @@ We have added the following features to the extension:
 
 ![Screenshot showing the GitHub Pull Requests view, highlighting the assign to Copilot action, and the PR query for work assigned to Copilot.](https://code.visualstudio.com/assets/updates/1_101/github-pull-request-coding-agent.png)
 
-### Source control history item details
+### Source control history item details {#source-control-history-item-details}
 
 Upon popular demand, selecting an item in the Source Control Graph view now reveals the resources of that history item. You can choose between a tree view or list view representation from the `...` menu.
 
@@ -418,7 +418,7 @@ Upon popular demand, selecting an item in the Source Control Graph view now reve
 
 To open all resources of a history item in the multi-file diff editor, use the **Open Changes** action on hover. Selecting a particular resource from the Graph view opens a diff editor only for that resource. Select the **Open File** action to open the file for that particular version.
 
-### Add history item to chat context
+### Add history item to chat context {#add-history-item-chat-context}
 
 You can now add a source control history item as context to a chat request. This can be useful when you want to provide the contents of a specific commit or pull request as context for your chat prompt.
 
@@ -426,9 +426,9 @@ You can now add a source control history item as context to a chat request. This
 
 To add a history item to chat, use **Add Context** > **Source Control** from the Chat view and then choose a particular history item. Alternatively, right-click the history item in the source control graph and then select **Copilot** > **Add History Item to Chat** from the context menu.
 
-## Tasks
+## Tasks {#tasks}
 
-### Instance policy
+### Instance policy {#instance-policy}
 
 Task `runOptions` now has an `instancePolicy` property, which determines what happens when a task has reached its `instanceLimit`.
 
@@ -436,9 +436,9 @@ Options include `prompt` (default), `silent`, `terminateNewest`, `terminateOldes
 
 ![Screenshot showing an `instancePolicy` being configured in a `tasks.json` file and displays the options with prompt as the default value.](https://code.visualstudio.com/assets/updates/1_101/instancePolicy.png)
 
-## Terminal
+## Terminal {#terminal}
 
-### Language server based terminal suggest
+### Language server based terminal suggest {#language-server-terminal-suggest}
 
 Language server completions are now available in the terminal for interactive Python REPL sessions.
 This brings the same language completions you receive in the editor now inside the terminal.
@@ -453,7 +453,7 @@ To try it out, ensure the following settings are enabled:
 * `setting(terminal.integrated.suggest.enabled:true)`
 * `setting(python.analysis.supportAllPythonDocuments:true)`
 
-## Remote Development
+## Remote Development {#remote-development}
 
 The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
 
@@ -465,11 +465,11 @@ Highlights include:
 You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_101.md).
 
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### Python
+### Python {#python}
 
-#### Python chat tools
+#### Python chat tools {#python-chat-tools}
 
 The [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) now includes the following chat tools: “Get information for a Python Environment”, “Get executable information for a Python Environment”, “Install Python Package” and “Configure Python Environment”. You can either directly reference them in your prompt by adding `#getPythonEnvironmentInfo` `#installPythonPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information, based on file or workspace context, and handle package installation with accurate environment resolution.
 
@@ -479,7 +479,7 @@ Tools that were previously introduced in the [Python Environments](https://marke
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/python-tools.mp4" title="Video demoing the Python tools called implicitly by the model in agent mode." autoplay loop controls muted></video>
 
-#### Create a project from a template
+#### Create a project from a template {#create-project-from-template}
 
 The [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) now supports project creation for Python packages and basic scripts, allowing you to bypass scaffolding and get coding more quickly. Use the command **Python Envs: Create Project from Template** to select whether you want to create a package or a script.
 
@@ -487,23 +487,23 @@ For package creation, you are able to name the package, create a virtual environ
 
 For scripts, it creates a new python file with the name of your choice and include boilerplate code.
 
-#### PyEnv and Poetry support
+#### PyEnv and Poetry support {#pyenv-poetry-support}
 
 We added support for `pyenv` for environment management, and `poetry` for both package and environment management in the [Python Environements](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension.
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### MCP extension APIs
+### MCP extension APIs {#mcp-extension-apis}
 
 Extensions can now publish collections of MCP servers. This enables you to bundle MCP servers with your extension or build extensions that dynamically discover MCP servers from other sources. Learn more in our [MCP extension development guide](https://code.visualstudio.com/api/extension-guides/mcp) or by checking out the [MCP extension sample](https://github.com/microsoft/vscode-extension-samples/blob/main/mcp-extension-sample).
 
-### Secret scanning when packaging extensions
+### Secret scanning when packaging extensions {#secret-scanning-packaging-extensions}
 
 VSCE now scans for secrets when packaging your extension. If any potential secrets (for example, API keys, tokens, credentials, or environment variable files like `.env`) are detected in your source files, VSCE displays an error during the packaging process. This helps you avoid accidentally publishing sensitive information to the Marketplace. Make sure to review and address any error before publishing your extension.
 
 If you need to bypass specific checks, you can use the `--allow-package-secrets <secret_type>` or `--allow-package-env-file` flags when running VSCE. These flags let you configure which secret or environment file checks should be skipped during packaging.
 
-### Web Environment detection
+### Web Environment detection {#web-environment-detection}
 
 ⚠️ Breaking change ⚠️
 
@@ -522,9 +522,9 @@ In the future, this setting might be enabled by default, so we urge extension au
 * Enable `setting(extensions.supportNodeGlobalNavigator)`.
 * Verify extension behavior remains unchanged.
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Authentication Providers: Supported Authorization Servers for MCP
+### Authentication Providers: Supported Authorization Servers for MCP {#authentication-providers-mcp}
 
 Currently only leveraged in [MCP authentication](#mcp-support-for-auth), this API proposal enables your `AuthenticationProvider` to declare the authorization servers that are associated with it.
 
@@ -592,23 +592,23 @@ As mentioned, this functionality is currently used in MCP support, where we rece
 
 The full API proposal can be found [in the vscode repo](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/src/vscode-dts/vscode.proposed.authIssuers.d.ts) and we'd love to hear your feedback in the [GitHub issue](https://github.com/microsoft/vscode/issues/248775)!
 
-## Engineering
+## Engineering {#engineering}
 
-### Electron 35 update
+### Electron 35 update {#electron-35-update}
 
 In this milestone, we are promoting the Electron 35 update to users on our Stable release. This update comes with Chromium 134.0.6998.205 and Node.js 22.15.1. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
 
-### Adopting ESM in a real-world extension
+### Adopting ESM in a real-world extension {#adopting-esm-real-world-extension}
 
 Last milestone, we have announced support for JavaScript-modules (ESM). This enables extensions to use `import` and `export` statements, but currently only when targeting the NodeJS extension host.
 
 This month, we have done a real-world adoption with [GitHub Issue Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks). It is not trivial because this extension can be run in the NodeJS extension host (which supports ESM extensions) and the web worker extension host, which currently does not support ESM extensions. This required a more complex bundler configuration and you might want to take inspiration from its [esbuild-config](https://github.com/microsoft/vscode-github-issue-notebooks/blob/main/esbuild.mjs).
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -617,7 +617,7 @@ Contributions to our issue tracking:
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull requests
+### Pull requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_101.md
+++ b/docs/release-notes/v1_101.md
@@ -1,43 +1,43 @@
 ---
 Order: 110
-TOCTitle: May 2025
-PageTitle: Visual Studio Code May 2025
-MetaDescription: Learn what is new in the Visual Studio Code May 2025 Release (1.101)
+TOCTitle: 2025 年 5 月
+PageTitle: Visual Studio Code 2025 年 5 月
+MetaDescription: Visual Studio Code 2025 年 5 月リリース (1.101) の新機能について説明します
 MetaSocialImage: 1_101/release-highlights.png
 Date: 2025-06-12
 DownloadVersion: 1.101.0
 ---
-# May 2025 (version 1.101) {#may-2025-version-1101}
+# 2025 年 5 月 (バージョン 1.101) {#may-2025-version-1101}
 
-_Release date: June 12, 2025_
+_リリース日: 2025 年 6 月 12 日_
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the May 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2025 年 5 月リリースへようこそ。このバージョンには多くの更新プログラムが含まれており、気に入っていただけることを願っています。主なハイライトは次のとおりです:
 
 * **MCP**
-  * Expand your agent coding flow with support for prompts, resources, and sampling ([Show more](#mcp-support-for-prompts)).
-  * Access MCP servers that require authentication ([Show more](#mcp-support-for-auth)).
-  * Debug MCP servers with development mode ([Show more](#mcp-development-mode)).
-  * Publish MCP servers from an extension ([Show more](#mcp-extension-apis)).
+  * プロンプト、リソース、サンプリングのサポートにより、エージェントコーディングフローを拡張します ([詳細](#mcp-support-for-prompts))。
+  * 認証が必要な MCP サーバーにアクセスします ([詳細](#mcp-support-for-auth))。
+  * 開発モードで MCP サーバーをデバッグします ([詳細](#mcp-development-mode))。
+  * 拡張機能から MCP サーバーを公開します ([詳細](#mcp-extension-apis))。
 
-* **Chat**
-  * Group and manage related tools by combining them in a tool set ([Show more](#chat-tool-sets)).
+* **チャット**
+  * ツールセットにツールを組み合わせることで、関連ツールをグループ化して管理します ([詳細](#chat-tool-sets))。
 
-* **Source Control**
-  * View files in Source Control Graph view ([Show more](#source-control-history-item-details)).
-  * Assign and track work for GitHub Copilot Coding Agent from within VS Code ([Show more](#copilot-coding-agent-integration)).
+* **ソース管理**
+  * ソース管理グラフビューでファイルを表示します ([詳細](#source-control-history-item-details))。
+  * VS Code 内から GitHub Copilot Coding Agent の作業を割り当てて追跡します ([詳細](#copilot-coding-agent-integration))。
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+>これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
+**Insiders:** 新機能をできるだけ早く試したいですか？ 夜間の [Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、利用可能になり次第、最新の更新プログラムを試すことができます。
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Chat tool sets {#chat-tool-sets}
+### チャットツールセット {#chat-tool-sets}
 
-VS Code now enables you to define tool sets, either through a proposed API or through the UI. A tool set is a collection of different tools that can be used just like individual tools. Tool sets make it easier to group related tools together, and quickly enable or disable them in agent mode. For instance, the tool set below is for managing GitHub notifications (using the [GitHub MCP server](https://github.com/github/github-mcp-server)).
+VS Code では、提案された API または UI を介してツールセットを定義できるようになりました。ツールセットは、個々のツールと同じように使用できるさまざまなツールのコレクションです。ツールセットを使用すると、関連するツールを簡単にグループ化し、エージェントモードですばやく有効または無効にすることができます。たとえば、以下のツールセットは GitHub 通知を管理するためのものです ([GitHub MCP サーバー](https://github.com/github/github-mcp-server) を使用)。
 
 ```json
 {
@@ -47,86 +47,85 @@ VS Code now enables you to define tool sets, either through a proposed API or th
       "dismiss_notification",
       "get_notification_details",
     ],
-    "description": "Manage GH notification",
+    "description": "GH 通知を管理",
     "icon": "github-project"
   }
 }
 ```
 
-To create a tool set, run the **Configure Tool Sets** > **Create new tool sets file** command from the Command Palette. You can then select the tools you want to include in the tool set, and provide a description and icon.
+ツールセットを作成するには、コマンドパレットから **Configure Tool Sets** > **Create new tool sets file** コマンドを実行します。次に、ツールセットに含めるツールを選択し、説明とアイコンを指定できます。
 
-To use a tool set in a chat query, reference it by #-mentioning its name, like `#gh-news`. You can also choose it from the tool picker in the chat input box.
+チャットクエリでツールセットを使用するには、`#gh-news` のように名前を #-メンションして参照します。チャット入力ボックスのツールピッカーから選択することもできます。
 
-![Screenshot of the Chat view showing a query about unread notifications, using the 'gh-news' tool set highlighted in both the chat interface and a JSON configuration file which defines this tool set.](https://code.visualstudio.com/assets/updates/1_101/tool-set-gh.png)
+![チャットビューのスクリーンショット。未読通知に関するクエリが表示されており、チャットインターフェイスとこのツールセットを定義する JSON 設定ファイルの両方で 'gh-news' ツールセットが強調表示されています。](https://code.visualstudio.com/assets/updates/1_101/tool-set-gh.png)
 
-Learn more about [tools sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) in our documentation.
+ドキュメントで [ツールセット](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) の詳細をご覧ください。
 
-### MCP support for prompts {#mcp-support-for-prompts}
+### プロンプトの MCP サポート {#mcp-support-for-prompts}
 
-VS Code's Model Context Protocol support now includes prompt support. Prompts can be defined by MCP servers to generate reusable snippets or tasks for the language model. Prompts are accessible as slash `/` commands in chat, in the format `/mcp.servername.promptname`. You can enter plain text or include command output in prompt variables, and we also support completions when servers provide it.
+VS Code のモデルコンテキストプロトコルサポートにプロンプトサポートが含まれるようになりました。プロンプトは MCP サーバーによって定義でき、言語モデル用の再利用可能なスニペットやタスクを生成できます。プロンプトは、チャットでスラッシュ `/` コマンドとして `/mcp.servername.promptname` の形式でアクセスできます。プレーンテキストを入力したり、プロンプト変数にコマンド出力を含めたりすることができ、サーバーが提供する場合は補完もサポートします。
 
-The following example shows how we generate a prompt using AI, save it using the [Gistpad MCP server](https://github.com/lostintangent/gistpad-mcp), and then use it to generate a changelog entry:
+次の例は、AI を使用してプロンプトを生成し、[Gistpad MCP サーバー](https://github.com/lostintangent/gistpad-mcp) を使用して保存し、それを使用して変更ログエントリを生成する方法を示しています:
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/mcp-prompts.mp4" autoplay loop controls muted></video>
 
-### MCP support for resources {#mcp-support-for-resources}
+### リソースの MCP サポート {#mcp-support-for-resources}
 
-VS Code's Model Context Protocol support now includes resource support, which includes support for resource templates. It is available in several places:
+VS Code のモデルコンテキストプロトコルサポートにリソースサポートが含まれるようになりました。これにはリソーステンプレートのサポートも含まれます。いくつかの場所で利用できます:
 
-1. Resources returned from MCP tool calls are available to the model and can be saved in chat, either via a **Save** button or by dragging the resource onto the Explorer view.
-1. Resources can be attached as context via the **Add Context...** button in chat, then selecting **MCP Resources...**.
-1. You can browse and view resources across servers using the **MCP: Browse Resources** command or for a server by its entry in the **MCP: List Servers** command.
+1. MCP ツール呼び出しから返されたリソースはモデルで利用でき、**保存** ボタンを使用するか、リソースをエクスプローラービューにドラッグすることでチャットに保存できます。
+1. リソースは、チャットの **コンテキストを追加...** ボタンをクリックし、**MCP リソース...** を選択することでコンテキストとして添付できます。
+1. **MCP: リソースの参照** コマンドを使用するか、**MCP: サーバーの一覧表示** コマンドのエントリからサーバーを選択することで、サーバー間でリソースを参照および表示できます。
 
-Here's an example of attaching resources from the [Gistpad MCP server](https://github.com/lostintangent/gistpad-mcp) to chat:
+これは、[Gistpad MCP サーバー](https://github.com/lostintangent/gistpad-mcp) からチャットにリソースを添付する例です:
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/mcp-resources.mp4" autoplay loop controls muted></video>
 
-### MCP support for sampling (Experimental) {#mcp-support-for-sampling-experimental}
+### サンプリングの MCP サポート (実験的) {#mcp-support-for-sampling-experimental}
 
-VS Code's Model Context Protocol support now includes sampling, which allows MCP servers to make requests back to the model. You'll be asked to confirm the first time an MCP server makes a sampling request, and you can configure the models the MCP server has access to as well as see a request log by selecting the server in **MCP: List Servers.**
+VS Code のモデルコンテキストプロトコルサポートにサンプリングが含まれるようになりました。これにより、MCP サーバーはモデルにリクエストを返すことができます。MCP サーバーが初めてサンプリングリクエストを行う際に確認を求められ、**MCP: サーバーの一覧表示** でサーバーを選択することで、MCP サーバーがアクセスできるモデルを設定したり、リクエストログを確認したりできます。
 
 <video src="https://code.visualstudio.com/assets/updates/1_101/mcp-sampling.mp4" autoplay loop controls muted></video>
 
-Sampling support is still preliminary and we plan to expand and improve it in future iterations.
+サンプリングサポートはまだ準備段階であり、今後のイテレーションで拡張および改善する予定です。
 
-### MCP support for auth {#mcp-support-for-auth}
+### 認証の MCP サポート {#mcp-support-for-auth}
 
-VS Code now supports MCP servers that require authentication, allowing you to interact with an MCP server that operates on behalf of your user account for that service.
+VS Code は認証が必要な MCP サーバーをサポートするようになり、そのサービスのユーザーアカウントに代わって動作する MCP サーバーと対話できるようになりました。
 
-This feature implements the MCP authorization specification for clients, and supports both:
+この機能は、クライアント向けの MCP 認証仕様を実装しており、次の両方をサポートしています:
 
-* [2025-3-26 spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization), where the MCP server behaves as an authorization server.
-* [Draft spec](https://modelcontextprotocol.io/specification/draft/basic/authorization), where the MCP server behaves as a resource server (this is expected to be finalized any day now).
+* [2025-3-26 仕様](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization)。MCP サーバーは認証サーバーとして動作します。
+* [ドラフト仕様](https://modelcontextprotocol.io/specification/draft/basic/authorization)。MCP サーバーはリソースサーバーとして動作します (これは間もなく最終決定される予定です)。
 
-If the MCP server implements the draft spec and leverages GitHub or Entra as the auth server, you can manage which MCP servers have access to your account:
+MCP サーバーがドラフト仕様を実装し、GitHub または Entra を認証サーバーとして利用している場合、どのアカウントにどの MCP サーバーがアクセスできるかを管理できます:
 
-![Screenshot of the "Manage Trusted MCP Servers" option in the account menu.](https://code.visualstudio.com/assets/updates/1_101/manage-trusted-mcp.png)
+![アカウントメニューの「信頼できる MCP サーバーの管理」オプションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/manage-trusted-mcp.png)
 
-![Screenshot of the "Manage Trusted MCP Servers" Quick Pick.](https://code.visualstudio.com/assets/updates/1_101/manage-trusted-mcp-quick-pick.png)
+![「信頼できる MCP サーバーの管理」クイックピックのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/manage-trusted-mcp-quick-pick.png)
 
-You can also manage which account that server should use (via the gear button in the previous quick pick):
+また、そのサーバーがどのアカウントを使用するかを管理することもできます (前のクイックピックの歯車ボタン経由):
 
-![Screenshot of the "Account Preference" Quick Pick.](https://code.visualstudio.com/assets/updates/1_101/account-pref-quick-pick.png)
+![「アカウント設定」クイックピックのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/account-pref-quick-pick.png)
 
-For other MCP servers that rely on dynamic client registration, we include the auth state in the same place as everything else, for example with Linear:
+動的クライアント登録に依存する他の MCP サーバーについては、認証状態を他のすべてと同じ場所に含めます。たとえば Linear の場合:
 
-![Screenshot of Linear appearing in the account menu.](https://code.visualstudio.com/assets/updates/1_101/linear-account-menu.png)
+![アカウントメニューに Linear が表示されているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/linear-account-menu.png)
 
-There you can also sign out. For these we support not only the code authorization flow but also the device code flow should your authorization server support it.
+そこからサインアウトすることもできます。これらについては、コード認証フローだけでなく、認証サーバーがサポートしていればデバイスコードフローもサポートします。
 
-We have also introduced the command `Authentication: Remove Dynamic Authentication Providers` that allows you to clean up any of these dynamic client registrations. This will throw away the client id issued to VS Code and all data associated with this authentication provider.
+また、これらの動的クライアント登録をクリーンアップできる `Authentication: Remove Dynamic Authentication Providers` コマンドも導入しました。これにより、VS Code に発行されたクライアント ID と、この認証プロバイダーに関連付けられたすべてのデータが破棄されます。
 
-Remember, you can use the **MCP: Add Server...** command to add MCP servers. This is the same entry point for servers with authentication.
+**MCP: サーバーの追加...** コマンドを使用して MCP サーバーを追加できることを覚えておいてください。これは認証付きサーバーの同じエントリポイントです。
 
-### MCP development mode {#mcp-development-mode}
+### MCP 開発モード {#mcp-development-mode}
 
-You can enable _development mode_ for MCP servers by adding a `dev` key to the server config. This is an object with two properties:
+サーバー設定に `dev` キーを追加することで、MCP サーバーの _開発モード_ を有効にできます。これは 2 つのプロパティを持つオブジェクトです:
 
-* `watch`: A file glob pattern to watch for files change that will restart the MCP server.
-* `debug`: Enables you to set up a debugger with the MCP server. Currently, we only support debugging Node.js and Python servers launched with `node` and `python` respectively.
+* `watch`: MCP サーバーを再起動するファイル変更を監視するファイル glob パターン。
+* `debug`: MCP サーバーでデバッガーを設定できます。現在、`node` と `python` でそれぞれ起動された Node.js と Python サーバーのデバッグのみをサポートしています。
 
 **.vscode/mcp.json**
-
 ```diff
 {
   "servers": {
@@ -139,396 +138,393 @@ You can enable _development mode_ for MCP servers by adding a `dev` key to the s
 +     },
 ```
 
-### Chat UX improvements {#chat-ux-improvements}
+### チャット UX の改善 {#chat-ux-improvements}
 
-We're continuously working to improve the chat user experience in VS Code based on your feedback. One such feedback was that it can be difficult to distinguish between user messages and AI responses in the chat. To address this, we've made the appearance of user messages more distinct.
+私たちは、皆様からのフィードバックに基づいて VS Code のチャットユーザーエクスペリエンスを継続的に改善しています。そのようなフィードバックの 1 つは、チャットでユーザーメッセージと AI 応答を区別するのが難しいということでした。これに対処するために、ユーザーメッセージの外観をより明確にしました。
 
-Undoing previous requests is now also more visible - just hover over a request and select the `X` button to undo that request and any following requests. Or even quicker, use the `kb(workbench.action.chat.undoEdits)` keyboard shortcut!
+以前のリクエストの取り消しもより見やすくなりました。リクエストにカーソルを合わせ、`X` ボタンを選択してそのリクエストとそれに続くリクエストを取り消します。または、さらに速く、`kb(workbench.action.chat.undoEdits)` キーボードショートカットを使用してください！
 
-Finally, attachments from the chat input box are now more navigable.
+最後に、チャット入力ボックスからの添付ファイルがよりナビゲートしやすくなりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/new-chat-ui-ux.mp4" title="A video of the new chat UI/UX where a request is removed to undo edits since that point." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/new-chat-ui-ux.mp4" title="新しいチャット UI/UX の動画。リクエストが削除され、その時点からの編集が元に戻されます。" autoplay loop controls muted></video>
 
-Learn more about using [chat in VS Code](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) in our documentation.
+ドキュメントで [VS Code でのチャットの使用](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) の詳細をご覧ください。
 
-### Apply edits more efficiently {#apply-edits-efficiently}
+### 編集をより効率的に適用する {#apply-edits-efficiently}
 
-When editing files, VS Code can take two different approaches: it either rewrites the file top to bottom or it makes multiple, smaller edits. Both approaches differ, for example the former can be slower for large files and intermediate states do often not compile successfully. Because of that the UI adopts and conditionally disables auto-save and squiggles, but only when needed.
+ファイルを編集する際、VS Code は 2 つの異なるアプローチを取ることができます。ファイルを最初から最後まで書き換えるか、複数の小さな編集を行うかです。どちらのアプローチも異なり、たとえば前者は大きなファイルでは遅くなる可能性があり、中間状態はしばしば正常にコンパイルされません。そのため、UI は適応し、必要に応じて自動保存と波線を条件付きで無効にします。
 
-We have also aligned the keybindings for the **Keep** and **Undo** commands. Keeping and undoing individual changes is now done with `kb(chatEditor.action.acceptHunk)` and `kb(chatEditor.action.undoHunk)`. In the same spirit, we have also aligned the keybinding for keeping and undoing all changes in a file, they are now `kb(chatEditor.action.accept)` and `kb(chatEditor.action.reject)`. This is not just for alignment but also removes prior conflicts with popular editing commands (like **Delete All Left**).
+また、**保持** と **元に戻す** コマンドのキーバインドも調整しました。個々の変更の保持と元に戻す操作は、`kb(chatEditor.action.acceptHunk)` と `kb(chatEditor.action.undoHunk)` で行われるようになりました。同様に、ファイル内のすべての変更を保持および元に戻すためのキーバインドも調整し、現在は `kb(chatEditor.action.accept)` と `kb(chatEditor.action.reject)` になっています。これは調整のためだけでなく、一般的な編集コマンド ( **左側をすべて削除** など) との以前の競合も解消します。
 
-### Implicit context {#implicit-context}
+### 暗黙的なコンテキスト {#implicit-context}
 
-We've streamlined and simplified the way that adding your current file as context works in chat. Many people found the "eyeball toggle" that we previously had to be a bit clunky. Now, your current file is offered as a suggested context item. Just select the item to add or remove it from chat context. From prompt input field, press `Shift+Tab, Enter` to quickly do this with the keyboard.
+チャットで現在のファイルをコンテキストとして追加する方法を合理化し、簡素化しました。以前の「目玉トグル」は少し扱いにくいと感じる人が多くいました。現在、現在のファイルは提案されたコンテキストアイテムとして提供されます。アイテムを選択するだけで、チャットコンテキストに追加したり削除したりできます。プロンプト入力フィールドから、`Shift+Tab, Enter` を押すと、キーボードですばやくこれを行うことができます。
 
-Additionally, in agent mode, we include a hint about your current editor. This doesn't include the contents of the file, just the file name and cursor position. The agent can then use the tools it has to read the contents of the file on its own, if it thinks that it's relevant to your query.
+さらに、エージェントモードでは、現在のエディターに関するヒントが含まれます。これにはファイルの内容は含まれず、ファイル名とカーソル位置のみが含まれます。エージェントは、クエリに関連性があると考えた場合、独自のツールを使用してファイルの内容を読み取ることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/implicit-context-flow.mp4" title="A video of the current open editor being suggest as implicit context and added as an attachment." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/implicit-context-flow.mp4" title="現在開いているエディターが暗黙的なコンテキストとして提案され、添付ファイルとして追加される動画。" autoplay loop controls muted></video>
 
-Learn more about [adding context in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context) in our documentation.
+ドキュメントで [チャットでのコンテキストの追加](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context) の詳細をご覧ください。
 
-### Fix task configuration errors {#fix-task-configuration-errors}
+### タスク設定エラーの修正 {#fix-task-configuration-errors}
 
-Configuring tasks and problem matchers can be tricky. Use the **Fix with Github Copilot** action that is offered when there are errors in your task configuration to address them quickly and efficiently.
+タスクと問題マッチャーの設定は難しい場合があります。タスク設定にエラーがある場合に提供される **Github Copilot で修正** アクションを使用して、迅速かつ効率的に対処してください。
 
-### Custom chat modes (Preview) {#custom-chat-modes-preview}
+### カスタムチャットモード (プレビュー) {#custom-chat-modes-preview}
 
-By default, the chat view supports three built-in chat modes: Ask, Edit and Agent. Each chat mode comes with a set of base instructions that describe how the LLM should handle a request, as well as the list of tools that can be used for that.
+デフォルトでは、チャットビューは 3 つの組み込みチャットモード (Ask、Edit、Agent) をサポートしています。各チャットモードには、LLM がリクエストをどのように処理すべきかを説明する一連の基本命令と、そのために使用できるツールのリストが付属しています。
 
-You can now define your own custom chat modes, which can be used in the Chat view. Custom chat modes allow you to tailor the behavior of chat and specify which tools are available in that mode. This is particularly useful for specialized workflows or when you want to provide specific instructions to the LLM. For example, you can create a custom chat mode for planning new features, which only has read-only access to your codebase.
+チャットビューで使用できる独自のカスタムチャットモードを定義できるようになりました。カスタムチャットモードを使用すると、チャットの動作を調整し、そのモードで使用できるツールを指定できます。これは、特殊なワークフローや LLM に特定の指示を提供したい場合に特に便利です。たとえば、新しい機能を計画するためのカスタムチャットモードを作成できます。このモードでは、コードベースへの読み取り専用アクセスのみが許可されます。
 
-To define and use a custom chat mode, follow these steps:
+カスタムチャットモードを定義して使用するには、次の手順に従います:
 
-1. Define a custom mode by using the **Chat: Configure Chat Modes** command from the Command Palette.
-1. Provide the instructions and available tools for your custom chat mode in the `*.chatprompt.md` file that is created.
-1. In the Chat view, select the chat mode from the chat mode dropdown list.
-1. Submit your chat prompt and
+1. コマンドパレットから **Chat: Configure Chat Modes** コマンドを使用してカスタムモードを定義します。
+1. 作成された `*.chatprompt.md` ファイルで、カスタムチャットモードの指示と利用可能なツールを提供します。
+1. チャットビューで、チャットモードのドロップダウンリストからチャットモードを選択します。
+1. チャットプロンプトを送信し、
 
-![Screenshot of the custom chat mode selected in the Chat view.](https://code.visualstudio.com/assets/updates/1_101/custom-chat-mode-view.png)
+![チャットビューで選択されたカスタムチャットモードのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/custom-chat-mode-view.png)
 
-The following example shows a custom "Planning" chat mode:
+次の例は、カスタムの「計画」チャットモードを示しています:
 
 ```md
 ---
-description: Generate an implementation plan for new features or refactoring existing code.
+description: 新機能の実装計画または既存コードのリファクタリング計画を生成します。
 tools: ['codebase', 'fetch', 'findTestFiles', 'githubRepo', 'search', 'usages']
 ---
-# Planning mode instructions
-You are in planning mode. Your task is to generate an implementation plan for a new feature or for refactoring existing code.
-Don't make any code edits, just generate a plan.
+# 計画モードの指示
+あなたは計画モードです。あなたのタスクは、新機能または既存コードのリファクタリングのための実装計画を生成することです。
+コード編集は行わず、計画のみを生成してください。
 
-The plan consists of a Markdown document that describes the implementation plan, including the following sections:
+計画は、次のセクションを含む実装計画を記述した Markdown ドキュメントで構成されます:
 
-* Overview: A brief description of the feature or refactoring task.
-* Requirements: A list of requirements for the feature or refactoring task.
-* Implementation Steps: A detailed list of steps to implement the feature or refactoring task.
-* Testing: A list of tests that need to be implemented to verify the feature or refactoring task.
+* 概要: 機能またはリファクタリングタスクの簡単な説明。
+* 要件: 機能またはリファクタリングタスクの要件のリスト。
+* 実装手順: 機能またはリファクタリングタスクを実装するための詳細な手順のリスト。
+* テスト: 機能またはリファクタリングタスクを検証するために実装する必要があるテストのリスト。
 ```
 
-> **Note**: The feature is work in progress, but please try it out! Please follow the latest progress in VS Code Insiders and let us know what's not working or is missing.
+> **注**: この機能は開発中ですが、ぜひお試しください！ VS Code Insiders での最新の進捗状況をフォローし、動作しない点や不足している点をお知らせください。
 
-### Task diagnostic awareness {#task-diagnostic-awareness}
+### タスク診断の認識 {#task-diagnostic-awareness}
 
-When the chat agent runs a task, it is now aware of any errors or warnings identified by problem matchers. This diagnostic context allows the chat agent to respond more intelligently to issues as they arise.
+チャットエージェントがタスクを実行すると、問題マッチャーによって特定されたエラーや警告を認識するようになりました。この診断コンテキストにより、チャットエージェントは発生した問題に対してよりインテリジェントに応答できます。
 
-### Terminal cwd context {#terminal-cwd-context}
+### ターミナルの cwd コンテキスト {#terminal-cwd-context}
 
-When agent mode has opened a terminal and shell integration is active, the chat agent is aware of the current working directory (cwd). This enables more accurate and context-aware command support.
+エージェントモードでターミナルが開き、シェル統合がアクティブな場合、チャットエージェントは現在の作業ディレクトリ (cwd) を認識します。これにより、より正確でコンテキストを意識したコマンドサポートが可能になります。
 
-### Floating window improvements {#floating-window-improvements}
+### フローティングウィンドウの改善 {#floating-window-improvements}
 
-When you move a chat session into a floating window, there are now two new actions available in the title bar:
+チャットセッションをフローティングウィンドウに移動すると、タイトルバーに 2 つの新しいアクションが利用可能になります:
 
-* Dock the chat back into the VS Code window where it came from
-* Start a new chat session in the floating window.
+* チャットを元の VS Code ウィンドウにドッキングする
+* フローティングウィンドウで新しいチャットセッションを開始する。
 
-![Screenshot of the Chat view in a floating window, highlighting the Dock and New Chat buttons in the title bar.](https://code.visualstudio.com/assets/updates/1_101/chat-floating.png)
+![フローティングウィンドウ内のチャットビューのスクリーンショット。タイトルバーのドッキングボタンと新しいチャットボタンが強調表示されています。](https://code.visualstudio.com/assets/updates/1_101/chat-floating.png)
 
-### Fetch tool confirmation {#fetch-tool-confirmation}
+### フェッチツールの確認 {#fetch-tool-confirmation}
 
-The fetch tool enables you to pull information from a web page. We have added a warning message to the confirmation to inform you about potential prompt injection.
+フェッチツールを使用すると、Web ページから情報を取得できます。潜在的なプロンプトインジェクションについて通知するために、確認に警告メッセージを追加しました。
 
-![Screenshot of the fetch tool with a warning about prompt injection.](https://code.visualstudio.com/assets/updates/1_101/fetch-warning.png)
+![プロンプトインジェクションに関する警告が表示されたフェッチツールのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/fetch-warning.png)
 
-### Customize more built-in tools {#customize-built-in-tools}
+### より多くの組み込みツールをカスタマイズする {#customize-built-in-tools}
 
-It's now possible to enable or disable all built-in tools in agent mode or your custom mode. For example, disable `editFiles` to disallow agent mode to edit files directly, or `runCommands` for running terminal commands.
+エージェントモードまたはカスタムモードですべての組み込みツールを有効または無効にできるようになりました。たとえば、`editFiles` を無効にしてエージェントモードがファイルを直接編集できないようにしたり、ターミナルコマンドを実行するための `runCommands` を無効にしたりできます。
 
-In agent mode, select the **Configure Tools** button to open the tool picker, and select your desired set of tools.
+エージェントモードで、**ツールの設定** ボタンを選択してツールピッカーを開き、目的のツールセットを選択します。
 
-![Screenshot of the tool picker, showing the "editFiles" tool set item cleared.](https://code.visualstudio.com/assets/updates/1_101/built-in-toolsets.png)
+![ツールピッカーのスクリーンショット。「editFiles」ツールセットアイテムがクリアされている状態を示しています。](https://code.visualstudio.com/assets/updates/1_101/built-in-toolsets.png)
 
-Some of the entries in this menu represent tool sets that group multiple tools. For example, we give the model multiple tools to edit or create text files and notebooks, which may also differ by model family, and `editFiles` groups all of these.
+このメニューの一部のエントリは、複数のツールをグループ化するツールセットを表します。たとえば、モデルにはテキストファイルやノートブックを編集または作成するための複数のツールが提供され、これらはモデルファミリーによって異なる場合があり、`editFiles` はこれらすべてをグループ化します。
 
-### Send elements to chat (Experimental) {#send-elements-to-chat-experimental}
+### 要素をチャットに送信 (実験的) {#send-elements-to-chat-experimental}
 
-Last milestone, we added a [new experimental feature](https://code.visualstudio.com/updates/v1_100#_select-and-attach-ui-elements-to-chat-experimental) where you could open the Simple Browser and select web elements to add to chat from the embedded browser.
+前回のマイルストーンでは、シンプルブラウザーを開き、埋め込みブラウザーからチャットに追加する Web 要素を選択できる [新しい実験的機能](https://code.visualstudio.com/updates/v1_100#_select-and-attach-ui-elements-to-chat-experimental) を追加しました。
 
-![Screenshot showing the Live Preview extension, highlighting the overlay controls to select web elements from the web page.](https://code.visualstudio.com/assets/updates/1_101/live-preview-select-web-elements.png)
+![Live Preview 拡張機能を示すスクリーンショット。Web ページから Web 要素を選択するためのオーバーレイコントロールが強調表示されています。](https://code.visualstudio.com/assets/updates/1_101/live-preview-select-web-elements.png)
 
-As we continue to improve this feature, we have added support for selecting web elements in the [Live Preview extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) as well. Check this out by downloading the extension and spinning up a live server from any HTML file.
+この機能の改善を続ける中で、[Live Preview 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) でも Web 要素を選択できるようになりました。拡張機能をダウンロードし、任意の HTML ファイルからライブサーバーを起動して、これを確認してください。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### User action required sound {#user-action-required-sound}
+### ユーザー操作が必要な場合のサウンド {#user-action-required-sound}
 
-We’ve added an accessibility signal to indicate when chat requires user action. This is opt-in as we fine tune the sound. You can configure this behavior with `setting(accessibility.signals.chatUserActionRequired)`.
+チャットでユーザー操作が必要な場合に通知するアクセシビリティシグナルを追加しました。サウンドを微調整しているため、これはオプトインです。この動作は `setting(accessibility.signals.chatUserActionRequired)` で設定できます。
 
-### New code action sounds {#new-code-action-sounds}
+### 新しいコードアクションサウンド {#new-code-action-sounds}
 
-We’ve introduced distinct sounds for:
+次のための個別のサウンドを導入しました:
 
-* when a code action is triggered: `setting(accessibility.signals.codeActionTriggered)`
-* when a code action is applied: `setting(accessibility.signals.codeActionApplied)`
+* コードアクションがトリガーされたとき: `setting(accessibility.signals.codeActionTriggered)`
+* コードアクションが適用されたとき: `setting(accessibility.signals.codeActionApplied)`
 
-### Agent mode accessibility improvements {#agent-mode-accessibility-improvements}
+### エージェントモードのアクセシビリティ改善 {#agent-mode-accessibility-improvements}
 
-We now include rich information about confirmation dialogs in the accessible view, covering past tool runs, the current tool run, and any pending confirmations. This includes the inputs that will be used.
+アクセス可能なビューに確認ダイアログに関する豊富な情報が含まれるようになり、過去のツール実行、現在のツール実行、および保留中の確認を網羅します。これには、使用される入力も含まれます。
 
-When a confirmation dialog appears in a response, the action’s title is now included in the ARIA label of the corresponding code block, the response’s ARIA label, and the live alert to provide better context for screen reader users.
+応答に確認ダイアログが表示されると、対応するコードブロックの ARIA ラベル、応答の ARIA ラベル、およびライブアラートにアクションのタイトルが含まれるようになり、スクリーンリーダーユーザーにより良いコンテキストを提供します。
 
-## Editor Experience {#editor-experience}
+## エディターエクスペリエンス {#editor-experience}
 
-### Find as you type {#find-as-you-type}
+### 入力時に検索 {#find-as-you-type}
 
-**Setting**: `setting(editor.find.findOnType:true)`
+**設定**: `setting(editor.find.findOnType:true)`
 
-Find-as-you-type has been the default behavior of the Find control, but now you can control whether to keep it that way or disable it so that it will only perform the search after hitting enter.
+入力時検索は検索コントロールのデフォルトの動作でしたが、これを維持するか、Enter キーを押した後にのみ検索を実行するように無効にするかを制御できるようになりました。
 
-### Custom menus with native window title bar {#custom-menus-native-window-title-bar}
+### ネイティブウィンドウタイトルバーでのカスタムメニュー {#custom-menus-native-window-title-bar}
 
-**Setting**: `setting(window.menuStyle)`
+**設定**: `setting(window.menuStyle)`
 
-You can now specify the menu style that is used for the menu bar and context menus on Windows and Linux, and for context menus on macOS by using the `setting(window.menuStyle)` setting:
+Windows と Linux のメニューバーとコンテキストメニュー、および macOS のコンテキストメニューに使用されるメニュースタイルを `setting(window.menuStyle)` 設定を使用して指定できるようになりました:
 
-* `native`: rendered by the OS
-* `custom`: rendered by VS Code
-* `inherit`: matches the style of the title bar as set by `setting(window.titleBarStyle)` (lets you use a native title bar with a custom menu bar and context menus).
+* `native`: OS によってレンダリングされます
+* `custom`: VS Code によってレンダリングされます
+* `inherit`: `setting(window.titleBarStyle)` によって設定されたタイトルバーのスタイルに一致します (ネイティブのタイトルバーとカスタムのメニューバーおよびコンテキストメニューを使用できます)。
 
-### Linux native window context menu {#linux-native-window-context-menu}
+### Linux ネイティブウィンドウコンテキストメニュー {#linux-native-window-context-menu}
 
-We now support the native window context menu when you right-click on the application icon in the custom title bar.
+カスタムタイトルバーのアプリケーションアイコンを右クリックしたときに、ネイティブウィンドウコンテキストメニューをサポートするようになりました。
 
-![Screenshot of the native window context menu over the custom title bar.](https://code.visualstudio.com/assets/updates/1_101/linux-os-title-menu.png)
+![カスタムタイトルバー上のネイティブウィンドウコンテキストメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/linux-os-title-menu.png)
 
-### Process explorer web support {#process-explorer-web-support}
+### プロセスエクスプローラーの Web サポート {#process-explorer-web-support}
 
-The process explorer was converted to use the floating window infrastructure that we have in the workbench for editor windows. As a result, this also means that we now support the process explorer in web when connected to a remote (for example in Codespaces).
+プロセスエクスプローラーは、エディターウィンドウ用にワークベンチにあるフローティングウィンドウインフラストラクチャを使用するように変換されました。その結果、リモートに接続されている場合 (たとえば Codespaces で)、Web でプロセスエクスプローラーをサポートするようになりました。
 
-![Screenshot of the VS Code process explorer in a floating window.](https://code.visualstudio.com/assets/updates/1_101/process-explorer.png)
+![フローティングウィンドウ内の VS Code プロセスエクスプローラーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/process-explorer.png)
 
-### Windows shell environment discovery {#windows-shell-environment-discovery}
+### Windows シェル環境の検出 {#windows-shell-environment-discovery}
 
-We have now implemented shell environment discovery for PowerShell on Windows. This means that VS Code inherits any environment configured in the PowerShell profiles, such as the PATH updates that Node.js configures through various version managers.
+Windows 上の PowerShell のシェル環境検出を実装しました。これにより、VS Code は PowerShell プロファイルで設定された環境 (Node.js がさまざまなバージョンマネージャーを介して設定する PATH 更新など) を継承します。
 
-### Unpublished extension warning {#unpublished-extension-warning}
+### 未公開の拡張機能の警告 {#unpublished-extension-warning}
 
-Installed extensions now show a warning indicator when they're no longer available in the Marketplace, helping you identify potentially problematic extensions that were unpublished or removed.
+インストール済みの拡張機能が Marketplace で利用できなくなった場合、警告インジケーターが表示されるようになり、未公開または削除された可能性のある問題のある拡張機能を特定するのに役立ちます。
 
-![Screenshot of an extension with a warning indicator and a message indicating it's no longer available in the Marketplace.](https://code.visualstudio.com/assets/updates/1_101/pulled-extension.png)
+![警告インジケーターと Marketplace で利用できなくなったことを示すメッセージが表示された拡張機能のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/pulled-extension.png)
 
-### Settings search suggestions (Preview) {#settings-search-suggestions-preview}
+### 設定検索の提案 (プレビュー) {#settings-search-suggestions-preview}
 
-**Setting**: `setting(workbench.settings.showAISearchToggle:true)`
+**設定**: `setting(workbench.settings.showAISearchToggle:true)`
 
-This milestone, we added a toggle to the Settings editor that starts an AI search to find semantically similar results instead of results that are based on string matching. For example, the AI search finds the `editor.fontSize` setting when you search for "increase text size".
+このマイルストーンでは、設定エディターにトグルを追加しました。これにより、文字列一致に基づく結果ではなく、意味的に類似した結果を見つけるための AI 検索が開始されます。たとえば、「テキストサイズを大きくする」と検索すると、AI 検索は `editor.fontSize` 設定を見つけます。
 
-To see the toggle, enable the setting and reload VS Code. We are also in the process of identifying and fixing some of the less accurate settings search results, and we welcome feedback on when a natural language query did not find an expected setting.
+トグルを表示するには、設定を有効にして VS Code をリロードします。また、精度の低い設定検索結果の一部を特定して修正するプロセスを進めており、自然言語クエリで期待される設定が見つからなかった場合のフィードバックを歓迎します。
 
-For the next milestone, we are also considering removing the toggle and changing the experimental setting to one that controls when to directly append the slower AI search results to the end of the list.
+次のマイルストーンでは、トグルを削除し、実験的な設定を、低速な AI 検索結果をリストの末尾に直接追加するタイミングを制御するものに変更することも検討しています。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/settings-editor-ai-search.mp4" title="Video showing AI search in the Settings editor that finds the `editor.fontSize` setting when you search 'increase text size'." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/settings-editor-ai-search.mp4" title="設定エディターで AI 検索が「テキストサイズを大きくする」と検索したときに `editor.fontSize` 設定を見つける様子を示す動画。" autoplay loop controls muted></video>
 
-### Search keyword suggestions (Preview) {#search-keyword-suggestions-preview}
+### 検索キーワードの提案 (プレビュー) {#search-keyword-suggestions-preview}
 
-**Setting**: `setting(search.searchView.keywordSuggestions)`
+**設定**: `setting(search.searchView.keywordSuggestions)`
 
-Last milestone, we introduced [keyword suggestions](https://code.visualstudio.com/updates/v1_100#_semantic-text-search-with-keyword-suggestions-experimental) in the Search view to help you find relevant results faster. We have now significantly improved the performance of the suggestions, so you will see the results ~5x faster than before.
+前回のマイルストーンでは、検索ビューに [キーワード提案](https://code.visualstudio.com/updates/v1_100#_semantic-text-search-with-keyword-suggestions-experimental) を導入し、関連性の高い結果をより速く見つけられるようにしました。提案のパフォーマンスを大幅に改善したため、結果が以前より約 5 倍速く表示されるようになります。
 
-We have also moved the setting from the Chat extension into VS Code core, and renamed it from `github.copilot.chat.search.keywordSuggestions` to `setting(search.searchView.keywordSuggestions)`.
+また、設定をチャット拡張機能から VS Code コアに移動し、名前を `github.copilot.chat.search.keywordSuggestions` から `setting(search.searchView.keywordSuggestions)` に変更しました。
 
-### Semantic search behavior options (Preview) {#semantic-search-behavior-options-preview}
+### セマンティック検索の動作オプション (プレビュー) {#semantic-search-behavior-options-preview}
 
-**Setting**: `setting(search.searchView.semanticSearchBehavior)`
+**設定**: `setting(search.searchView.semanticSearchBehavior)`
 
-With semantic search in the Search view, you can get results based on the meaning of your query rather than just matching text. This is particularly useful if you don't know the exact terms to search for.
+検索ビューのセマンティック検索を使用すると、テキストの一致だけでなく、クエリの意味に基づいて結果を取得できます。これは、検索する正確な用語がわからない場合に特に便利です。
 
-By default, semantic search is only run when you explicitly request it. We have now added a setting to control when you want semantic search to be triggered:
+デフォルトでは、セマンティック検索は明示的に要求された場合にのみ実行されます。セマンティック検索をトリガーするタイミングを制御する設定を追加しました:
 
-* `manual` (default): only run semantic search when triggered manually from the UI (`kb(search.action.searchWithAI)`)
-* `runOnEmpty`: run semantic search automatically when the text search returns no results
-* `auto`: always run semantic search in parallel with text search for every search query
+* `manual` (デフォルト): UI から手動でトリガーされた場合にのみセマンティック検索を実行します (`kb(search.action.searchWithAI)`)
+* `runOnEmpty`: テキスト検索で結果が返されなかった場合に自動的にセマンティック検索を実行します
+* `auto`: すべての検索クエリに対してテキスト検索と並行して常にセマンティック検索を実行します
 
-### Edit Context {#edit-context}
+### 編集コンテキスト {#edit-context}
 
-**Setting**: `setting(editor.experimentalEditContextEnabled)`
+**設定**: `setting(editor.experimentalEditContextEnabled)`
 
-We have enabled the `setting(editor.experimentalEditContextEnabled)` setting by default on Stable. This means that the input of the editor is now powered by the EditContext API. This fixes numerous bugs, especially in relation to the IME experience, and going forward will pave the way for a more versatile and robust input experience within the editor.
+Stable で `setting(editor.experimentalEditContextEnabled)` 設定をデフォルトで有効にしました。これは、エディターの入力が EditContext API によって提供されるようになったことを意味します。これにより、特に IME エクスペリエンスに関連する多数のバグが修正され、将来的にはエディター内でより多用途で堅牢な入力エクスペリエンスへの道が開かれます。
 
-See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/EditContext_API) for more detail on the EditContext API.
+EditContext API の詳細については、[MDN ドキュメント](https://developer.mozilla.org/en-US/docs/Web/API/EditContext_API) を参照してください。
 
-## Code Editing {#code-editing}
+## コード編集 {#code-editing}
 
-### NES import suggestions {#nes-import-suggestions}
+### NES インポートの提案 {#nes-import-suggestions}
 
-**Setting**: `setting(github.copilot.nextEditSuggestions.fixes)`
+**設定**: `setting(github.copilot.nextEditSuggestions.fixes)`
 
-Last month, we introduced support for next edit suggestions to automatically suggest adding missing import statements for TypeScript and JavaScript. In this release, we've improved the accuracy and reliability of these suggestions and expanded support to Python files as well.
+先月、TypeScript と JavaScript の欠落しているインポートステートメントの追加を自動的に提案する、次の編集提案のサポートを導入しました。このリリースでは、これらの提案の精度と信頼性を向上させ、Python ファイルにもサポートを拡張しました。
 
-![Screenshot showing NES suggesting an import statement.](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
+![NES がインポートステートメントを提案しているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
 
-NES is enabled for all VS Code Insiders users, and it will progressively be enabled by default for Stable users during June. You can enable NES yourself via its setting at any time.
+NES はすべての VS Code Insiders ユーザーに対して有効になっており、6 月中に Stable ユーザーに対して段階的にデフォルトで有効になります。いつでも設定から NES を自分で有効にできます。
 
-### NES acceptance flow {#nes-acceptance-flow}
+### NES 受け入れフロー {#nes-acceptance-flow}
 
-Accepting next edit suggestions is now more seamless with improved keyboard navigation. Once you accept a suggestion, you can continue accepting subsequent suggestions with a single `kbstyle(Tab)` press, as long as you haven't started typing again. Once you start typing, press `kbstyle(Tab)` to first move the cursor to the next suggestion before you can accept it.
+次の編集提案の受け入れが、キーボードナビゲーションの改善により、よりシームレスになりました。提案を受け入れると、再度入力を開始するまでは、単一の `kbstyle(Tab)` キーを押すだけで後続の提案を引き続き受け入れることができます。入力を開始すると、`kbstyle(Tab)` を押してまずカーソルを次の提案に移動してから受け入れることができます。
 
-## Notebooks {#notebooks}
+## ノートブック {#notebooks}
 
-### Follow mode for agent cell execution {#follow-mode-agent-cell-execution}
+### エージェントセル実行のフォローモード {#follow-mode-agent-cell-execution}
 
-**Setting**: `setting(github.copilot.chat.notebook.followCellExecution.enabled)`
+**設定**: `setting(github.copilot.chat.notebook.followCellExecution.enabled)`
 
-With follow mode, the Notebook view will automatically scroll to the cell that is currently being executed by the agent. Use the `setting(github.copilot.chat.notebook.followCellExecution.enabled)` setting to enable or disable follow mode for agent cell execution in Jupyter Notebooks.
+フォローモードでは、ノートブックビューはエージェントによって現在実行されているセルに自動的にスクロールします。Jupyter Notebooks でのエージェントセル実行のフォローモードを有効または無効にするには、`setting(github.copilot.chat.notebook.followCellExecution.enabled)` 設定を使用します。
 
-Once the agent has used the run cell tool, the Notebook toolbar is updated with a pin icon, indicating the state of follow mode. You can toggle the behavior mid agent response without changing the base setting value, allowing you to follow the work of the agent in real-time, and toggle it off when you want to review a specific portion of code while the agent continues to iterate. When you wish to follow again, simply toggle the mode, and join at the next execution.
+エージェントがセル実行ツールを使用すると、ノートブックツールバーがピンアイコンで更新され、フォローモードの状態が示されます。基本設定値を変更せずにエージェントの応答の途中で動作を切り替えることができ、エージェントの作業をリアルタイムでフォローし、エージェントが反復を続けている間に特定のコード部分を確認したい場合はオフに切り替えることができます。再度フォローしたい場合は、モードを切り替えるだけで、次の実行時に参加できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/notebook-follow-mode.mp4" title="Video that shows the AI executing cells in a notebook with follow mode enabled. When the cell is run, the notebook scrolls to reveal it." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/notebook-follow-mode.mp4" title="フォローモードが有効になっているノートブックで AI がセルを実行する様子を示す動画。セルが実行されると、ノートブックがスクロールして表示されます。" autoplay loop controls muted></video>
 
-### Notebook tools for agent mode {#notebook-tools-agent-mode}
+### エージェントモード用のノートブックツール {#notebook-tools-agent-mode}
 
-#### Configure notebook {#configure-notebook}
+#### ノートブックの設定 {#configure-notebook}
 
-The [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) contributes tools for configuring the Kernel of a Jupyter Notebook. This tool ensures that a Kernel is selected and is ready for use in the Notebook.
-This involves walking you through the process of creating a Virtual Environment if required (the recommended approach), or prompting you to select an existing Python environment.
+[Jupyter 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) は、Jupyter Notebook のカーネルを設定するためのツールを提供します。このツールは、カーネルが選択され、ノートブックで使用できる状態であることを保証します。これには、必要に応じて仮想環境を作成するプロセス (推奨されるアプローチ) を案内したり、既存の Python 環境を選択するように促したりすることが含まれます。
 
-This tool ensures the LLM can perform operations on the Notebook such as running cells with minimal user interaction, thereby improving the overall user experience in agent mode.
+このツールにより、LLM は最小限のユーザー操作でセルの実行などの操作をノートブックで実行できるようになり、エージェントモードでの全体的なユーザーエクスペリエンスが向上します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/notebook-tools.mp4" title="Video that shows the AI configuring the Python environment, installing dependencies and finally running notebook cells." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/notebook-tools.mp4" title="AI が Python 環境を設定し、依存関係をインストールし、最後にノートブックセルを実行する様子を示す動画。" autoplay loop controls muted></video>
 
-#### Long running agent workflows {#long-running-agent-workflows}
+#### 長時間実行されるエージェントワークフロー {#long-running-agent-workflows}
 
-The agent has access to an internal Notebook Summary tool to help keep it on track with an accurate context. That summary is also included when summarizing the conversation history when the context gets too large to keep the agent going through complex operations.
+エージェントは、正確なコンテキストで軌道に乗せるのに役立つ内部ノートブックサマリーツールにアクセスできます。そのサマリーは、コンテキストが大きくなりすぎてエージェントが複雑な操作を続行できなくなった場合に、会話履歴を要約する際にも含まれます。
 
-#### Cell preview in run confirmation {#cell-preview-run-confirmation}
+#### 実行確認でのセルプレビュー {#cell-preview-run-confirmation}
 
-A snippet of the code is shown from a notebook cell when the agent requests confirmation to run that cell. The cell links in the Chat view now also enable you to directly navigate to cells in the notebook.
+エージェントがそのセルの実行確認を要求すると、ノートブックセルからコードのスニペットが表示されます。チャットビューのセルリンクにより、ノートブック内のセルに直接移動できるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/run-cell-confirmation.mp4" title="Video showing the AI asking to run a cell including a link to the cell and a preview of its content." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/run-cell-confirmation.mp4" title="AI がセルへのリンクとその内容のプレビューを含むセルの実行を要求する様子を示す動画。" autoplay loop controls muted></video>
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Copilot coding agent integration {#copilot-coding-agent-integration}
+### Copilot コーディングエージェントの統合 {#copilot-coding-agent-integration}
 
-With Copilot coding agent, GitHub Copilot can work independently in the background to complete tasks, just like a human developer. We have expanded the GitHub Pull Requests extension to make it easier to assign and track tasks for the agent from within VS Code.
+Copilot コーディングエージェントを使用すると、GitHub Copilot は人間の開発者のようにバックグラウンドで独立してタスクを完了できます。GitHub Pull Requests 拡張機能を拡張し、VS Code 内からエージェントのタスクを簡単に割り当てて追跡できるようにしました。
 
-We have added the following features to the extension:
+拡張機能に次の機能を追加しました:
 
-* **Assign to Copilot**: assign a pull request or issue to Copilot from the issue or PR view in VS Code
-* **Copilot on My Behalf** PR query: quickly see all pull requests that Copilot is working on for you.
-* **PR view**: see the status of the Copilot coding agent and open the session details in the browser.
+* **Copilot に割り当て**: VS Code の issue または PR ビューからプルリクエストまたは issue を Copilot に割り当てます
+* **Copilot on My Behalf** PR クエリ: Copilot があなたのために作業しているすべてのプルリクエストをすばやく確認できます。
+* **PR ビュー**: Copilot コーディングエージェントのステータスを確認し、ブラウザーでセッションの詳細を開きます。
 
-![Screenshot showing the GitHub Pull Requests view, highlighting the assign to Copilot action, and the PR query for work assigned to Copilot.](https://code.visualstudio.com/assets/updates/1_101/github-pull-request-coding-agent.png)
+![GitHub Pull Requests ビューを示すスクリーンショット。Copilot への割り当てアクションと、Copilot に割り当てられた作業の PR クエリが強調表示されています。](https://code.visualstudio.com/assets/updates/1_101/github-pull-request-coding-agent.png)
 
-### Source control history item details {#source-control-history-item-details}
+### ソース管理履歴アイテムの詳細 {#source-control-history-item-details}
 
-Upon popular demand, selecting an item in the Source Control Graph view now reveals the resources of that history item. You can choose between a tree view or list view representation from the `...` menu.
+多くのご要望にお応えして、ソース管理グラフビューでアイテムを選択すると、その履歴アイテムのリソースが表示されるようになりました。`...` メニューからツリービューまたはリストビューの表現を選択できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/source-control-graph-view-resources.mp4" title="Video showing the Source Control Graph view, displaying the files for a commit and showing a diff editor of its changes." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/source-control-graph-view-resources.mp4" title="ソース管理グラフビューを示す動画。コミットのファイルを表示し、その変更の差分エディターを表示します。" autoplay loop controls muted></video>
 
-To open all resources of a history item in the multi-file diff editor, use the **Open Changes** action on hover. Selecting a particular resource from the Graph view opens a diff editor only for that resource. Select the **Open File** action to open the file for that particular version.
+履歴アイテムのすべてのリソースを複数ファイル差分エディターで開くには、ホバー時の **変更を開く** アクションを使用します。グラフビューから特定のリソースを選択すると、そのリソースのみの差分エディターが開きます。特定のバージョンのファイルを開くには、**ファイルを開く** アクションを選択します。
 
-### Add history item to chat context {#add-history-item-chat-context}
+### 履歴アイテムをチャットコンテキストに追加 {#add-history-item-chat-context}
 
-You can now add a source control history item as context to a chat request. This can be useful when you want to provide the contents of a specific commit or pull request as context for your chat prompt.
+ソース管理履歴アイテムをチャットリクエストのコンテキストとして追加できるようになりました。これは、特定のコミットまたはプルリクエストの内容をチャットプロンプトのコンテキストとして提供したい場合に便利です。
 
-![Screenshot of the Chat view input box that has a history item added as context.](https://code.visualstudio.com/assets/updates/1_101/chat-context-source-control-commit.png)
+![履歴アイテムがコンテキストとして追加されたチャットビュー入力ボックスのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/chat-context-source-control-commit.png)
 
-To add a history item to chat, use **Add Context** > **Source Control** from the Chat view and then choose a particular history item. Alternatively, right-click the history item in the source control graph and then select **Copilot** > **Add History Item to Chat** from the context menu.
+履歴アイテムをチャットに追加するには、チャットビューから **コンテキストを追加** > **ソース管理** を使用し、特定の履歴アイテムを選択します。または、ソース管理グラフで履歴アイテムを右クリックし、コンテキストメニューから **Copilot** > **履歴アイテムをチャットに追加** を選択します。
 
-## Tasks {#tasks}
+## タスク {#tasks}
 
-### Instance policy {#instance-policy}
+### インスタンスポリシー {#instance-policy}
 
-Task `runOptions` now has an `instancePolicy` property, which determines what happens when a task has reached its `instanceLimit`.
+タスクの `runOptions` に `instancePolicy` プロパティが追加されました。これは、タスクが `instanceLimit` に達したときに何が起こるかを決定します。
 
-Options include `prompt` (default), `silent`, `terminateNewest`, `terminateOldest`, and `warn`.
+オプションには、`prompt` (デフォルト)、`silent`、`terminateNewest`、`terminateOldest`、`warn` が含まれます。
 
-![Screenshot showing an `instancePolicy` being configured in a `tasks.json` file and displays the options with prompt as the default value.](https://code.visualstudio.com/assets/updates/1_101/instancePolicy.png)
+![`tasks.json` ファイルで `instancePolicy` が設定され、デフォルト値として prompt を含むオプションが表示されているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_101/instancePolicy.png)
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Language server based terminal suggest {#language-server-terminal-suggest}
+### 言語サーバーベースのターミナル提案 {#language-server-terminal-suggest}
 
-Language server completions are now available in the terminal for interactive Python REPL sessions.
-This brings the same language completions you receive in the editor now inside the terminal.
-We are starting with support for Python via Pylance, with plans to expand to more languages in the future.
+対話型 Python REPL セッションのターミナルで言語サーバー補完が利用できるようになりました。これにより、エディターで受け取るのと同じ言語補完がターミナル内で利用できます。Pylance を介した Python のサポートから開始し、将来的にはより多くの言語に拡張する予定です。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/lsp_completions.mp4" title="Video that shows completions from LSP in REPL in the terminal." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/lsp_completions.mp4" title="ターミナルの REPL で LSP からの補完を示す動画。" autoplay loop controls muted></video>
 
-To try it out, ensure the following settings are enabled:
+試すには、次の設定が有効になっていることを確認してください:
 
 * `setting(terminal.integrated.shellIntegration.enabled:true)`
 * `setting(python.terminal.shellIntegration.enabled:true)`
 * `setting(terminal.integrated.suggest.enabled:true)`
 * `setting(python.analysis.supportAllPythonDocuments:true)`
 
-## Remote Development {#remote-development}
+## リモート開発 {#remote-development}
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[リモート開発拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) を使用すると、[開発コンテナー](https://code.visualstudio.com/docs/devcontainers/containers)、SSH または [リモートトンネル](https://code.visualstudio.com/docs/remote/tunnels) を介したリモートマシン、または [Linux 用 Windows サブシステム](https://learn.microsoft.com/windows/wsl) (WSL) をフル機能の開発環境として使用できます。
 
-Highlights include:
+ハイライトは次のとおりです:
 
-* SSH pre-connection script
-* Remote Explorer improvements
+* SSH 事前接続スクリプト
+* リモートエクスプローラーの改善
 
-You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_101.md).
+これらの機能の詳細については、[リモート開発リリースノート](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_101.md) を参照してください。
 
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### Python {#python}
 
-#### Python chat tools {#python-chat-tools}
+#### Python チャットツール {#python-chat-tools}
 
-The [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) now includes the following chat tools: “Get information for a Python Environment”, “Get executable information for a Python Environment”, “Install Python Package” and “Configure Python Environment”. You can either directly reference them in your prompt by adding `#getPythonEnvironmentInfo` `#installPythonPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information, based on file or workspace context, and handle package installation with accurate environment resolution.
+[Python 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.python) には、「Python 環境の情報を取得」、「Python 環境の実行可能情報を取得」、「Python パッケージのインストール」、「Python 環境の設定」というチャットツールが含まれるようになりました。プロンプトで `#getPythonEnvironmentInfo` `#installPythonPackage` を追加して直接参照するか、エージェントモードが該当するツールを自動的に呼び出します。これらのツールは、ファイルまたはワークスペースのコンテキストに基づいて適切な環境情報をシームレスに検出し、正確な環境解決でパッケージのインストールを処理します。
 
-The “Configure Python Environment” tool ensures that the Python Environment is set up correctly for the workspace. This includes creating a Virtual Environment if needed, and selecting that as the active Python Environment for the workspace.
+「Python 環境の設定」ツールは、Python 環境がワークスペースに対して正しく設定されていることを保証します。これには、必要に応じて仮想環境を作成し、それをワークスペースのアクティブな Python 環境として選択することが含まれます。
 
-Tools that were previously introduced in the [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) have been migrated to the Python extension, thereby making these tools available to all users with the Python extension installed.
+以前 [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) 拡張機能 (プレビュー) で導入されたツールは Python 拡張機能に移行され、これにより Python 拡張機能がインストールされているすべてのユーザーがこれらのツールを利用できるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_101/python-tools.mp4" title="Video demoing the Python tools called implicitly by the model in agent mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/python-tools.mp4" title="エージェントモードでモデルによって暗黙的に呼び出される Python ツールをデモする動画。" autoplay loop controls muted></video>
 
-#### Create a project from a template {#create-project-from-template}
+#### テンプレートからプロジェクトを作成 {#create-project-from-template}
 
-The [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) now supports project creation for Python packages and basic scripts, allowing you to bypass scaffolding and get coding more quickly. Use the command **Python Envs: Create Project from Template** to select whether you want to create a package or a script.
+[Python Environments 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) は、Python パッケージと基本スクリプトのプロジェクト作成をサポートするようになり、スキャフォールディングをバイパスしてより迅速にコーディングを開始できるようになりました。**Python Envs: Create Project from Template** コマンドを使用して、パッケージを作成するかスクリプトを作成するかを選択します。
 
-For package creation, you are able to name the package, create a virtual environment, and receive a scaffolded project which includes a tests subfolder, `pyproject.toml`, `dev-requirements.txt`, and boilerplate `__main__.py` and `__init__.py` files.
+パッケージ作成では、パッケージに名前を付け、仮想環境を作成し、テストサブフォルダー、`pyproject.toml`、`dev-requirements.txt`、および定型的な `__main__.py` と `__init__.py` ファイルを含むスキャフォールディングされたプロジェクトを受け取ることができます。
 
-For scripts, it creates a new python file with the name of your choice and include boilerplate code.
+スクリプトの場合、選択した名前で新しい Python ファイルを作成し、定型的なコードを含めます。
 
-#### PyEnv and Poetry support {#pyenv-poetry-support}
+#### PyEnv と Poetry のサポート {#pyenv-poetry-support}
 
-We added support for `pyenv` for environment management, and `poetry` for both package and environment management in the [Python Environements](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension.
+[Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) 拡張機能に、環境管理用の `pyenv` と、パッケージおよび環境管理用の `poetry` のサポートを追加しました。
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能のオーサリング {#extension-authoring}
 
-### MCP extension APIs {#mcp-extension-apis}
+### MCP 拡張機能 API {#mcp-extension-apis}
 
-Extensions can now publish collections of MCP servers. This enables you to bundle MCP servers with your extension or build extensions that dynamically discover MCP servers from other sources. Learn more in our [MCP extension development guide](https://code.visualstudio.com/api/extension-guides/mcp) or by checking out the [MCP extension sample](https://github.com/microsoft/vscode-extension-samples/blob/main/mcp-extension-sample).
+拡張機能は MCP サーバーのコレクションを公開できるようになりました。これにより、MCP サーバーを拡張機能にバンドルしたり、他のソースから MCP サーバーを動的に検出する拡張機能を構築したりできます。詳細については、[MCP 拡張機能開発ガイド](https://code.visualstudio.com/api/extension-guides/mcp) を参照するか、[MCP 拡張機能サンプル](https://github.com/microsoft/vscode-extension-samples/blob/main/mcp-extension-sample) を確認してください。
 
-### Secret scanning when packaging extensions {#secret-scanning-packaging-extensions}
+### 拡張機能パッケージ化時のシークレットスキャン {#secret-scanning-packaging-extensions}
 
-VSCE now scans for secrets when packaging your extension. If any potential secrets (for example, API keys, tokens, credentials, or environment variable files like `.env`) are detected in your source files, VSCE displays an error during the packaging process. This helps you avoid accidentally publishing sensitive information to the Marketplace. Make sure to review and address any error before publishing your extension.
+VSCE は、拡張機能をパッケージ化する際にシークレットをスキャンするようになりました。ソースファイルで潜在的なシークレット (API キー、トークン、資格情報、`.env` などの環境変数ファイルなど) が検出された場合、VSCE はパッケージ化プロセス中にエラーを表示します。これにより、機密情報を誤って Marketplace に公開することを回避できます。拡張機能を公開する前に、エラーを確認して対処してください。
 
-If you need to bypass specific checks, you can use the `--allow-package-secrets <secret_type>` or `--allow-package-env-file` flags when running VSCE. These flags let you configure which secret or environment file checks should be skipped during packaging.
+特定のチェックをバイパスする必要がある場合は、VSCE の実行時に `--allow-package-secrets <secret_type>` または `--allow-package-env-file` フラグを使用できます。これらのフラグを使用すると、パッケージ化中にスキップするシークレットまたは環境ファイルチェックを設定できます。
 
-### Web Environment detection {#web-environment-detection}
+### Web 環境の検出 {#web-environment-detection}
 
-⚠️ Breaking change ⚠️
+⚠️ 破壊的変更 ⚠️
 
-**Setting**: `setting(extensions.supportNodeGlobalNavigator)`
+**設定**: `setting(extensions.supportNodeGlobalNavigator)`
 
-The Node.js extension host is now updated to v22 from v20, as part of our [Electron 35 runtime update](#electron-35-update). This update brings in support for the [`navigator` global object](https://github.com/nodejs/node/commit/b40f0c30743aaecd57071f7be305df43e1083817) in the desktop and remote extension hosts.
+Node.js 拡張機能ホストは、[Electron 35 ランタイム更新](#electron-35-update) の一環として、v20 から v22 に更新されました。この更新により、デスクトップおよびリモート拡張機能ホストで [`navigator` グローバルオブジェクト](https://github.com/nodejs/node/commit/b40f0c30743aaecd57071f7be305df43e1083817) がサポートされるようになります。
 
-This change could introduce a breaking change for extensions that rely on the presence of the `navigator` object to detect the web environment.
+この変更は、Web 環境を検出するために `navigator` オブジェクトの存在に依存する拡張機能にとって破壊的変更となる可能性があります。
 
-To help extension authors migrate, we have created a polyfill for `globalThis.navigator` that is initialized to `undefined`, so your extension continues to work correctly. The polyfill is behind the `setting(extensions.supportNodeGlobalNavigator)` VS Code setting. By default, this setting is disabled and the polyfill is in place. We capture telemetry and log an error (in extension development mode) when your extension tries to access the `navigator` in this way.
+拡張機能作成者の移行を支援するために、`undefined` に初期化される `globalThis.navigator` のポリフィルを作成しました。これにより、拡張機能は引き続き正しく動作します。ポリフィルは `setting(extensions.supportNodeGlobalNavigator)` VS Code 設定の背後にあります。デフォルトでは、この設定は無効になっており、ポリフィルが配置されています。拡張機能がこの方法で `navigator` にアクセスしようとすると、テレメトリをキャプチャし、エラーをログに記録します (拡張機能開発モードの場合)。
 
-In the future, this setting might be enabled by default, so we urge extension authors to migrate their code to be compatible with the new `navigator` global object. Follow these steps to migrate your code:
+将来的には、この設定がデフォルトで有効になる可能性があるため、拡張機能作成者には、新しい `navigator` グローバルオブジェクトと互換性があるようにコードを移行することを強くお勧めします。コードを移行するには、次の手順に従います:
 
-* Check the extension host log for a `PendingMigrationError` that has error stack originating your extension.
-* Ensure checks like `typeof navigator === 'object'` are migrated to `typeof process === 'object' && process.versions.node` as needed.
-* Enable `setting(extensions.supportNodeGlobalNavigator)`.
-* Verify extension behavior remains unchanged.
+* 拡張機能ホストログで、拡張機能から発生したエラースタックを持つ `PendingMigrationError` を確認します。
+* 必要に応じて、`typeof navigator === 'object'` のようなチェックが `typeof process === 'object' && process.versions.node` に移行されていることを確認します。
+* `setting(extensions.supportNodeGlobalNavigator)` を有効にします。
+* 拡張機能の動作が変わらないことを確認します。
 
-## Proposed APIs {#proposed-apis}
+## 提案された API {#proposed-apis}
 
-### Authentication Providers: Supported Authorization Servers for MCP {#authentication-providers-mcp}
+### 認証プロバイダー: MCP でサポートされる認証サーバー {#authentication-providers-mcp}
 
-Currently only leveraged in [MCP authentication](#mcp-support-for-auth), this API proposal enables your `AuthenticationProvider` to declare the authorization servers that are associated with it.
+現在 [MCP 認証](#mcp-support-for-auth) でのみ利用されているこの API 提案により、`AuthenticationProvider` はそれに関連付けられている認証サーバーを宣言できます。
 
-For example, if you look at the GitHub Authentication Provider, it includes the typical GitHub authorization URL in the authorizationServerGlobs property of [the auth provider contribution](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/github-authentication/package.json#L35-L41):
+たとえば、GitHub 認証プロバイダーを見ると、[認証プロバイダーコントリビューション](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/github-authentication/package.json#L35-L41) の authorizationServerGlobs プロパティに一般的な GitHub 認証 URL が含まれています:
 
 ```json
 {
@@ -540,9 +536,9 @@ For example, if you look at the GitHub Authentication Provider, it includes the 
 }
 ```
 
-This property is used for activation of your extension - if the requested authorization server matches, your extension will be activated.
+このプロパティは拡張機能のアクティベーションに使用されます。要求された認証サーバーが一致する場合、拡張機能がアクティベートされます。
 
-Additionally, when registering the authentication provider, you MUST include the finalized authorization server url globs. Just like [what GitHub Authentication does here](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/github-authentication/src/github.ts#L144-L149):
+さらに、認証プロバイダーを登録する際には、最終決定された認証サーバー URL glob を含める必要があります。[GitHub 認証がここで行っていること](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/github-authentication/src/github.ts#L144-L149) と同様です:
 
 ```ts
 vscode.authentication.registerAuthenticationProvider(
@@ -558,7 +554,7 @@ vscode.authentication.registerAuthenticationProvider(
 );
 ```
 
-For a more complex example, look to Microsoft Authentication. The authorization server depends on the tenant being placed in the path. So for this, we use a wildcard [in the contribution](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/microsoft-authentication/package.json#L33-L39):
+より複雑な例については、Microsoft 認証を参照してください。認証サーバーは、パスに配置されるテナントに依存します。そのため、これには [コントリビューション](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/microsoft-authentication/package.json#L33-L39) でワイルドカードを使用します:
 
 ```json
 {
@@ -570,7 +566,7 @@ For a more complex example, look to Microsoft Authentication. The authorization 
 },
 ```
 
-and [in the registration](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/microsoft-authentication/src/extensionV2.ts#L78-L88):
+そして [登録時](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/microsoft-authentication/src/extensionV2.ts#L78-L88) に:
 
 ```ts
 authentication.registerAuthenticationProvider(
@@ -586,40 +582,40 @@ authentication.registerAuthenticationProvider(
 )
 ```
 
-Then, when a caller passes in an authorization server URL when it asks for auth, it is passed down to both the `getSessions` and `createSession` functions via the `AuthenticationProviderSessionOptions` that are already present.
+次に、呼び出し元が認証を要求するときに認証サーバー URL を渡すと、それは既に存在する `AuthenticationProviderSessionOptions` を介して `getSessions` 関数と `createSession` 関数の両方に渡されます。
 
-As mentioned, this functionality is currently used in MCP support, where we receive the authorization server URL to authenticate with from the MCP server. That URL is then mapped to an auth provider, or if none exists, an auth provider is dynamically created for that auth server.
+前述のように、この機能は現在 MCP サポートで使用されており、MCP サーバーから認証に使用する認証サーバー URL を受け取ります。その URL は認証プロバイダーにマッピングされるか、存在しない場合はその認証サーバー用に認証プロバイダーが動的に作成されます。
 
-The full API proposal can be found [in the vscode repo](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/src/vscode-dts/vscode.proposed.authIssuers.d.ts) and we'd love to hear your feedback in the [GitHub issue](https://github.com/microsoft/vscode/issues/248775)!
+完全な API 提案は [vscode リポジトリ](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/src/vscode-dts/vscode.proposed.authIssuers.d.ts) にあり、[GitHub issue](https://github.com/microsoft/vscode/issues/248775) でのフィードバックをお待ちしています！
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### Electron 35 update {#electron-35-update}
+### Electron 35 アップデート {#electron-35-update}
 
-In this milestone, we are promoting the Electron 35 update to users on our Stable release. This update comes with Chromium 134.0.6998.205 and Node.js 22.15.1. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+このマイルストーンでは、Stable リリースのユーザーに Electron 35 アップデートをプロモートしています。このアップデートには、Chromium 134.0.6998.205 と Node.js 22.15.1 が含まれています。Insiders ビルドでセルフホストし、早期のフィードバックを提供してくださった皆様に感謝いたします。
 
-### Adopting ESM in a real-world extension {#adopting-esm-real-world-extension}
+### 実世界の拡張機能での ESM の採用 {#adopting-esm-real-world-extension}
 
-Last milestone, we have announced support for JavaScript-modules (ESM). This enables extensions to use `import` and `export` statements, but currently only when targeting the NodeJS extension host.
+前回のマイルストーンでは、JavaScript モジュール (ESM) のサポートを発表しました。これにより、拡張機能は `import` および `export` ステートメントを使用できるようになりますが、現在は NodeJS 拡張機能ホストをターゲットにしている場合に限られます。
 
-This month, we have done a real-world adoption with [GitHub Issue Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks). It is not trivial because this extension can be run in the NodeJS extension host (which supports ESM extensions) and the web worker extension host, which currently does not support ESM extensions. This required a more complex bundler configuration and you might want to take inspiration from its [esbuild-config](https://github.com/microsoft/vscode-github-issue-notebooks/blob/main/esbuild.mjs).
+今月、[GitHub Issue Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks) で実世界の採用を行いました。この拡張機能は NodeJS 拡張機能ホスト (ESM 拡張機能をサポート) と Web ワーカー拡張機能ホスト (現在 ESM 拡張機能をサポートしていません) で実行できるため、これは簡単ではありません。これにはより複雑なバンドラー設定が必要であり、その [esbuild-config](https://github.com/microsoft/vscode-github-issue-notebooks/blob/main/esbuild.mjs) からインスピレーションを得たいと思うかもしれません。
 
-## Thank you {#thank-you}
+## ありがとうございます {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code の貢献者の皆様に心より感謝申し上げます。
 
-### Issue tracking {#issue-tracking}
+### Issue トラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+Issue トラッキングへの貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
 * [@alpalla (Alessio Palladino)](https://github.com/alpalla): Add a task instancePolicy to task runOptions  [PR ##117129](https://github.com/microsoft/vscode/pull/117129)
 * [@0xEbrahim (Ebrahim El-Sayed)](https://github.com/0xEbrahim): Fix Typo and Grammar [PR #248814](https://github.com/microsoft/vscode/pull/248814)
@@ -657,11 +653,11 @@ Contributions to `vscode`:
 * [@xzakharov (Oleksandr Zakharov)](https://github.com/xzakharov): fix(devcontainer): bump rust feature to fix container build [PR #250430](https://github.com/microsoft/vscode/pull/250430)
 * [@y0sh1ne (y0sh1ne)](https://github.com/y0sh1ne): Fix Copy Message with multiple selections (#247927) [PR #248172](https://github.com/microsoft/vscode/pull/248172)
 
-Contributions to `vscode-copilot-release`:
+`vscode-copilot-release` への貢献:
 
 * [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): chore: update bug report template [PR #9702](https://github.com/microsoft/vscode-copilot-release/pull/9702)
 
-Contributions to `vscode-css-languageservice`:
+`vscode-css-languageservice` への貢献:
 
 * [@Legend-Master (Tony)](https://github.com/Legend-Master): Add basic media query auto complete support [PR #443](https://github.com/microsoft/vscode-css-languageservice/pull/443)
 * [@rgant (J Rob Gant)](https://github.com/rgant)
@@ -669,55 +665,55 @@ Contributions to `vscode-css-languageservice`:
   * Remove extra characters [PR #437](https://github.com/microsoft/vscode-css-languageservice/pull/437)
   * refactor: Extend the base tsconfig.json [PR #438](https://github.com/microsoft/vscode-css-languageservice/pull/438)
 
-Contributions to `vscode-custom-data`:
+`vscode-custom-data` への貢献:
 
 * [@Legend-Master (Tony)](https://github.com/Legend-Master): Add media query support [PR #118](https://github.com/microsoft/vscode-custom-data/pull/118)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献:
 
 * [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs)
   * Add `eslint.codeActionsOnSave.options` [PR #1999](https://github.com/microsoft/vscode-eslint/pull/1999)
   * Add all possible flat configuration extensions [PR #2017](https://github.com/microsoft/vscode-eslint/pull/2017)
 
-Contributions to `vscode-generator-code`:
+`vscode-generator-code` への貢献:
 
 * [@SamB (Samuel Bronson)](https://github.com/SamB): Do not link to top of vscode docs [PR #518](https://github.com/microsoft/vscode-generator-code/pull/518)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
 * [@kdy1 (Donny/강동윤)](https://github.com/kdy1): chore: Fix default url for turbopack [PR #2223](https://github.com/microsoft/vscode-js-debug/pull/2223)
 * [@mikaelwaltersson (Mikael Waltersson)](https://github.com/mikaelwaltersson): Fix bug where the WasmWorker instance is disposed but never re-spawned on page reloads + writeMemory when WASM memory is SharedArrayBuffer [PR #2211](https://github.com/microsoft/vscode-js-debug/pull/2211)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献:
 
 * [@WillHirsch](https://github.com/WillHirsch): Downgrade diagnostic severity for use of bang instead of percent for package installs [PR #16601](https://github.com/microsoft/vscode-jupyter/pull/16601)
 
-Contributions to `vscode-languageserver-node`:
+`vscode-languageserver-node` への貢献:
 
 * [@martijnwalraven (Martijn Walraven)](https://github.com/martijnwalraven): Fix `workspace/textDocumentContent/refresh` request [PR #1637](https://github.com/microsoft/vscode-languageserver-node/pull/1637)
 
-Contributions to `vscode-markdown-tm-grammar`:
+`vscode-markdown-tm-grammar` への貢献:
 
 * [@Barros1902 (Tomás Barros )](https://github.com/Barros1902): Fix strikethrough with underscores in Markdown syntax (Fixes microsoft#173) [PR #174](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/174)
 
-Contributions to `vscode-prompt-tsx`:
+`vscode-prompt-tsx` への貢献:
 
 * [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): chore: npm audit fix [PR #175](https://github.com/microsoft/vscode-prompt-tsx/pull/175)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
 * [@kabel (Kevin Abel)](https://github.com/kabel): Allow verified GitHub emails when none are private [PR #6921](https://github.com/microsoft/vscode-pull-request-github/pull/6921)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
 * [@kycutler (Kyle Cutler)](https://github.com/kycutler): Fix `TypeError` from trying to read directory [PR #692](https://github.com/microsoft/vscode-python-debugger/pull/692)
 
-Contributions to `debug-adapter-protocol`:
+`debug-adapter-protocol` への貢献:
 
 * [@DrSergei](https://github.com/DrSergei): Fix some typos [PR #543](https://github.com/microsoft/debug-adapter-protocol/pull/543)
 * [@robertoaloi (Roberto Aloi)](https://github.com/robertoaloi): Add Erlang EDB Debugger [PR #544](https://github.com/microsoft/debug-adapter-protocol/pull/544)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
 * [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721)
   * add caddy [PR #2131](https://github.com/microsoft/language-server-protocol/pull/2131)
@@ -727,7 +723,7 @@ Contributions to `language-server-protocol`:
 * [@nieomylnieja (Mateusz Hawrus)](https://github.com/nieomylnieja): chore: Add Nobl9 VSCode extension to servers.md [PR #2136](https://github.com/microsoft/language-server-protocol/pull/2136)
 * [@zonuexe (USAMI Kenta)](https://github.com/zonuexe): Add LSP clients for Emacs [PR #2145](https://github.com/microsoft/language-server-protocol/pull/2145)
 
-Contributions to `lsprotocol`:
+`lsprotocol` への貢献:
 
 * [@debonte (Erik De Bonte)](https://github.com/debonte)
   * Update to latest LSP spec [PR #420](https://github.com/microsoft/lsprotocol/pull/420)

--- a/docs/release-notes/v1_101.md
+++ b/docs/release-notes/v1_101.md
@@ -57,7 +57,7 @@ To create a tool set, run the **Configure Tool Sets** > **Create new tool sets f
 
 To use a tool set in a chat query, reference it by #-mentioning its name, like `#gh-news`. You can also choose it from the tool picker in the chat input box.
 
-![Screenshot of the Chat view showing a query about unread notifications, using the 'gh-news' tool set highlighted in both the chat interface and a JSON configuration file which defines this tool set.](images/1_101/tool-set-gh.png)
+![Screenshot of the Chat view showing a query about unread notifications, using the 'gh-news' tool set highlighted in both the chat interface and a JSON configuration file which defines this tool set.](https://code.visualstudio.com/assets/updates/1_101/tool-set-gh.png)
 
 Learn more about [tools sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) in our documentation.
 
@@ -67,7 +67,7 @@ VS Code's Model Context Protocol support now includes prompt support. Prompts ca
 
 The following example shows how we generate a prompt using AI, save it using the [Gistpad MCP server](https://github.com/lostintangent/gistpad-mcp), and then use it to generate a changelog entry:
 
-<video src="images/1_101/mcp-prompts.mp4" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/mcp-prompts.mp4" autoplay loop controls muted></video>
 
 ### MCP support for resources
 
@@ -79,13 +79,13 @@ VS Code's Model Context Protocol support now includes resource support, which in
 
 Here's an example of attaching resources from the [Gistpad MCP server](https://github.com/lostintangent/gistpad-mcp) to chat:
 
-<video src="images/1_101/mcp-resources.mp4" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/mcp-resources.mp4" autoplay loop controls muted></video>
 
 ### MCP support for sampling (Experimental)
 
 VS Code's Model Context Protocol support now includes sampling, which allows MCP servers to make requests back to the model. You'll be asked to confirm the first time an MCP server makes a sampling request, and you can configure the models the MCP server has access to as well as see a request log by selecting the server in **MCP: List Servers.**
 
-<video src="images/1_101/mcp-sampling.mp4" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/mcp-sampling.mp4" autoplay loop controls muted></video>
 
 Sampling support is still preliminary and we plan to expand and improve it in future iterations.
 
@@ -100,17 +100,17 @@ This feature implements the MCP authorization specification for clients, and sup
 
 If the MCP server implements the draft spec and leverages GitHub or Entra as the auth server, you can manage which MCP servers have access to your account:
 
-![Screenshot of the "Manage Trusted MCP Servers" option in the account menu.](images/1_101/manage-trusted-mcp.png)
+![Screenshot of the "Manage Trusted MCP Servers" option in the account menu.](https://code.visualstudio.com/assets/updates/1_101/manage-trusted-mcp.png)
 
-![Screenshot of the "Manage Trusted MCP Servers" Quick Pick.](images/1_101/manage-trusted-mcp-quick-pick.png)
+![Screenshot of the "Manage Trusted MCP Servers" Quick Pick.](https://code.visualstudio.com/assets/updates/1_101/manage-trusted-mcp-quick-pick.png)
 
 You can also manage which account that server should use (via the gear button in the previous quick pick):
 
-![Screenshot of the "Account Preference" Quick Pick.](images/1_101/account-pref-quick-pick.png)
+![Screenshot of the "Account Preference" Quick Pick.](https://code.visualstudio.com/assets/updates/1_101/account-pref-quick-pick.png)
 
 For other MCP servers that rely on dynamic client registration, we include the auth state in the same place as everything else, for example with Linear:
 
-![Screenshot of Linear appearing in the account menu.](images/1_101/linear-account-menu.png)
+![Screenshot of Linear appearing in the account menu.](https://code.visualstudio.com/assets/updates/1_101/linear-account-menu.png)
 
 There you can also sign out. For these we support not only the code authorization flow but also the device code flow should your authorization server support it.
 
@@ -147,7 +147,7 @@ Undoing previous requests is now also more visible - just hover over a request a
 
 Finally, attachments from the chat input box are now more navigable.
 
-<video src="images/1_101/new-chat-ui-ux.mp4" title="A video of the new chat UI/UX where a request is removed to undo edits since that point." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/new-chat-ui-ux.mp4" title="A video of the new chat UI/UX where a request is removed to undo edits since that point." autoplay loop controls muted></video>
 
 Learn more about using [chat in VS Code](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) in our documentation.
 
@@ -163,7 +163,7 @@ We've streamlined and simplified the way that adding your current file as contex
 
 Additionally, in agent mode, we include a hint about your current editor. This doesn't include the contents of the file, just the file name and cursor position. The agent can then use the tools it has to read the contents of the file on its own, if it thinks that it's relevant to your query.
 
-<video src="images/1_101/implicit-context-flow.mp4" title="A video of the current open editor being suggest as implicit context and added as an attachment." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/implicit-context-flow.mp4" title="A video of the current open editor being suggest as implicit context and added as an attachment." autoplay loop controls muted></video>
 
 Learn more about [adding context in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context) in our documentation.
 
@@ -184,7 +184,7 @@ To define and use a custom chat mode, follow these steps:
 1. In the Chat view, select the chat mode from the chat mode dropdown list.
 1. Submit your chat prompt and
 
-![Screenshot of the custom chat mode selected in the Chat view.](images/1_101/custom-chat-mode-view.png)
+![Screenshot of the custom chat mode selected in the Chat view.](https://code.visualstudio.com/assets/updates/1_101/custom-chat-mode-view.png)
 
 The following example shows a custom "Planning" chat mode:
 
@@ -222,13 +222,13 @@ When you move a chat session into a floating window, there are now two new actio
 * Dock the chat back into the VS Code window where it came from
 * Start a new chat session in the floating window.
 
-![Screenshot of the Chat view in a floating window, highlighting the Dock and New Chat buttons in the title bar.](images/1_101/chat-floating.png)
+![Screenshot of the Chat view in a floating window, highlighting the Dock and New Chat buttons in the title bar.](https://code.visualstudio.com/assets/updates/1_101/chat-floating.png)
 
 ### Fetch tool confirmation
 
 The fetch tool enables you to pull information from a web page. We have added a warning message to the confirmation to inform you about potential prompt injection.
 
-![Screenshot of the fetch tool with a warning about prompt injection.](images/1_101/fetch-warning.png)
+![Screenshot of the fetch tool with a warning about prompt injection.](https://code.visualstudio.com/assets/updates/1_101/fetch-warning.png)
 
 ### Customize more built-in tools
 
@@ -236,7 +236,7 @@ It's now possible to enable or disable all built-in tools in agent mode or your 
 
 In agent mode, select the **Configure Tools** button to open the tool picker, and select your desired set of tools.
 
-![Screenshot of the tool picker, showing the "editFiles" tool set item cleared.](images/1_101/built-in-toolsets.png)
+![Screenshot of the tool picker, showing the "editFiles" tool set item cleared.](https://code.visualstudio.com/assets/updates/1_101/built-in-toolsets.png)
 
 Some of the entries in this menu represent tool sets that group multiple tools. For example, we give the model multiple tools to edit or create text files and notebooks, which may also differ by model family, and `editFiles` groups all of these.
 
@@ -244,7 +244,7 @@ Some of the entries in this menu represent tool sets that group multiple tools. 
 
 Last milestone, we added a [new experimental feature](https://code.visualstudio.com/updates/v1_100#_select-and-attach-ui-elements-to-chat-experimental) where you could open the Simple Browser and select web elements to add to chat from the embedded browser.
 
-![Screenshot showing the Live Preview extension, highlighting the overlay controls to select web elements from the web page.](images/1_101/live-preview-select-web-elements.png)
+![Screenshot showing the Live Preview extension, highlighting the overlay controls to select web elements from the web page.](https://code.visualstudio.com/assets/updates/1_101/live-preview-select-web-elements.png)
 
 As we continue to improve this feature, we have added support for selecting web elements in the [Live Preview extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) as well. Check this out by downloading the extension and spinning up a live server from any HTML file.
 
@@ -289,13 +289,13 @@ You can now specify the menu style that is used for the menu bar and context men
 
 We now support the native window context menu when you right-click on the application icon in the custom title bar.
 
-![Screenshot of the native window context menu over the custom title bar.](images/1_101/linux-os-title-menu.png)
+![Screenshot of the native window context menu over the custom title bar.](https://code.visualstudio.com/assets/updates/1_101/linux-os-title-menu.png)
 
 ### Process explorer web support
 
 The process explorer was converted to use the floating window infrastructure that we have in the workbench for editor windows. As a result, this also means that we now support the process explorer in web when connected to a remote (for example in Codespaces).
 
-![Screenshot of the VS Code process explorer in a floating window.](images/1_101/process-explorer.png)
+![Screenshot of the VS Code process explorer in a floating window.](https://code.visualstudio.com/assets/updates/1_101/process-explorer.png)
 
 ### Windows shell environment discovery
 
@@ -305,7 +305,7 @@ We have now implemented shell environment discovery for PowerShell on Windows. T
 
 Installed extensions now show a warning indicator when they're no longer available in the Marketplace, helping you identify potentially problematic extensions that were unpublished or removed.
 
-![Screenshot of an extension with a warning indicator and a message indicating it's no longer available in the Marketplace.](images/1_101/pulled-extension.png)
+![Screenshot of an extension with a warning indicator and a message indicating it's no longer available in the Marketplace.](https://code.visualstudio.com/assets/updates/1_101/pulled-extension.png)
 
 ### Settings search suggestions (Preview)
 
@@ -317,7 +317,7 @@ To see the toggle, enable the setting and reload VS Code. We are also in the pro
 
 For the next milestone, we are also considering removing the toggle and changing the experimental setting to one that controls when to directly append the slower AI search results to the end of the list.
 
-<video src="images/1_101/settings-editor-ai-search.mp4" title="Video showing AI search in the Settings editor that finds the `editor.fontSize` setting when you search 'increase text size'." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/settings-editor-ai-search.mp4" title="Video showing AI search in the Settings editor that finds the `editor.fontSize` setting when you search 'increase text size'." autoplay loop controls muted></video>
 
 ### Search keyword suggestions (Preview)
 
@@ -355,7 +355,7 @@ See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/EditContext_
 
 Last month, we introduced support for next edit suggestions to automatically suggest adding missing import statements for TypeScript and JavaScript. In this release, we've improved the accuracy and reliability of these suggestions and expanded support to Python files as well.
 
-![Screenshot showing NES suggesting an import statement.](images/1_100/nes-import.png)
+![Screenshot showing NES suggesting an import statement.](https://code.visualstudio.com/assets/updates/1_100/nes-import.png)
 
 NES is enabled for all VS Code Insiders users, and it will progressively be enabled by default for Stable users during June. You can enable NES yourself via its setting at any time.
 
@@ -373,7 +373,7 @@ With follow mode, the Notebook view will automatically scroll to the cell that i
 
 Once the agent has used the run cell tool, the Notebook toolbar is updated with a pin icon, indicating the state of follow mode. You can toggle the behavior mid agent response without changing the base setting value, allowing you to follow the work of the agent in real-time, and toggle it off when you want to review a specific portion of code while the agent continues to iterate. When you wish to follow again, simply toggle the mode, and join at the next execution.
 
-<video src="images/1_101/notebook-follow-mode.mp4" title="Video that shows the AI executing cells in a notebook with follow mode enabled. When the cell is run, the notebook scrolls to reveal it." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/notebook-follow-mode.mp4" title="Video that shows the AI executing cells in a notebook with follow mode enabled. When the cell is run, the notebook scrolls to reveal it." autoplay loop controls muted></video>
 
 ### Notebook tools for agent mode
 
@@ -384,7 +384,7 @@ This involves walking you through the process of creating a Virtual Environment 
 
 This tool ensures the LLM can perform operations on the Notebook such as running cells with minimal user interaction, thereby improving the overall user experience in agent mode.
 
-<video src="images/1_101/notebook-tools.mp4" title="Video that shows the AI configuring the Python environment, installing dependencies and finally running notebook cells." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/notebook-tools.mp4" title="Video that shows the AI configuring the Python environment, installing dependencies and finally running notebook cells." autoplay loop controls muted></video>
 
 #### Long running agent workflows
 
@@ -394,7 +394,7 @@ The agent has access to an internal Notebook Summary tool to help keep it on tra
 
 A snippet of the code is shown from a notebook cell when the agent requests confirmation to run that cell. The cell links in the Chat view now also enable you to directly navigate to cells in the notebook.
 
-<video src="images/1_101/run-cell-confirmation.mp4" title="Video showing the AI asking to run a cell including a link to the cell and a preview of its content." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/run-cell-confirmation.mp4" title="Video showing the AI asking to run a cell including a link to the cell and a preview of its content." autoplay loop controls muted></video>
 
 ## Source Control
 
@@ -408,13 +408,13 @@ We have added the following features to the extension:
 * **Copilot on My Behalf** PR query: quickly see all pull requests that Copilot is working on for you.
 * **PR view**: see the status of the Copilot coding agent and open the session details in the browser.
 
-![Screenshot showing the GitHub Pull Requests view, highlighting the assign to Copilot action, and the PR query for work assigned to Copilot.](images/1_101/github-pull-request-coding-agent.png)
+![Screenshot showing the GitHub Pull Requests view, highlighting the assign to Copilot action, and the PR query for work assigned to Copilot.](https://code.visualstudio.com/assets/updates/1_101/github-pull-request-coding-agent.png)
 
 ### Source control history item details
 
 Upon popular demand, selecting an item in the Source Control Graph view now reveals the resources of that history item. You can choose between a tree view or list view representation from the `...` menu.
 
-<video src="images/1_101/source-control-graph-view-resources.mp4" title="Video showing the Source Control Graph view, displaying the files for a commit and showing a diff editor of its changes." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/source-control-graph-view-resources.mp4" title="Video showing the Source Control Graph view, displaying the files for a commit and showing a diff editor of its changes." autoplay loop controls muted></video>
 
 To open all resources of a history item in the multi-file diff editor, use the **Open Changes** action on hover. Selecting a particular resource from the Graph view opens a diff editor only for that resource. Select the **Open File** action to open the file for that particular version.
 
@@ -422,7 +422,7 @@ To open all resources of a history item in the multi-file diff editor, use the *
 
 You can now add a source control history item as context to a chat request. This can be useful when you want to provide the contents of a specific commit or pull request as context for your chat prompt.
 
-![Screenshot of the Chat view input box that has a history item added as context.](images/1_101/chat-context-source-control-commit.png)
+![Screenshot of the Chat view input box that has a history item added as context.](https://code.visualstudio.com/assets/updates/1_101/chat-context-source-control-commit.png)
 
 To add a history item to chat, use **Add Context** > **Source Control** from the Chat view and then choose a particular history item. Alternatively, right-click the history item in the source control graph and then select **Copilot** > **Add History Item to Chat** from the context menu.
 
@@ -434,7 +434,7 @@ Task `runOptions` now has an `instancePolicy` property, which determines what ha
 
 Options include `prompt` (default), `silent`, `terminateNewest`, `terminateOldest`, and `warn`.
 
-![Screenshot showing an `instancePolicy` being configured in a `tasks.json` file and displays the options with prompt as the default value.](images/1_101/instancePolicy.png)
+![Screenshot showing an `instancePolicy` being configured in a `tasks.json` file and displays the options with prompt as the default value.](https://code.visualstudio.com/assets/updates/1_101/instancePolicy.png)
 
 ## Terminal
 
@@ -444,7 +444,7 @@ Language server completions are now available in the terminal for interactive Py
 This brings the same language completions you receive in the editor now inside the terminal.
 We are starting with support for Python via Pylance, with plans to expand to more languages in the future.
 
-<video src="images/1_101/lsp_completions.mp4" title="Video that shows completions from LSP in REPL in the terminal." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/lsp_completions.mp4" title="Video that shows completions from LSP in REPL in the terminal." autoplay loop controls muted></video>
 
 To try it out, ensure the following settings are enabled:
 
@@ -477,7 +477,7 @@ The “Configure Python Environment” tool ensures that the Python Environment 
 
 Tools that were previously introduced in the [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) have been migrated to the Python extension, thereby making these tools available to all users with the Python extension installed.
 
-<video src="images/1_101/python-tools.mp4" title="Video demoing the Python tools called implicitly by the model in agent mode." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_101/python-tools.mp4" title="Video demoing the Python tools called implicitly by the model in agent mode." autoplay loop controls muted></video>
 
 #### Create a project from a template
 

--- a/docs/release-notes/v1_101.md
+++ b/docs/release-notes/v1_101.md
@@ -1,0 +1,739 @@
+---
+Order: 110
+TOCTitle: May 2025
+PageTitle: Visual Studio Code May 2025
+MetaDescription: Learn what is new in the Visual Studio Code May 2025 Release (1.101)
+MetaSocialImage: 1_101/release-highlights.png
+Date: 2025-06-12
+DownloadVersion: 1.101.0
+---
+# May 2025 (version 1.101)
+
+_Release date: June 12, 2025_
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the May 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* **MCP**
+  * Expand your agent coding flow with support for prompts, resources, and sampling ([Show more](#mcp-support-for-prompts)).
+  * Access MCP servers that require authentication ([Show more](#mcp-support-for-auth)).
+  * Debug MCP servers with development mode ([Show more](#mcp-development-mode)).
+  * Publish MCP servers from an extension ([Show more](#mcp-extension-apis)).
+
+* **Chat**
+  * Group and manage related tools by combining them in a tool set ([Show more](#chat-tool-sets)).
+
+* **Source Control**
+  * View files in Source Control Graph view ([Show more](#source-control-history-item-details)).
+  * Assign and track work for GitHub Copilot Coding Agent from within VS Code ([Show more](#copilot-coding-agent-integration)).
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## Chat
+
+### Chat tool sets
+
+VS Code now enables you to define tool sets, either through a proposed API or through the UI. A tool set is a collection of different tools that can be used just like individual tools. Tool sets make it easier to group related tools together, and quickly enable or disable them in agent mode. For instance, the tool set below is for managing GitHub notifications (using the [GitHub MCP server](https://github.com/github/github-mcp-server)).
+
+```json
+{
+  "gh-news": {
+    "tools": [
+      "list_notifications",
+      "dismiss_notification",
+      "get_notification_details",
+    ],
+    "description": "Manage GH notification",
+    "icon": "github-project"
+  }
+}
+```
+
+To create a tool set, run the **Configure Tool Sets** > **Create new tool sets file** command from the Command Palette. You can then select the tools you want to include in the tool set, and provide a description and icon.
+
+To use a tool set in a chat query, reference it by #-mentioning its name, like `#gh-news`. You can also choose it from the tool picker in the chat input box.
+
+![Screenshot of the Chat view showing a query about unread notifications, using the 'gh-news' tool set highlighted in both the chat interface and a JSON configuration file which defines this tool set.](images/1_101/tool-set-gh.png)
+
+Learn more about [tools sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) in our documentation.
+
+### MCP support for prompts
+
+VS Code's Model Context Protocol support now includes prompt support. Prompts can be defined by MCP servers to generate reusable snippets or tasks for the language model. Prompts are accessible as slash `/` commands in chat, in the format `/mcp.servername.promptname`. You can enter plain text or include command output in prompt variables, and we also support completions when servers provide it.
+
+The following example shows how we generate a prompt using AI, save it using the [Gistpad MCP server](https://github.com/lostintangent/gistpad-mcp), and then use it to generate a changelog entry:
+
+<video src="images/1_101/mcp-prompts.mp4" autoplay loop controls muted></video>
+
+### MCP support for resources
+
+VS Code's Model Context Protocol support now includes resource support, which includes support for resource templates. It is available in several places:
+
+1. Resources returned from MCP tool calls are available to the model and can be saved in chat, either via a **Save** button or by dragging the resource onto the Explorer view.
+1. Resources can be attached as context via the **Add Context...** button in chat, then selecting **MCP Resources...**.
+1. You can browse and view resources across servers using the **MCP: Browse Resources** command or for a server by its entry in the **MCP: List Servers** command.
+
+Here's an example of attaching resources from the [Gistpad MCP server](https://github.com/lostintangent/gistpad-mcp) to chat:
+
+<video src="images/1_101/mcp-resources.mp4" autoplay loop controls muted></video>
+
+### MCP support for sampling (Experimental)
+
+VS Code's Model Context Protocol support now includes sampling, which allows MCP servers to make requests back to the model. You'll be asked to confirm the first time an MCP server makes a sampling request, and you can configure the models the MCP server has access to as well as see a request log by selecting the server in **MCP: List Servers.**
+
+<video src="images/1_101/mcp-sampling.mp4" autoplay loop controls muted></video>
+
+Sampling support is still preliminary and we plan to expand and improve it in future iterations.
+
+### MCP support for auth
+
+VS Code now supports MCP servers that require authentication, allowing you to interact with an MCP server that operates on behalf of your user account for that service.
+
+This feature implements the MCP authorization specification for clients, and supports both:
+
+* [2025-3-26 spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization), where the MCP server behaves as an authorization server.
+* [Draft spec](https://modelcontextprotocol.io/specification/draft/basic/authorization), where the MCP server behaves as a resource server (this is expected to be finalized any day now).
+
+If the MCP server implements the draft spec and leverages GitHub or Entra as the auth server, you can manage which MCP servers have access to your account:
+
+![Screenshot of the "Manage Trusted MCP Servers" option in the account menu.](images/1_101/manage-trusted-mcp.png)
+
+![Screenshot of the "Manage Trusted MCP Servers" Quick Pick.](images/1_101/manage-trusted-mcp-quick-pick.png)
+
+You can also manage which account that server should use (via the gear button in the previous quick pick):
+
+![Screenshot of the "Account Preference" Quick Pick.](images/1_101/account-pref-quick-pick.png)
+
+For other MCP servers that rely on dynamic client registration, we include the auth state in the same place as everything else, for example with Linear:
+
+![Screenshot of Linear appearing in the account menu.](images/1_101/linear-account-menu.png)
+
+There you can also sign out. For these we support not only the code authorization flow but also the device code flow should your authorization server support it.
+
+We have also introduced the command `Authentication: Remove Dynamic Authentication Providers` that allows you to clean up any of these dynamic client registrations. This will throw away the client id issued to VS Code and all data associated with this authentication provider.
+
+Remember, you can use the **MCP: Add Server...** command to add MCP servers. This is the same entry point for servers with authentication.
+
+### MCP development mode
+
+You can enable _development mode_ for MCP servers by adding a `dev` key to the server config. This is an object with two properties:
+
+* `watch`: A file glob pattern to watch for files change that will restart the MCP server.
+* `debug`: Enables you to set up a debugger with the MCP server. Currently, we only support debugging Node.js and Python servers launched with `node` and `python` respectively.
+
+**.vscode/mcp.json**
+
+```diff
+{
+  "servers": {
+    "gistpad": {
+      "command": "node",
+      "args": ["build/index.js"],
++     "dev": {
++       "watch": "build/**/*.js",
++       "debug": { "type": "node" }
++     },
+```
+
+### Chat UX improvements
+
+We're continuously working to improve the chat user experience in VS Code based on your feedback. One such feedback was that it can be difficult to distinguish between user messages and AI responses in the chat. To address this, we've made the appearance of user messages more distinct.
+
+Undoing previous requests is now also more visible - just hover over a request and select the `X` button to undo that request and any following requests. Or even quicker, use the `kb(workbench.action.chat.undoEdits)` keyboard shortcut!
+
+Finally, attachments from the chat input box are now more navigable.
+
+<video src="images/1_101/new-chat-ui-ux.mp4" title="A video of the new chat UI/UX where a request is removed to undo edits since that point." autoplay loop controls muted></video>
+
+Learn more about using [chat in VS Code](https://code.visualstudio.com/docs/copilot/chat/copilot-chat) in our documentation.
+
+### Apply edits more efficiently
+
+When editing files, VS Code can take two different approaches: it either rewrites the file top to bottom or it makes multiple, smaller edits. Both approaches differ, for example the former can be slower for large files and intermediate states do often not compile successfully. Because of that the UI adopts and conditionally disables auto-save and squiggles, but only when needed.
+
+We have also aligned the keybindings for the **Keep** and **Undo** commands. Keeping and undoing individual changes is now done with `kb(chatEditor.action.acceptHunk)` and `kb(chatEditor.action.undoHunk)`. In the same spirit, we have also aligned the keybinding for keeping and undoing all changes in a file, they are now `kb(chatEditor.action.accept)` and `kb(chatEditor.action.reject)`. This is not just for alignment but also removes prior conflicts with popular editing commands (like **Delete All Left**).
+
+### Implicit context
+
+We've streamlined and simplified the way that adding your current file as context works in chat. Many people found the "eyeball toggle" that we previously had to be a bit clunky. Now, your current file is offered as a suggested context item. Just select the item to add or remove it from chat context. From prompt input field, press `Shift+Tab, Enter` to quickly do this with the keyboard.
+
+Additionally, in agent mode, we include a hint about your current editor. This doesn't include the contents of the file, just the file name and cursor position. The agent can then use the tools it has to read the contents of the file on its own, if it thinks that it's relevant to your query.
+
+<video src="images/1_101/implicit-context-flow.mp4" title="A video of the current open editor being suggest as implicit context and added as an attachment." autoplay loop controls muted></video>
+
+Learn more about [adding context in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context) in our documentation.
+
+### Fix task configuration errors
+
+Configuring tasks and problem matchers can be tricky. Use the **Fix with Github Copilot** action that is offered when there are errors in your task configuration to address them quickly and efficiently.
+
+### Custom chat modes (Preview)
+
+By default, the chat view supports three built-in chat modes: Ask, Edit and Agent. Each chat mode comes with a set of base instructions that describe how the LLM should handle a request, as well as the list of tools that can be used for that.
+
+You can now define your own custom chat modes, which can be used in the Chat view. Custom chat modes allow you to tailor the behavior of chat and specify which tools are available in that mode. This is particularly useful for specialized workflows or when you want to provide specific instructions to the LLM. For example, you can create a custom chat mode for planning new features, which only has read-only access to your codebase.
+
+To define and use a custom chat mode, follow these steps:
+
+1. Define a custom mode by using the **Chat: Configure Chat Modes** command from the Command Palette.
+1. Provide the instructions and available tools for your custom chat mode in the `*.chatprompt.md` file that is created.
+1. In the Chat view, select the chat mode from the chat mode dropdown list.
+1. Submit your chat prompt and
+
+![Screenshot of the custom chat mode selected in the Chat view.](images/1_101/custom-chat-mode-view.png)
+
+The following example shows a custom "Planning" chat mode:
+
+```md
+---
+description: Generate an implementation plan for new features or refactoring existing code.
+tools: ['codebase', 'fetch', 'findTestFiles', 'githubRepo', 'search', 'usages']
+---
+# Planning mode instructions
+You are in planning mode. Your task is to generate an implementation plan for a new feature or for refactoring existing code.
+Don't make any code edits, just generate a plan.
+
+The plan consists of a Markdown document that describes the implementation plan, including the following sections:
+
+* Overview: A brief description of the feature or refactoring task.
+* Requirements: A list of requirements for the feature or refactoring task.
+* Implementation Steps: A detailed list of steps to implement the feature or refactoring task.
+* Testing: A list of tests that need to be implemented to verify the feature or refactoring task.
+```
+
+> **Note**: The feature is work in progress, but please try it out! Please follow the latest progress in VS Code Insiders and let us know what's not working or is missing.
+
+### Task diagnostic awareness
+
+When the chat agent runs a task, it is now aware of any errors or warnings identified by problem matchers. This diagnostic context allows the chat agent to respond more intelligently to issues as they arise.
+
+### Terminal cwd context
+
+When agent mode has opened a terminal and shell integration is active, the chat agent is aware of the current working directory (cwd). This enables more accurate and context-aware command support.
+
+### Floating window improvements
+
+When you move a chat session into a floating window, there are now two new actions available in the title bar:
+
+* Dock the chat back into the VS Code window where it came from
+* Start a new chat session in the floating window.
+
+![Screenshot of the Chat view in a floating window, highlighting the Dock and New Chat buttons in the title bar.](images/1_101/chat-floating.png)
+
+### Fetch tool confirmation
+
+The fetch tool enables you to pull information from a web page. We have added a warning message to the confirmation to inform you about potential prompt injection.
+
+![Screenshot of the fetch tool with a warning about prompt injection.](images/1_101/fetch-warning.png)
+
+### Customize more built-in tools
+
+It's now possible to enable or disable all built-in tools in agent mode or your custom mode. For example, disable `editFiles` to disallow agent mode to edit files directly, or `runCommands` for running terminal commands.
+
+In agent mode, select the **Configure Tools** button to open the tool picker, and select your desired set of tools.
+
+![Screenshot of the tool picker, showing the "editFiles" tool set item cleared.](images/1_101/built-in-toolsets.png)
+
+Some of the entries in this menu represent tool sets that group multiple tools. For example, we give the model multiple tools to edit or create text files and notebooks, which may also differ by model family, and `editFiles` groups all of these.
+
+### Send elements to chat (Experimental)
+
+Last milestone, we added a [new experimental feature](https://code.visualstudio.com/updates/v1_100#_select-and-attach-ui-elements-to-chat-experimental) where you could open the Simple Browser and select web elements to add to chat from the embedded browser.
+
+![Screenshot showing the Live Preview extension, highlighting the overlay controls to select web elements from the web page.](images/1_101/live-preview-select-web-elements.png)
+
+As we continue to improve this feature, we have added support for selecting web elements in the [Live Preview extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server) as well. Check this out by downloading the extension and spinning up a live server from any HTML file.
+
+## Accessibility
+
+### User action required sound
+
+We’ve added an accessibility signal to indicate when chat requires user action. This is opt-in as we fine tune the sound. You can configure this behavior with `setting(accessibility.signals.chatUserActionRequired)`.
+
+### New code action sounds
+
+We’ve introduced distinct sounds for:
+
+* when a code action is triggered: `setting(accessibility.signals.codeActionTriggered)`
+* when a code action is applied: `setting(accessibility.signals.codeActionApplied)`
+
+### Agent mode accessibility improvements
+
+We now include rich information about confirmation dialogs in the accessible view, covering past tool runs, the current tool run, and any pending confirmations. This includes the inputs that will be used.
+
+When a confirmation dialog appears in a response, the action’s title is now included in the ARIA label of the corresponding code block, the response’s ARIA label, and the live alert to provide better context for screen reader users.
+
+## Editor Experience
+
+### Find as you type
+
+**Setting**: `setting(editor.find.findOnType:true)`
+
+Find-as-you-type has been the default behavior of the Find control, but now you can control whether to keep it that way or disable it so that it will only perform the search after hitting enter.
+
+### Custom menus with native window title bar
+
+**Setting**: `setting(window.menuStyle)`
+
+You can now specify the menu style that is used for the menu bar and context menus on Windows and Linux, and for context menus on macOS by using the `setting(window.menuStyle)` setting:
+
+* `native`: rendered by the OS
+* `custom`: rendered by VS Code
+* `inherit`: matches the style of the title bar as set by `setting(window.titleBarStyle)` (lets you use a native title bar with a custom menu bar and context menus).
+
+### Linux native window context menu
+
+We now support the native window context menu when you right-click on the application icon in the custom title bar.
+
+![Screenshot of the native window context menu over the custom title bar.](images/1_101/linux-os-title-menu.png)
+
+### Process explorer web support
+
+The process explorer was converted to use the floating window infrastructure that we have in the workbench for editor windows. As a result, this also means that we now support the process explorer in web when connected to a remote (for example in Codespaces).
+
+![Screenshot of the VS Code process explorer in a floating window.](images/1_101/process-explorer.png)
+
+### Windows shell environment discovery
+
+We have now implemented shell environment discovery for PowerShell on Windows. This means that VS Code inherits any environment configured in the PowerShell profiles, such as the PATH updates that Node.js configures through various version managers.
+
+### Unpublished extension warning
+
+Installed extensions now show a warning indicator when they're no longer available in the Marketplace, helping you identify potentially problematic extensions that were unpublished or removed.
+
+![Screenshot of an extension with a warning indicator and a message indicating it's no longer available in the Marketplace.](images/1_101/pulled-extension.png)
+
+### Settings search suggestions (Preview)
+
+**Setting**: `setting(workbench.settings.showAISearchToggle:true)`
+
+This milestone, we added a toggle to the Settings editor that starts an AI search to find semantically similar results instead of results that are based on string matching. For example, the AI search finds the `editor.fontSize` setting when you search for "increase text size".
+
+To see the toggle, enable the setting and reload VS Code. We are also in the process of identifying and fixing some of the less accurate settings search results, and we welcome feedback on when a natural language query did not find an expected setting.
+
+For the next milestone, we are also considering removing the toggle and changing the experimental setting to one that controls when to directly append the slower AI search results to the end of the list.
+
+<video src="images/1_101/settings-editor-ai-search.mp4" title="Video showing AI search in the Settings editor that finds the `editor.fontSize` setting when you search 'increase text size'." autoplay loop controls muted></video>
+
+### Search keyword suggestions (Preview)
+
+**Setting**: `setting(search.searchView.keywordSuggestions)`
+
+Last milestone, we introduced [keyword suggestions](https://code.visualstudio.com/updates/v1_100#_semantic-text-search-with-keyword-suggestions-experimental) in the Search view to help you find relevant results faster. We have now significantly improved the performance of the suggestions, so you will see the results ~5x faster than before.
+
+We have also moved the setting from the Chat extension into VS Code core, and renamed it from `github.copilot.chat.search.keywordSuggestions` to `setting(search.searchView.keywordSuggestions)`.
+
+### Semantic search behavior options (Preview)
+
+**Setting**: `setting(search.searchView.semanticSearchBehavior)`
+
+With semantic search in the Search view, you can get results based on the meaning of your query rather than just matching text. This is particularly useful if you don't know the exact terms to search for.
+
+By default, semantic search is only run when you explicitly request it. We have now added a setting to control when you want semantic search to be triggered:
+
+* `manual` (default): only run semantic search when triggered manually from the UI (`kb(search.action.searchWithAI)`)
+* `runOnEmpty`: run semantic search automatically when the text search returns no results
+* `auto`: always run semantic search in parallel with text search for every search query
+
+### Edit Context
+
+**Setting**: `setting(editor.experimentalEditContextEnabled)`
+
+We have enabled the `setting(editor.experimentalEditContextEnabled)` setting by default on Stable. This means that the input of the editor is now powered by the EditContext API. This fixes numerous bugs, especially in relation to the IME experience, and going forward will pave the way for a more versatile and robust input experience within the editor.
+
+See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/EditContext_API) for more detail on the EditContext API.
+
+## Code Editing
+
+### NES import suggestions
+
+**Setting**: `setting(github.copilot.nextEditSuggestions.fixes)`
+
+Last month, we introduced support for next edit suggestions to automatically suggest adding missing import statements for TypeScript and JavaScript. In this release, we've improved the accuracy and reliability of these suggestions and expanded support to Python files as well.
+
+![Screenshot showing NES suggesting an import statement.](images/1_100/nes-import.png)
+
+NES is enabled for all VS Code Insiders users, and it will progressively be enabled by default for Stable users during June. You can enable NES yourself via its setting at any time.
+
+### NES acceptance flow
+
+Accepting next edit suggestions is now more seamless with improved keyboard navigation. Once you accept a suggestion, you can continue accepting subsequent suggestions with a single `kbstyle(Tab)` press, as long as you haven't started typing again. Once you start typing, press `kbstyle(Tab)` to first move the cursor to the next suggestion before you can accept it.
+
+## Notebooks
+
+### Follow mode for agent cell execution
+
+**Setting**: `setting(github.copilot.chat.notebook.followCellExecution.enabled)`
+
+With follow mode, the Notebook view will automatically scroll to the cell that is currently being executed by the agent. Use the `setting(github.copilot.chat.notebook.followCellExecution.enabled)` setting to enable or disable follow mode for agent cell execution in Jupyter Notebooks.
+
+Once the agent has used the run cell tool, the Notebook toolbar is updated with a pin icon, indicating the state of follow mode. You can toggle the behavior mid agent response without changing the base setting value, allowing you to follow the work of the agent in real-time, and toggle it off when you want to review a specific portion of code while the agent continues to iterate. When you wish to follow again, simply toggle the mode, and join at the next execution.
+
+<video src="images/1_101/notebook-follow-mode.mp4" title="Video that shows the AI executing cells in a notebook with follow mode enabled. When the cell is run, the notebook scrolls to reveal it." autoplay loop controls muted></video>
+
+### Notebook tools for agent mode
+
+#### Configure notebook
+
+The [Jupyter extension](https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter) contributes tools for configuring the Kernel of a Jupyter Notebook. This tool ensures that a Kernel is selected and is ready for use in the Notebook.
+This involves walking you through the process of creating a Virtual Environment if required (the recommended approach), or prompting you to select an existing Python environment.
+
+This tool ensures the LLM can perform operations on the Notebook such as running cells with minimal user interaction, thereby improving the overall user experience in agent mode.
+
+<video src="images/1_101/notebook-tools.mp4" title="Video that shows the AI configuring the Python environment, installing dependencies and finally running notebook cells." autoplay loop controls muted></video>
+
+#### Long running agent workflows
+
+The agent has access to an internal Notebook Summary tool to help keep it on track with an accurate context. That summary is also included when summarizing the conversation history when the context gets too large to keep the agent going through complex operations.
+
+#### Cell preview in run confirmation
+
+A snippet of the code is shown from a notebook cell when the agent requests confirmation to run that cell. The cell links in the Chat view now also enable you to directly navigate to cells in the notebook.
+
+<video src="images/1_101/run-cell-confirmation.mp4" title="Video showing the AI asking to run a cell including a link to the cell and a preview of its content." autoplay loop controls muted></video>
+
+## Source Control
+
+### Copilot coding agent integration
+
+With Copilot coding agent, GitHub Copilot can work independently in the background to complete tasks, just like a human developer. We have expanded the GitHub Pull Requests extension to make it easier to assign and track tasks for the agent from within VS Code.
+
+We have added the following features to the extension:
+
+* **Assign to Copilot**: assign a pull request or issue to Copilot from the issue or PR view in VS Code
+* **Copilot on My Behalf** PR query: quickly see all pull requests that Copilot is working on for you.
+* **PR view**: see the status of the Copilot coding agent and open the session details in the browser.
+
+![Screenshot showing the GitHub Pull Requests view, highlighting the assign to Copilot action, and the PR query for work assigned to Copilot.](images/1_101/github-pull-request-coding-agent.png)
+
+### Source control history item details
+
+Upon popular demand, selecting an item in the Source Control Graph view now reveals the resources of that history item. You can choose between a tree view or list view representation from the `...` menu.
+
+<video src="images/1_101/source-control-graph-view-resources.mp4" title="Video showing the Source Control Graph view, displaying the files for a commit and showing a diff editor of its changes." autoplay loop controls muted></video>
+
+To open all resources of a history item in the multi-file diff editor, use the **Open Changes** action on hover. Selecting a particular resource from the Graph view opens a diff editor only for that resource. Select the **Open File** action to open the file for that particular version.
+
+### Add history item to chat context
+
+You can now add a source control history item as context to a chat request. This can be useful when you want to provide the contents of a specific commit or pull request as context for your chat prompt.
+
+![Screenshot of the Chat view input box that has a history item added as context.](images/1_101/chat-context-source-control-commit.png)
+
+To add a history item to chat, use **Add Context** > **Source Control** from the Chat view and then choose a particular history item. Alternatively, right-click the history item in the source control graph and then select **Copilot** > **Add History Item to Chat** from the context menu.
+
+## Tasks
+
+### Instance policy
+
+Task `runOptions` now has an `instancePolicy` property, which determines what happens when a task has reached its `instanceLimit`.
+
+Options include `prompt` (default), `silent`, `terminateNewest`, `terminateOldest`, and `warn`.
+
+![Screenshot showing an `instancePolicy` being configured in a `tasks.json` file and displays the options with prompt as the default value.](images/1_101/instancePolicy.png)
+
+## Terminal
+
+### Language server based terminal suggest
+
+Language server completions are now available in the terminal for interactive Python REPL sessions.
+This brings the same language completions you receive in the editor now inside the terminal.
+We are starting with support for Python via Pylance, with plans to expand to more languages in the future.
+
+<video src="images/1_101/lsp_completions.mp4" title="Video that shows completions from LSP in REPL in the terminal." autoplay loop controls muted></video>
+
+To try it out, ensure the following settings are enabled:
+
+* `setting(terminal.integrated.shellIntegration.enabled:true)`
+* `setting(python.terminal.shellIntegration.enabled:true)`
+* `setting(terminal.integrated.suggest.enabled:true)`
+* `setting(python.analysis.supportAllPythonDocuments:true)`
+
+## Remote Development
+
+The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+
+Highlights include:
+
+* SSH pre-connection script
+* Remote Explorer improvements
+
+You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_101.md).
+
+
+## Contributions to extensions
+
+### Python
+
+#### Python chat tools
+
+The [Python Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) now includes the following chat tools: “Get information for a Python Environment”, “Get executable information for a Python Environment”, “Install Python Package” and “Configure Python Environment”. You can either directly reference them in your prompt by adding `#getPythonEnvironmentInfo` `#installPythonPackage`, or agent mode will automatically call the tool as applicable. These tools seamlessly detect appropriate environment information, based on file or workspace context, and handle package installation with accurate environment resolution.
+
+The “Configure Python Environment” tool ensures that the Python Environment is set up correctly for the workspace. This includes creating a Virtual Environment if needed, and selecting that as the active Python Environment for the workspace.
+
+Tools that were previously introduced in the [Python Environments](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension (preview) have been migrated to the Python extension, thereby making these tools available to all users with the Python extension installed.
+
+<video src="images/1_101/python-tools.mp4" title="Video demoing the Python tools called implicitly by the model in agent mode." autoplay loop controls muted></video>
+
+#### Create a project from a template
+
+The [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) now supports project creation for Python packages and basic scripts, allowing you to bypass scaffolding and get coding more quickly. Use the command **Python Envs: Create Project from Template** to select whether you want to create a package or a script.
+
+For package creation, you are able to name the package, create a virtual environment, and receive a scaffolded project which includes a tests subfolder, `pyproject.toml`, `dev-requirements.txt`, and boilerplate `__main__.py` and `__init__.py` files.
+
+For scripts, it creates a new python file with the name of your choice and include boilerplate code.
+
+#### PyEnv and Poetry support
+
+We added support for `pyenv` for environment management, and `poetry` for both package and environment management in the [Python Environements](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) extension.
+
+## Extension Authoring
+
+### MCP extension APIs
+
+Extensions can now publish collections of MCP servers. This enables you to bundle MCP servers with your extension or build extensions that dynamically discover MCP servers from other sources. Learn more in our [MCP extension development guide](https://code.visualstudio.com/api/extension-guides/mcp) or by checking out the [MCP extension sample](https://github.com/microsoft/vscode-extension-samples/blob/main/mcp-extension-sample).
+
+### Secret scanning when packaging extensions
+
+VSCE now scans for secrets when packaging your extension. If any potential secrets (for example, API keys, tokens, credentials, or environment variable files like `.env`) are detected in your source files, VSCE displays an error during the packaging process. This helps you avoid accidentally publishing sensitive information to the Marketplace. Make sure to review and address any error before publishing your extension.
+
+If you need to bypass specific checks, you can use the `--allow-package-secrets <secret_type>` or `--allow-package-env-file` flags when running VSCE. These flags let you configure which secret or environment file checks should be skipped during packaging.
+
+### Web Environment detection
+
+⚠️ Breaking change ⚠️
+
+**Setting**: `setting(extensions.supportNodeGlobalNavigator)`
+
+The Node.js extension host is now updated to v22 from v20, as part of our [Electron 35 runtime update](#electron-35-update). This update brings in support for the [`navigator` global object](https://github.com/nodejs/node/commit/b40f0c30743aaecd57071f7be305df43e1083817) in the desktop and remote extension hosts.
+
+This change could introduce a breaking change for extensions that rely on the presence of the `navigator` object to detect the web environment.
+
+To help extension authors migrate, we have created a polyfill for `globalThis.navigator` that is initialized to `undefined`, so your extension continues to work correctly. The polyfill is behind the `setting(extensions.supportNodeGlobalNavigator)` VS Code setting. By default, this setting is disabled and the polyfill is in place. We capture telemetry and log an error (in extension development mode) when your extension tries to access the `navigator` in this way.
+
+In the future, this setting might be enabled by default, so we urge extension authors to migrate their code to be compatible with the new `navigator` global object. Follow these steps to migrate your code:
+
+* Check the extension host log for a `PendingMigrationError` that has error stack originating your extension.
+* Ensure checks like `typeof navigator === 'object'` are migrated to `typeof process === 'object' && process.versions.node` as needed.
+* Enable `setting(extensions.supportNodeGlobalNavigator)`.
+* Verify extension behavior remains unchanged.
+
+## Proposed APIs
+
+### Authentication Providers: Supported Authorization Servers for MCP
+
+Currently only leveraged in [MCP authentication](#mcp-support-for-auth), this API proposal enables your `AuthenticationProvider` to declare the authorization servers that are associated with it.
+
+For example, if you look at the GitHub Authentication Provider, it includes the typical GitHub authorization URL in the authorizationServerGlobs property of [the auth provider contribution](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/github-authentication/package.json#L35-L41):
+
+```json
+{
+  "label": "GitHub",
+  "id": "github",
+  "authorizationServerGlobs": [
+    "https://github.com/login/oauth"
+  ]
+}
+```
+
+This property is used for activation of your extension - if the requested authorization server matches, your extension will be activated.
+
+Additionally, when registering the authentication provider, you MUST include the finalized authorization server url globs. Just like [what GitHub Authentication does here](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/github-authentication/src/github.ts#L144-L149):
+
+```ts
+vscode.authentication.registerAuthenticationProvider(
+ type,
+ this._githubServer.friendlyName,
+ this,
+ {
+  supportsMultipleAccounts: true,
+  supportedAuthorizationServers: [
+   ghesUri ?? vscode.Uri.parse('https://github.com/login/oauth')
+  ]
+ }
+);
+```
+
+For a more complex example, look to Microsoft Authentication. The authorization server depends on the tenant being placed in the path. So for this, we use a wildcard [in the contribution](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/microsoft-authentication/package.json#L33-L39):
+
+```json
+{
+  "label": "Microsoft",
+  "id": "microsoft",
+  "authorizationServerGlobs": [
+    "https://login.microsoftonline.com/*/v2.0"
+  ]
+},
+```
+
+and [in the registration](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/extensions/microsoft-authentication/src/extensionV2.ts#L78-L88):
+
+```ts
+authentication.registerAuthenticationProvider(
+ 'microsoft',
+ 'Microsoft',
+ authProvider,
+ {
+  supportsMultipleAccounts: true,
+  supportedAuthorizationServers: [
+   Uri.parse('https://login.microsoftonline.com/*/v2.0')
+  ]
+ }
+)
+```
+
+Then, when a caller passes in an authorization server URL when it asks for auth, it is passed down to both the `getSessions` and `createSession` functions via the `AuthenticationProviderSessionOptions` that are already present.
+
+As mentioned, this functionality is currently used in MCP support, where we receive the authorization server URL to authenticate with from the MCP server. That URL is then mapped to an auth provider, or if none exists, an auth provider is dynamically created for that auth server.
+
+The full API proposal can be found [in the vscode repo](https://github.com/microsoft/vscode/blob/c9f19f8ad20aa88b1d924c8f7ff8d6b9f6269be8/src/vscode-dts/vscode.proposed.authIssuers.d.ts) and we'd love to hear your feedback in the [GitHub issue](https://github.com/microsoft/vscode/issues/248775)!
+
+## Engineering
+
+### Electron 35 update
+
+In this milestone, we are promoting the Electron 35 update to users on our Stable release. This update comes with Chromium 134.0.6998.205 and Node.js 22.15.1. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+
+### Adopting ESM in a real-world extension
+
+Last milestone, we have announced support for JavaScript-modules (ESM). This enables extensions to use `import` and `export` statements, but currently only when targeting the NodeJS extension host.
+
+This month, we have done a real-world adoption with [GitHub Issue Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-github-issue-notebooks). It is not trivial because this extension can be run in the NodeJS extension host (which supports ESM extensions) and the web worker extension host, which currently does not support ESM extensions. This required a more complex bundler configuration and you might want to take inspiration from its [esbuild-config](https://github.com/microsoft/vscode-github-issue-notebooks/blob/main/esbuild.mjs).
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@alpalla (Alessio Palladino)](https://github.com/alpalla): Add a task instancePolicy to task runOptions  [PR ##117129](https://github.com/microsoft/vscode/pull/117129)
+* [@0xEbrahim (Ebrahim El-Sayed)](https://github.com/0xEbrahim): Fix Typo and Grammar [PR #248814](https://github.com/microsoft/vscode/pull/248814)
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): For editor font choice, if OS is not detected assume Linux [PR #248133](https://github.com/microsoft/vscode/pull/248133)
+* [@adnval (kevin)](https://github.com/adnval): Add installed filter [PR #248055](https://github.com/microsoft/vscode/pull/248055)
+* [@bhack](https://github.com/bhack): Add to new source format and the mandatory signed-by [PR #239390](https://github.com/microsoft/vscode/pull/239390)
+* [@dylanchu](https://github.com/dylanchu): TerminalTaskSystem: Add support for nushell [PR #238440](https://github.com/microsoft/vscode/pull/238440)
+* [@eronnen (Ely Ronnen)](https://github.com/eronnen)
+  * make maximum number of lines in debug console configurable [PR #245915](https://github.com/microsoft/vscode/pull/245915)
+  * Update log tmLanguage from vscode-logfile-highlighter 3.4.1 [PR #249046](https://github.com/microsoft/vscode/pull/249046)
+  * Disassembly View: don't display invalid memory instructions [PR #249779](https://github.com/microsoft/vscode/pull/249779)
+  * disasembly view: handle negative line height returned by debug adapter [PR #250081](https://github.com/microsoft/vscode/pull/250081)
+* [@gabritto (Gabriela Araujo Britto)](https://github.com/gabritto): [typescript-language-features] Add configuration for maximum hover length [PR #248181](https://github.com/microsoft/vscode/pull/248181)
+* [@hickford (M Hickford)](https://github.com/hickford): Highlight active line number correctly regardless of word wrap [PR #240029](https://github.com/microsoft/vscode/pull/240029)
+* [@imfing (Xin)](https://github.com/imfing): fix: conditionally append scope parameter in authorization URL for DynamicAuthProvider [PR #250084](https://github.com/microsoft/vscode/pull/250084)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413)
+  * Fix timeline git requests are not cancelled when switching editors too fast [PR #244335](https://github.com/microsoft/vscode/pull/244335)
+  * Fix vscode.env.onDidChangeShell not firing in the webworker extension host [PR #249824](https://github.com/microsoft/vscode/pull/249824)
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl)
+  * refactor: reuse chat attachment widgets in chat list renderer [PR #248163](https://github.com/microsoft/vscode/pull/248163)
+  * fix: register widgets in chat attachments content part [PR #249054](https://github.com/microsoft/vscode/pull/249054)
+  * fix: set content reference description on historical chat attachments [PR #249112](https://github.com/microsoft/vscode/pull/249112)
+  * fix: use markdown string for MCP tool confirmation [PR #249497](https://github.com/microsoft/vscode/pull/249497)
+  * fix: allow Continue On if edit session identity provider mutates edit session payload [PR #250057](https://github.com/microsoft/vscode/pull/250057)
+* [@JoyceGu (Joyce Gu)](https://github.com/JoyceGu): Joycegu/add genai packages 05222025 [PR #249589](https://github.com/microsoft/vscode/pull/249589)
+* [@mawosoft (Matthias Wolf)](https://github.com/mawosoft): Fix PowerShell shell integration when strict mode is enabled. [PR #248625](https://github.com/microsoft/vscode/pull/248625)
+* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): fix(search): fix expand all not working [PR #248207](https://github.com/microsoft/vscode/pull/248207)
+* [@nojaf (Florian Verdonck)](https://github.com/nojaf): Close all unused ports command [PR #244245](https://github.com/microsoft/vscode/pull/244245)
+* [@nomike (nomike)](https://github.com/nomike): Enhance GithHub publishing logic to handle renamed repositories [PR #245024](https://github.com/microsoft/vscode/pull/245024)
+* [@Parasaran-Python (Parasaran)](https://github.com/Parasaran-Python): Fix #248222 | Regex changes to allow multiple leading dots in relative paths [PR #248340](https://github.com/microsoft/vscode/pull/248340)
+* [@pelmers-db (Peter Elmers)](https://github.com/pelmers-db): Fix cancellation logic in Picker onDidChangeValue handler (fixes #247945) [PR #247946](https://github.com/microsoft/vscode/pull/247946)
+* [@randy3k (Randy Lai)](https://github.com/randy3k): Update upstream repo for R syntax [PR #248880](https://github.com/microsoft/vscode/pull/248880)
+* [@rbuckton (Ron Buckton)](https://github.com/rbuckton): Add casts to silence breaks due to updated DOM types [PR #248346](https://github.com/microsoft/vscode/pull/248346)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): Support `@builtin @disabled` [PR #235885](https://github.com/microsoft/vscode/pull/235885)
+* [@xzakharov (Oleksandr Zakharov)](https://github.com/xzakharov): fix(devcontainer): bump rust feature to fix container build [PR #250430](https://github.com/microsoft/vscode/pull/250430)
+* [@y0sh1ne (y0sh1ne)](https://github.com/y0sh1ne): Fix Copy Message with multiple selections (#247927) [PR #248172](https://github.com/microsoft/vscode/pull/248172)
+
+Contributions to `vscode-copilot-release`:
+
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): chore: update bug report template [PR #9702](https://github.com/microsoft/vscode-copilot-release/pull/9702)
+
+Contributions to `vscode-css-languageservice`:
+
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): Add basic media query auto complete support [PR #443](https://github.com/microsoft/vscode-css-languageservice/pull/443)
+* [@rgant (J Rob Gant)](https://github.com/rgant)
+  * feature:(#305) Add support for `oklab` and `oklch` color functions [PR #436](https://github.com/microsoft/vscode-css-languageservice/pull/436)
+  * Remove extra characters [PR #437](https://github.com/microsoft/vscode-css-languageservice/pull/437)
+  * refactor: Extend the base tsconfig.json [PR #438](https://github.com/microsoft/vscode-css-languageservice/pull/438)
+
+Contributions to `vscode-custom-data`:
+
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): Add media query support [PR #118](https://github.com/microsoft/vscode-custom-data/pull/118)
+
+Contributions to `vscode-eslint`:
+
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs)
+  * Add `eslint.codeActionsOnSave.options` [PR #1999](https://github.com/microsoft/vscode-eslint/pull/1999)
+  * Add all possible flat configuration extensions [PR #2017](https://github.com/microsoft/vscode-eslint/pull/2017)
+
+Contributions to `vscode-generator-code`:
+
+* [@SamB (Samuel Bronson)](https://github.com/SamB): Do not link to top of vscode docs [PR #518](https://github.com/microsoft/vscode-generator-code/pull/518)
+
+Contributions to `vscode-js-debug`:
+
+* [@kdy1 (Donny/강동윤)](https://github.com/kdy1): chore: Fix default url for turbopack [PR #2223](https://github.com/microsoft/vscode-js-debug/pull/2223)
+* [@mikaelwaltersson (Mikael Waltersson)](https://github.com/mikaelwaltersson): Fix bug where the WasmWorker instance is disposed but never re-spawned on page reloads + writeMemory when WASM memory is SharedArrayBuffer [PR #2211](https://github.com/microsoft/vscode-js-debug/pull/2211)
+
+Contributions to `vscode-jupyter`:
+
+* [@WillHirsch](https://github.com/WillHirsch): Downgrade diagnostic severity for use of bang instead of percent for package installs [PR #16601](https://github.com/microsoft/vscode-jupyter/pull/16601)
+
+Contributions to `vscode-languageserver-node`:
+
+* [@martijnwalraven (Martijn Walraven)](https://github.com/martijnwalraven): Fix `workspace/textDocumentContent/refresh` request [PR #1637](https://github.com/microsoft/vscode-languageserver-node/pull/1637)
+
+Contributions to `vscode-markdown-tm-grammar`:
+
+* [@Barros1902 (Tomás Barros )](https://github.com/Barros1902): Fix strikethrough with underscores in Markdown syntax (Fixes microsoft#173) [PR #174](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/174)
+
+Contributions to `vscode-prompt-tsx`:
+
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): chore: npm audit fix [PR #175](https://github.com/microsoft/vscode-prompt-tsx/pull/175)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@kabel (Kevin Abel)](https://github.com/kabel): Allow verified GitHub emails when none are private [PR #6921](https://github.com/microsoft/vscode-pull-request-github/pull/6921)
+
+Contributions to `vscode-python-debugger`:
+
+* [@kycutler (Kyle Cutler)](https://github.com/kycutler): Fix `TypeError` from trying to read directory [PR #692](https://github.com/microsoft/vscode-python-debugger/pull/692)
+
+Contributions to `debug-adapter-protocol`:
+
+* [@DrSergei](https://github.com/DrSergei): Fix some typos [PR #543](https://github.com/microsoft/debug-adapter-protocol/pull/543)
+* [@robertoaloi (Roberto Aloi)](https://github.com/robertoaloi): Add Erlang EDB Debugger [PR #544](https://github.com/microsoft/debug-adapter-protocol/pull/544)
+
+Contributions to `language-server-protocol`:
+
+* [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721)
+  * add caddy [PR #2131](https://github.com/microsoft/language-server-protocol/pull/2131)
+  * add kdl [PR #2139](https://github.com/microsoft/language-server-protocol/pull/2139)
+* [@brynne8 (Brynne Taylor)](https://github.com/brynne8): fix typo in glob pattern spec [PR #2132](https://github.com/microsoft/language-server-protocol/pull/2132)
+* [@leon-bckl (Leon)](https://github.com/leon-bckl): Added c++20 lsp-framework [PR #2144](https://github.com/microsoft/language-server-protocol/pull/2144)
+* [@nieomylnieja (Mateusz Hawrus)](https://github.com/nieomylnieja): chore: Add Nobl9 VSCode extension to servers.md [PR #2136](https://github.com/microsoft/language-server-protocol/pull/2136)
+* [@zonuexe (USAMI Kenta)](https://github.com/zonuexe): Add LSP clients for Emacs [PR #2145](https://github.com/microsoft/language-server-protocol/pull/2145)
+
+Contributions to `lsprotocol`:
+
+* [@debonte (Erik De Bonte)](https://github.com/debonte)
+  * Update to latest LSP spec [PR #420](https://github.com/microsoft/lsprotocol/pull/420)
+  * Rewrite release pipeline to use MicroBuild rather than vscode's templates [PR #421](https://github.com/microsoft/lsprotocol/pull/421)
+  * Change `pyproject.toml` version to `2025.0.0rc1` [PR #422](https://github.com/microsoft/lsprotocol/pull/422)
+* [@myleshyson (Myles Hyson)](https://github.com/myleshyson): Add golang to plugin table [PR #418](https://github.com/microsoft/lsprotocol/pull/418)
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_101.md
     - release-notes/v1_100.md
     - release-notes/v1_99.md
     - release-notes/v1_98.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/2ea8ea46cd0fad8466a20ffe85ad1a9c201f1f09

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_101.md https://github.com/microsoft/vscode-docs/raw/4d2c4edb16cf446d2127c97a70629bf61331f037/release-notes/v1_101.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```