### PR TITLE
Translate June 2025 (version 1.102)

### DIFF
--- a/docs/release-notes/v1_102.md
+++ b/docs/release-notes/v1_102.md
@@ -63,21 +63,21 @@ This milestone, we have made several improvements and bug fixes in this area.
 
 Upon popular request, you can now also specify which language model should be used for a chat mode. Add the `model` metadata property to your `chatmode.md` file and provide the model identifier (we provide IntelliSense for the model info).
 
-![Screenshot that shows the IntelliSense for the model metadata property in chat mode file.](images/1_102/prompt-file-model-code-completion.png)
+![Screenshot that shows the IntelliSense for the model metadata property in chat mode file.](https://code.visualstudio.com/assets/updates/1_102/prompt-file-model-code-completion.png)
 
 #### Improved editing support
 
 The editor for [chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes), [prompts](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental), and [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) now supports completions, validation, and hovers for all supported metadata properties.
 
-![Screenshot that shows the hover information for tools.](images/1_102/tools-hover.png)
+![Screenshot that shows the hover information for tools.](https://code.visualstudio.com/assets/updates/1_102/tools-hover.png)
 
-![Screenshot that shows the model diagnostics when a model is not available for a specific chat mode.](images/1_102/prompt-file-diagnostics.png)
+![Screenshot that shows the model diagnostics when a model is not available for a specific chat mode.](https://code.visualstudio.com/assets/updates/1_102/prompt-file-diagnostics.png)
 
 #### Gear menu in the chat view
 
 The **Configure Chat** action in the Chat view toolbar lets you manage custom modes as well as reusable instructions, prompts, and tool sets:
 
-![Screenshot that shows the Configure Chat menu in the Chat view.](images/1_102/chat-gear.png)
+![Screenshot that shows the Configure Chat menu in the Chat view.](https://code.visualstudio.com/assets/updates/1_102/chat-gear.png)
 
 Selecting **Modes** shows all currently installed custom modes and enables you to open, create new, or delete modes.
 
@@ -113,7 +113,7 @@ For larger instructions that you want to include conditionally, you can use `.in
 
 New in this release, the large language model can load instructions on demand. Each request gets a list of all instruction files, along with glob pattern and description. In this example, the LLM has no instructions for TypeScript files explicitly added in the context. So, it looks for code style rules before creating a TypeScript file:
 
-![Screenshot showing loading instruction files on demand.](images/1_102/instructions-loading-on-demand.png)
+![Screenshot showing loading instruction files on demand.](https://code.visualstudio.com/assets/updates/1_102/instructions-loading-on-demand.png)
 
 ### Edit previous requests (Experimental)
 
@@ -125,13 +125,13 @@ There will be a controlled rollout of different entry points to editing requests
 * `setting(chat.editRequests.hover)`: Hover a request to reveal a toolbar with a button to begin an edit inline with the request.
 * `setting(chat.editRequests.input)`: Hover a request to reveal a toolbar, which will start edits in the input box at the bottom of chat.
 
-<video src="images/1_102/edit-previous-requests.mp4" title="Video showing the process of editing a previous request in the Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/edit-previous-requests.mp4" title="Video showing the process of editing a previous request in the Chat view." autoplay loop controls muted></video>
 
 ### Terminal auto approval (Experimental)
 
 Agent mode now has a mechanism for auto approving commands in the terminal. Here's a demo of it using the defaults:
 
-<video src="images/1_102/terminal-auto-approve.mp4" title="Video showing terminal commands like 'echo' and 'ls' being auto-approved in the Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/terminal-auto-approve.mp4" title="Video showing terminal commands like 'echo' and 'ls' being auto-approved in the Chat view." autoplay loop controls muted></video>
 
 There are currently two settings: the allow list and the deny list. The allow list is a list of command _prefixes_ or regular expressions that when matched allows the command to be run without explicit approval. For example, the following will allow any command starting with `npm run test` to be run, as well as _exactly_ `git status` or `git log`:
 
@@ -168,19 +168,19 @@ The two major parts we want to add to this feature are a UI entry point to more 
 
 Agent mode sometimes wants to run commands with a `cd` statement, just in case. We now detect this case when it matches the current working directory and simplify the command that is run.
 
-![Screenshot of the terminal, asking to run `cd C:\Github\Tyriar\xterm.js && echo hello` only runs `echo hello` when the current working directory already matches.](images/1_102/terminal-working-dir.png)
+![Screenshot of the terminal, asking to run `cd C:\Github\Tyriar\xterm.js && echo hello` only runs `echo hello` when the current working directory already matches.](https://code.visualstudio.com/assets/updates/1_102/terminal-working-dir.png)
 
 ### Agent awareness of tasks and terminals
 
 Agent mode now understands which background terminals it has created and which tasks are actively running. The agent can read task output by using the new `GetTaskOutput` tool, which helps prevent running duplicate tasks and improves workspace context.
 
-![Screenshot of VS Code window showing two build tasks running in the terminal panel. The left terminal displays several errors. The chat agent replies to describe status of my build tasks with a summary of each task's output.](images/1_102/task-status.png)
+![Screenshot of VS Code window showing two build tasks running in the terminal panel. The left terminal displays several errors. The chat agent replies to describe status of my build tasks with a summary of each task's output.](https://code.visualstudio.com/assets/updates/1_102/task-status.png)
 
 ### Maximized chat view
 
 You can now maximize the Secondary Side Bar to span the editor area and hide the Primary Side Bar and panel area. VS Code will remember this state between restarts and will restore the Chat view when you open an editor or view.
 
-<video src="images/1_102/auxmax.mp4" title="Video showing maximizing the Secondary Side Bar." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/auxmax.mp4" title="Video showing maximizing the Secondary Side Bar." autoplay loop controls muted></video>
 
 You can toggle in and out of the maximized state by using the new icon next to the close button, or use the new command `workbench.action.toggleMaximizedAuxiliaryBar` from the Command Palette.
 
@@ -188,7 +188,7 @@ You can toggle in and out of the maximized state by using the new icon next to t
 
 We now show a badge over the application icon in the dock when the window is not focused and the agent needs user confirmation to continue. The badge will disappear as soon as the related window that triggered it receives focus.
 
-![Screenshot of the VS Code dock icon showing an agent confirmation as a badge.](./images/1_102/badge.png)
+![Screenshot of the VS Code dock icon showing an agent confirmation as a badge.](https://code.visualstudio.com/assets/updates/1_102/badge.png)
 
 You can enable or disable this badge via the `setting(chat.notifyWindowOnConfirmation)` setting.
 
@@ -196,7 +196,7 @@ You can enable or disable this badge via the `setting(chat.notifyWindowOnConfirm
 
 A new subcommand `chat` is added to the VS Code CLI that enables you to start a chat session in the current working directory with the prompt provided.
 
-<video src="images/1_102/chatcli.mp4" title="Video showing the Chat CLI in action to open the Chat view from the command line and run a prompt." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/chatcli.mp4" title="Video showing the Chat CLI in action to open the Chat view from the command line and run a prompt." autoplay loop controls muted></video>
 
 The basic syntax is `code chat [options] [prompt]` and options can be any of:
 
@@ -218,7 +218,7 @@ We've reworked the UX around managing extension access to language models provid
 
 To make this clearer, we've removed the **AccountName (GitHub Copilot Chat)** item and replaced it with a new item called **Manage Language Model Access...**. This item opens a Quick Pick that enables you to manage which extensions have access to the language models provided by GitHub Copilot Chat.
 
-![Screenshot that shows the language model access Quick Pick.](images/1_102/lm-access-qp.png)
+![Screenshot that shows the language model access Quick Pick.](https://code.visualstudio.com/assets/updates/1_102/lm-access-qp.png)
 
 We think this is clearer... That said, in a future release we will explore more granular access control for language models (for example, only allowing specific models rather than _all_ models provided by an extension), so stay tuned for that.
 
@@ -244,7 +244,7 @@ In addition, organizations can now control the availability of MCP servers with 
 
 You can get started by installing some of the [popular MCP servers from our curated list](https://code.visualstudio.com/mcp). Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) and how you can use them to extend agent mode.
 
-![Screenshot that shows the MCP Servers page.](images/1_102/mcp-servers-page.png)
+![Screenshot that shows the MCP Servers page.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-page.png)
 
 If you want to build your own MCP server, check our [MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) for more details about how to take advantage of the MCP capabilities in VS Code.
 
@@ -252,7 +252,7 @@ If you want to build your own MCP server, check our [MCP developer guide](https:
 
 The latest MCP specification added support for [Elicitations](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) as a way for MCP servers to request input from MCP clients. The latest version of VS Code adopts this specification and includes support for elicitations.
 
-<video src="images/1_102/mcp-server-elicit.mp4" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/mcp-server-elicit.mp4" autoplay loop controls muted></video>
 
 ### MCP server discovery and installation
 
@@ -260,17 +260,17 @@ The new **MCP Servers** section in the Extensions view includes welcome content 
 
 Once installed, MCP servers automatically appear in your Extensions view under the **MCP SERVERS - INSTALLED** section, and their tools become available in the Chat view's tools Quick Pick. This makes it easy to verify that your MCP server is working correctly and access its capabilities immediately.
 
-<video src="images/1_102/mcp-servers-discovery-install.mp4" title="Video showing installing an MCP server from the MCP page on the VS Code website." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/mcp-servers-discovery-install.mp4" title="Video showing installing an MCP server from the MCP page on the VS Code website." autoplay loop controls muted></video>
 
 ### MCP server management view
 
 The new **MCP SERVERS - INSTALLED** view in the Extensions view makes it easy to monitor, configure, and control your installed MCP servers.
 
-![Screenshot showing the MCP Servers management view with installed servers.](images/1_102/mcp-servers-installed-view.png)
+![Screenshot showing the MCP Servers management view with installed servers.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-installed-view.png)
 
 The view lists the installed MCP servers and provides several management actions through the context menu:
 
-![Screenshot showing the context menu actions for an MCP server.](images/1_102/mcp-server-context-menu.png)
+![Screenshot showing the context menu actions for an MCP server.](https://code.visualstudio.com/assets/updates/1_102/mcp-server-context-menu.png)
 
 * **Start Server** / **Stop Server** / **Restart Server**: Control the server's running state
 * **Disconnect Account**: Remove account access from the server
@@ -283,11 +283,11 @@ The view lists the installed MCP servers and provides several management actions
 
 When you select an installed MCP server, VS Code opens the MCP server editor displaying the server's readme details, manifest, and its runtime configuration. This provides an overview of the server's capabilities and current settings, making it easy to understand what the server does and how it's configured.
 
-![Screenshot showing the MCP server editor with runtime configuration.](images/1_102/mcp-server-editor-configuration.png)
+![Screenshot showing the MCP server editor with runtime configuration.](https://code.visualstudio.com/assets/updates/1_102/mcp-server-editor-configuration.png)
 
 The **MCP SERVERS - INSTALLED** view also provides a **Browse MCP Servers...** action that takes you directly to the community website, making server discovery always accessible from within VS Code.
 
-![Screenshot that shows the Browse MCP Servers action in the MCP Servers view.](images/1_102/mcp-servers-browse-action.png)
+![Screenshot that shows the Browse MCP Servers action in the MCP Servers view.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-browse-action.png)
 
 ### MCP servers as first class resources
 
@@ -347,13 +347,13 @@ These commands provide quick access to your MCP configuration files, making it e
 You are now able to sign out or disconnect accounts from the MCP gear menu and quick picks.
 
 * MCP view gear menu:
-    ![Screenshot showing the Disconnect Account action shown in MCP view gear menu.](images/1_102/mcp-view-signout.png)
+    ![Screenshot showing the Disconnect Account action shown in MCP view gear menu.](https://code.visualstudio.com/assets/updates/1_102/mcp-view-signout.png)
 
 * MCP editor gear menu:
-    ![Screenshot showing the Disconnect Account action shown in MCP editor gear menu.](images/1_102/mcp-editor-signout.png)
+    ![Screenshot showing the Disconnect Account action shown in MCP editor gear menu.](https://code.visualstudio.com/assets/updates/1_102/mcp-editor-signout.png)
 
 * MCP quick pick:
-    ![Screenshot showing the Disconnect Account action shown in MCP quick pick menu.](images/1_102/mcp-qp-signout.png)
+    ![Screenshot showing the Disconnect Account action shown in MCP quick pick menu.](https://code.visualstudio.com/assets/updates/1_102/mcp-qp-signout.png)
 
 The **Disconnect** action is shown when the account is used by either other MCP servers or extensions, while **Sign Out** is shown when the account is only used by the MCP server. The sign out action completely removes the account from VS Code, while disconnect only removes access to the account from the MCP server.
 
@@ -381,7 +381,7 @@ Scroll the editor by simply clicking, or holding down your middle mouse button (
 
 Once activated, the cursor changes to a panning icon and moving the mouse up or down then smoothly scrolls the editor in that direction. The scrolling speed is determined by how far you move the mouse from the initial click point. Release the middle mouse button or click it again to stop scrolling and return to the standard cursor.
 
-<video src="images/1_102/middle-scroll.mp4" title="Screenrecording of the editor scrolling when the middle mouse button is clicked." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/middle-scroll.mp4" title="Screenrecording of the editor scrolling when the middle mouse button is clicked." autoplay loop controls muted></video>
 
 **Known Conflicts**
 
@@ -395,7 +395,7 @@ You can now temporarily pause inline suggestions and next edit suggestions (NES)
 
 To snooze suggestions, select the Copilot dashboard in the Status Bar, or run the **Snooze Inline Suggestions** command from the Command Palette and select a duration from the dropdown menu. During the snooze period, no inline suggestions or NES will appear.
 
-![Screenshot showing the Copilot dashboard with the snooze button at the bottom.](images/1_102/nes-snooze.png)
+![Screenshot showing the Copilot dashboard with the snooze button at the bottom.](https://code.visualstudio.com/assets/updates/1_102/nes-snooze.png)
 
 You can also assign a custom keybinding to quickly snooze suggestions for a specific duration by passing the desired duration as an argument to the command. For example:
 
@@ -415,7 +415,7 @@ You can also assign a custom keybinding to quickly snooze suggestions for a spec
 
 VS Code on Windows now supports using the accent color as the window frame border if that is enabled in Windows settings ("Show accent color on title bars and window borders").
 
-![Screenshot of the VS Code window with a red accent color border.](images/1_102/window-accent.png)
+![Screenshot of the VS Code window with a red accent color border.](https://code.visualstudio.com/assets/updates/1_102/window-accent.png)
 
 The new `setting(window.border)` setting enables you to control the color of the window border. Use `default` to use the Windows accent color, `off` to disable the border, or provide a specific color value to use a custom color.
 
@@ -429,7 +429,7 @@ This milestone, we modified the sparkle toggle in the Settings editor, so that i
 
 The toggle is enabled only when there are AI results available. We welcome feedback on when the AI settings search did not find an expected setting, and we plan to enable the setting by default over the next iteration.
 
-<video src="images/1_102/settings-search-toggle-stable.mp4" title="Switching between AI and non-AI results using the AI results toggle in the Settings editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/settings-search-toggle-stable.mp4" title="Switching between AI and non-AI results using the AI results toggle in the Settings editor" autoplay loop controls muted></video>
 
 ## Tasks
 
@@ -453,37 +453,37 @@ A new setting, `terminal.integrated.suggest.selectionMode`, helps you understand
 
 The default value is `partial`, which means that `kbStyle(Tab)` accepts the suggestion until navigation has occurred.
 
-![Screenshot showing the first terminal suggestion can be accepted with Tab.](images/1_102/terminal-selection-mode.png)
+![Screenshot showing the first terminal suggestion can be accepted with Tab.](https://code.visualstudio.com/assets/updates/1_102/terminal-selection-mode.png)
 
 #### Learn more
 
 The **Learn More** action `(kb(workbench.action.terminal.suggestLearnMore))` in the terminal suggest control's status bar is now highlighted for the first 10 times or if the control is shown for 10 seconds. This helps you discover how to configure, disable, and read about the suggest control.
 
-![Screenshot showing the Learn More action appears in the terminal suggest control status bar.](images/1_102/terminal-suggest-discoverability.png)
+![Screenshot showing the Learn More action appears in the terminal suggest control status bar.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-discoverability.png)
 
 #### Multi-command support
 
 Terminal suggest now supports multi-command lines. You can link commands with `;`, `&&`, and other shell operators, and receive suggestions for all commands on the line.
 
-![Screenshot showing the VS Code terminal showing a multi-command line with git commit and git push, and the terminal suggest widget displaying suggestions for pull, push, and other git commands.](images/1_102/terminal-suggest-multi.png)
+![Screenshot showing the VS Code terminal showing a multi-command line with git commit and git push, and the terminal suggest widget displaying suggestions for pull, push, and other git commands.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-multi.png)
 
 #### Symlink information
 
 We now display a symlink's realpath in the suggest details control and have unique icons for symlink files and folders to help distinguish them from other suggestions.
 
-![Screenshot showing the terminal suggest shows the symlink's path -> real path.](images/1_102/terminal-symlink.png)
+![Screenshot showing the terminal suggest shows the symlink's path -> real path.](https://code.visualstudio.com/assets/updates/1_102/terminal-symlink.png)
 
 #### Improved sorting
 
 We've improved sorting in many ways to give you the most relevant suggestions first. For example, giving `main` and `master` priority over other branches.
 
-![Screenshot showing the terminal suggest boosts main and master compared to other branch suggestions.](images/1_102/terminal-suggest-sorting.png)
+![Screenshot showing the terminal suggest boosts main and master compared to other branch suggestions.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-sorting.png)
 
 #### Git bash improvements
 
 We now properly support Git Bash path completions for folders and files. Additionally, we source the built-in commands and present them as suggestions.
 
-![Screenshot showing a Git Bash terminal with suggestions for builtin functions like cat, cp, and curl.](images/1_102/terminal-git-bash.png)
+![Screenshot showing a Git Bash terminal with suggestions for builtin functions like cat, cp, and curl.](https://code.visualstudio.com/assets/updates/1_102/terminal-git-bash.png)
 
 ## Contributions to extensions
 
@@ -503,7 +503,7 @@ Ask Copilot to continue a local change in the background by invoking the `#copil
 
 This tool automatically pushes pending changes to a remote branch and initiates a coding agent session from that branch along with the user's instruction.
 
-![Screenshot showing handing off a session to Copilot coding agent](images/1_102/coding-agent-start.png)
+![Screenshot showing handing off a session to Copilot coding agent](https://code.visualstudio.com/assets/updates/1_102/coding-agent-start.png)
 
 **Experimental:** Deeper UI integration can be enabled with the `setting(githubPullRequests.codingAgent.uiIntegration)` setting.  Once enabled, a new **Delegate to coding agent** button appears in the Chat view for repositories that have the agent enabled.
 
@@ -511,13 +511,13 @@ This tool automatically pushes pending changes to a remote branch and initiates 
 
 We have made improvements to notify and prominently display the status of coding agent pull requests in the **Copilot on my behalf** query. A numeric badge now indicates new changes.
 
-![Screenshot showing status of multiple coding agent pull requests](images/1_102/coding-agent-status.png)
+![Screenshot showing status of multiple coding agent pull requests](https://code.visualstudio.com/assets/updates/1_102/coding-agent-status.png)
 
 #### Session log
 
 You can now view the session log of a coding agent session directly in VS Code. This enables you to see the history of actions taken by the coding agent, including code changes and tool usage.
 
-![Screenshot showing the session log of a coding agent session.](images/1_102/coding-agent-session-log.png)
+![Screenshot showing the session log of a coding agent session.](https://code.visualstudio.com/assets/updates/1_102/coding-agent-session-log.png)
 
 #### Enhancements on `#activePullRequest` tool
 
@@ -568,7 +568,7 @@ In other words, we get the best of both worlds: a reliable sign-in flow that wor
 
 While we were at it, we also gave this [landing page a fresh coat of paint](#revamped-github-sign-in-flow). In future iterations, we'll apply this new design to other sign-in experiences.
 
-![Screenshot showing the redesigned authentication landing page.](./images/1_102/auth-landing.png)
+![Screenshot showing the redesigned authentication landing page.](https://code.visualstudio.com/assets/updates/1_102/auth-landing.png)
 
 ## Extension Authoring
 

--- a/docs/release-notes/v1_102.md
+++ b/docs/release-notes/v1_102.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_102/release-highlights.png
 Date: 2025-07-09
 DownloadVersion: 1.102.0
 ---
-# June 2025 (version 1.102)
+# June 2025 (version 1.102) {#june-2025-version-1102}
 
 _Release date: July 9, 2025_
 
@@ -36,9 +36,9 @@ Welcome to the June 2025 release of Visual Studio Code. There are many updates i
 >If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
 **Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
 
-## Chat
+## Chat {#chat}
 
-### Copilot Chat is open source
+### Copilot Chat is open source {#copilot-chat-is-open-source}
 
 We're excited to announce that we've open sourced the GitHub Copilot Chat extension! The source code is now available at [`microsoft/vscode-copilot-chat`](https://github.com/microsoft/vscode-copilot-chat) under the MIT license.
 
@@ -53,19 +53,19 @@ You can explore the repository to see how features like [agent mode](https://git
 
 To learn more about this milestone and our broader vision for open source AI editor tooling, read our detailed blog post: [Open Source AI Editor - First Milestone](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone).
 
-### Chat mode improvements
+### Chat mode improvements {#chat-mode-improvements}
 
 Last milestone, we previewed [custom chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes#_custom-chat-modes). In addition to the built-in chat modes 'Ask', 'Edit' and 'Agent', you can define your own chat modes with specific instructions and a set of allowed tools that you want the LLM to follow when replying to a request.
 
 This milestone, we have made several improvements and bug fixes in this area.
 
-#### Configure language model
+#### Configure language model {#configure-language-model}
 
 Upon popular request, you can now also specify which language model should be used for a chat mode. Add the `model` metadata property to your `chatmode.md` file and provide the model identifier (we provide IntelliSense for the model info).
 
 ![Screenshot that shows the IntelliSense for the model metadata property in chat mode file.](https://code.visualstudio.com/assets/updates/1_102/prompt-file-model-code-completion.png)
 
-#### Improved editing support
+#### Improved editing support {#improved-editing-support}
 
 The editor for [chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes), [prompts](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental), and [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) now supports completions, validation, and hovers for all supported metadata properties.
 
@@ -73,7 +73,7 @@ The editor for [chat modes](https://code.visualstudio.com/docs/copilot/chat/chat
 
 ![Screenshot that shows the model diagnostics when a model is not available for a specific chat mode.](https://code.visualstudio.com/assets/updates/1_102/prompt-file-diagnostics.png)
 
-#### Gear menu in the chat view
+#### Gear menu in the chat view {#gear-menu-in-the-chat-view}
 
 The **Configure Chat** action in the Chat view toolbar lets you manage custom modes as well as reusable instructions, prompts, and tool sets:
 
@@ -81,7 +81,7 @@ The **Configure Chat** action in the Chat view toolbar lets you manage custom mo
 
 Selecting **Modes** shows all currently installed custom modes and enables you to open, create new, or delete modes.
 
-#### Import modes, prompts and instructions via a `vscode` link
+#### Import modes, prompts and instructions via a `vscode` link {#import-modes-prompts-and-instructions-via-a-vscode-link}
 
 You can now import chat mode, reusable prompt and instruction files from external links, such as a gist or our [awesome-copilot](https://github.com/github/awesome-copilot) community repository. For example, the following link will import the chat mode file for Burke's GPT 4.1 Beast Mode:
 
@@ -91,7 +91,7 @@ This will prompt for a destination, either your current workspace or your user s
 
 Try it out on the 100+ community-contributed instructions, prompts, and chat modes at [awesome-copilot](https://github.com/github/awesome-copilot).
 
-### Generate custom instructions
+### Generate custom instructions {#generate-custom-instructions}
 
 Setting up [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization) for your project can significantly improve AI suggestions by providing context about your coding standards and project conventions. However, creating effective instructions from scratch might be challenging.
 
@@ -103,7 +103,7 @@ Learn more about [customizing AI responses with instructions](https://code.visua
 
 
 
-### Load instruction files on demand
+### Load instruction files on demand {#load-instruction-files-on-demand}
 
 Instruction files can be used to describe coding practices and project requirements. Instructions can be manually or automatically included as context to chat requests.
 
@@ -115,7 +115,7 @@ New in this release, the large language model can load instructions on demand. E
 
 ![Screenshot showing loading instruction files on demand.](https://code.visualstudio.com/assets/updates/1_102/instructions-loading-on-demand.png)
 
-### Edit previous requests (Experimental)
+### Edit previous requests (Experimental) {#edit-previous-requests-experimental}
 
 You can now click on previous requests to modify the text content, attached context, mode, and model. Upon submitting this change, this will remove all subsequent requests, undo any edits made, and send the new request in chat.
 
@@ -127,7 +127,7 @@ There will be a controlled rollout of different entry points to editing requests
 
 <video src="https://code.visualstudio.com/assets/updates/1_102/edit-previous-requests.mp4" title="Video showing the process of editing a previous request in the Chat view." autoplay loop controls muted></video>
 
-### Terminal auto approval (Experimental)
+### Terminal auto approval (Experimental) {#terminal-auto-approval-experimental}
 
 Agent mode now has a mechanism for auto approving commands in the terminal. Here's a demo of it using the defaults:
 
@@ -164,19 +164,19 @@ Thanks to the protections that we gain against prompt injection from [workspace 
 
 The two major parts we want to add to this feature are a UI entry point to more easily add new commands to the list ([#253268](https://github.com/microsoft/vscode/issues/253268)) and an opt-in option to allow an LLM to evaluate the command(s) safety ([#253267](https://github.com/microsoft/vscode/issues/253267)). We are also planning on both removing the `github.copilot.` prefix of these settings ([#253314](https://github.com/microsoft/vscode/issues/253314)) as well as merging them together ([#253472](https://github.com/microsoft/vscode/issues/253472)) in the next release before it becomes a preview setting.
 
-### Terminal command simplification
+### Terminal command simplification {#terminal-command-simplification}
 
 Agent mode sometimes wants to run commands with a `cd` statement, just in case. We now detect this case when it matches the current working directory and simplify the command that is run.
 
 ![Screenshot of the terminal, asking to run `cd C:\Github\Tyriar\xterm.js && echo hello` only runs `echo hello` when the current working directory already matches.](https://code.visualstudio.com/assets/updates/1_102/terminal-working-dir.png)
 
-### Agent awareness of tasks and terminals
+### Agent awareness of tasks and terminals {#agent-awareness-of-tasks-and-terminals}
 
 Agent mode now understands which background terminals it has created and which tasks are actively running. The agent can read task output by using the new `GetTaskOutput` tool, which helps prevent running duplicate tasks and improves workspace context.
 
 ![Screenshot of VS Code window showing two build tasks running in the terminal panel. The left terminal displays several errors. The chat agent replies to describe status of my build tasks with a summary of each task's output.](https://code.visualstudio.com/assets/updates/1_102/task-status.png)
 
-### Maximized chat view
+### Maximized chat view {#maximized-chat-view}
 
 You can now maximize the Secondary Side Bar to span the editor area and hide the Primary Side Bar and panel area. VS Code will remember this state between restarts and will restore the Chat view when you open an editor or view.
 
@@ -184,7 +184,7 @@ You can now maximize the Secondary Side Bar to span the editor area and hide the
 
 You can toggle in and out of the maximized state by using the new icon next to the close button, or use the new command `workbench.action.toggleMaximizedAuxiliaryBar` from the Command Palette.
 
-### Agent mode badge indicator
+### Agent mode badge indicator {#agent-mode-badge-indicator}
 
 We now show a badge over the application icon in the dock when the window is not focused and the agent needs user confirmation to continue. The badge will disappear as soon as the related window that triggered it receives focus.
 
@@ -192,7 +192,7 @@ We now show a badge over the application icon in the dock when the window is not
 
 You can enable or disable this badge via the `setting(chat.notifyWindowOnConfirmation)` setting.
 
-### Start chat from the command line
+### Start chat from the command line {#start-chat-from-the-command-line}
 
 A new subcommand `chat` is added to the VS Code CLI that enables you to start a chat session in the current working directory with the prompt provided.
 
@@ -208,11 +208,11 @@ The basic syntax is `code chat [options] [prompt]` and options can be any of:
 
 Reading from stdin is supported, provided you pass in `-` at the end, for example `ps aux | grep code | code chat <prompt> -`
 
-### Fetch tool supports non-HTTP URLs
+### Fetch tool supports non-HTTP URLs {#fetch-tool-supports-nonhttp-urls}
 
 We've seen that, on occasion, models want to call the Fetch tool with non-HTTP URLs, such as `file://` URLs. Rather than disallowing this, the Fetch tool now supports these URLs and returns the content of the file or resource at the URL. Images are also supported.
 
-### Clearer language model access management
+### Clearer language model access management {#clearer-language-model-access-management}
 
 We've reworked the UX around managing extension access to language models provided by extensions. Previously, you saw an item in the Account menu that said **AccountName (GitHub Copilot Chat)**, which had nothing to do with what account GitHub Copilot Chat was using. Rather, it allowed you to manage which extensions had access to the language models provided by Copilot Chat.
 
@@ -222,7 +222,7 @@ To make this clearer, we've removed the **AccountName (GitHub Copilot Chat)** it
 
 We think this is clearer... That said, in a future release we will explore more granular access control for language models (for example, only allowing specific models rather than _all_ models provided by an extension), so stay tuned for that.
 
-### Reading chat requests
+### Reading chat requests {#reading-chat-requests}
 
 Since the chat extension itself is open source, you now get access to one of the debugging tools that we've been using internally for awhile. To easily see the details of all requests made by Copilot Chat, run the command "Show Chat Debug View". This will show a treeview with an entry for each request made. You can see the full prompt that was sent to the model, the tools that were enabled, the response, and other key details. You can save the request log with right click > "Export As...".
 
@@ -230,13 +230,13 @@ The view also has entries for tool calls on their own, and a prompt-tsx debug vi
 
 > 🚨 **Note**: This log is very helpful in troubleshooting issues, and we will appreciate if you share it when filing an issue about the agent's behavior. But, this log may contain personal information such as the contents of your files or terminal output. Please review the contents carefully before sharing it with anyone else.
 
-### Edit Tool Improvements
+### Edit Tool Improvements {#edit-tool-improvements}
 
 This release includes several changes to the predictability and reliability of the edit tools used for GPT-4 models and Sonnet models. You should see more reliable editing behavior in this release and we will continue to improve these tools in future releases.
 
-## MCP
+## MCP {#mcp}
 
-### MCP support in VS Code is generally available
+### MCP support in VS Code is generally available {#mcp-support-in-vs-code-is-generally-available}
 
 We've have been working on expanding MCP support in VS Code for the past few months, and [support the full range of MCP features in the specification](https://code.visualstudio.com/blogs/2025/06/12/full-mcp-spec-support). As of this release, MCP support is now generally available in VS Code!
 
@@ -248,13 +248,13 @@ You can get started by installing some of the [popular MCP servers from our cura
 
 If you want to build your own MCP server, check our [MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) for more details about how to take advantage of the MCP capabilities in VS Code.
 
-### Support for elicitations
+### Support for elicitations {#support-for-elicitations}
 
 The latest MCP specification added support for [Elicitations](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) as a way for MCP servers to request input from MCP clients. The latest version of VS Code adopts this specification and includes support for elicitations.
 
 <video src="https://code.visualstudio.com/assets/updates/1_102/mcp-server-elicit.mp4" autoplay loop controls muted></video>
 
-### MCP server discovery and installation
+### MCP server discovery and installation {#mcp-server-discovery-and-installation}
 
 The new **MCP Servers** section in the Extensions view includes welcome content that links directly to the [popular MCP servers from our curated list](https://code.visualstudio.com/mcp). Visit the website to explore available MCP servers and select **Install** on any MCP server. This automatically launches VS Code and opens the MCP server editor that displays the server's readme and manifest information. You can review the server details and select **Install** to add the server to your VS Code instance.
 
@@ -262,7 +262,7 @@ Once installed, MCP servers automatically appear in your Extensions view under t
 
 <video src="https://code.visualstudio.com/assets/updates/1_102/mcp-servers-discovery-install.mp4" title="Video showing installing an MCP server from the MCP page on the VS Code website." autoplay loop controls muted></video>
 
-### MCP server management view
+### MCP server management view {#mcp-server-management-view}
 
 The new **MCP SERVERS - INSTALLED** view in the Extensions view makes it easy to monitor, configure, and control your installed MCP servers.
 
@@ -289,7 +289,7 @@ The **MCP SERVERS - INSTALLED** view also provides a **Browse MCP Servers...** a
 
 ![Screenshot that shows the Browse MCP Servers action in the MCP Servers view.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-browse-action.png)
 
-### MCP servers as first class resources
+### MCP servers as first class resources {#mcp-servers-as-first-class-resources}
 
 MCP servers are now treated as first-class resources in VS Code, similar to user tasks and other profile-specific configurations. This represents a significant architectural improvement from the previous approach where MCP servers were stored in user settings. This change makes MCP server management more robust and provides better separation of concerns between your general VS Code settings and your MCP server configurations. When you install or configure MCP servers, they're automatically stored in the appropriate [profile](https://code.visualstudio.com/docs/configure/profiles)-specific location to ensure that your main settings file stays clean and focused.
 
@@ -297,7 +297,7 @@ MCP servers are now treated as first-class resources in VS Code, similar to user
 * **Profile-specific**: Each VS Code profile maintains its own set of MCP servers, enabling you to have different server configurations for different workflows or projects
 * **Settings Sync integration**: MCP servers sync seamlessly across your devices through [Settings Sync](https://code.visualstudio.com/docs/configure/settings-sync), with granular control over what gets synchronized
 
-#### MCP migration support
+#### MCP migration support {#mcp-migration-support}
 
 With MCP servers being first-class resources and the associated change to their configuration, VS Code provides comprehensive migration support for users upgrading from the previous MCP server configuration format:
 
@@ -307,7 +307,7 @@ With MCP servers being first-class resources and the associated change to their 
 
 This migration ensures that your existing MCP server configurations continue to work without any manual intervention while providing the enhanced management capabilities of the new architecture.
 
-#### Dev Container support for MCP configuration
+#### Dev Container support for MCP configuration {#dev-container-support-for-mcp-configuration}
 
 The Dev Container configuration `devcontainer.json` and the Dev Container Feature configuration `devcontainer-feature.json` support MCP server configurations at the path `customizations.vscode.mcp`. When a Dev Container is created the collected MCP server configurations are written to the remote MCP configuration file `mcp.json`.
 
@@ -333,7 +333,7 @@ Sample `devcontainer.json` configuring the Playwright MCP server:
 }
 ```
 
-#### Commands to access MCP resources
+#### Commands to access MCP resources {#commands-to-access-mcp-resources}
 
 To make working with MCP servers more accessible, we've added commands to help you manage and access your MCP configuration files:
 
@@ -342,7 +342,7 @@ To make working with MCP servers more accessible, we've added commands to help y
 
 These commands provide quick access to your MCP configuration files, making it easy to view and manage your server configurations directly.
 
-### Quick management of MCP authentication
+### Quick management of MCP authentication {#quick-management-of-mcp-authentication}
 
 You are now able to sign out or disconnect accounts from the MCP gear menu and quick picks.
 
@@ -357,23 +357,23 @@ You are now able to sign out or disconnect accounts from the MCP gear menu and q
 
 The **Disconnect** action is shown when the account is used by either other MCP servers or extensions, while **Sign Out** is shown when the account is only used by the MCP server. The sign out action completely removes the account from VS Code, while disconnect only removes access to the account from the MCP server.
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Keep all edits from within the editor
+### Keep all edits from within the editor {#keep-all-edits-from-within-the-editor}
 
 Formerly, to accept all edits, focus would need to be in the Chat view. Now, with focus in the editor, you can run the command **Keep All Edits** (`kb(chatEditor.action.acceptAllEdits)`).
 
-### User action required sound
+### User action required sound {#user-action-required-sound}
 
 We’ve fine-tuned the accessibility signal to indicate when chat requires user action and set the default value to `auto`, so screen reader users will hear this signal. You can configure this behavior with the `setting(accessibility.signals.chatUserActionRequired)` setting.
 
-### Alert when rendering errors occur in chat
+### Alert when rendering errors occur in chat {#alert-when-rendering-errors-occur-in-chat}
 
 Previously, screen reader users were not alerted when a chat rendering error occurred . Users are now alerted with this information and can also focus it via keyboard.
 
-## Code Editing
+## Code Editing {#code-editing}
 
-### Scroll on middle click
+### Scroll on middle click {#scroll-on-middle-click}
 
 **Setting**: `setting(editor.scrollOnMiddleClick:true)`
 
@@ -389,7 +389,7 @@ Enabling this feature might interfere with other actions tied to the middle mous
 
 To avoid these conflicts, please enable only one of these settings at a time.
 
-### Snooze code completions
+### Snooze code completions {#snooze-code-completions}
 
 You can now temporarily pause inline suggestions and next edit suggestions (NES) by using the new **Snooze** feature. This is helpful when you want to focus without distraction from suggestions.
 
@@ -407,9 +407,9 @@ You can also assign a custom keybinding to quickly snooze suggestions for a spec
 }
 ```
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Windows accent color
+### Windows accent color {#windows-accent-color}
 
 **Setting**: `setting(window.border)`
 
@@ -421,7 +421,7 @@ The new `setting(window.border)` setting enables you to control the color of the
 
 **Note**: the border is only visible when the related Windows setting is enabled. It can not yet be set per workspace, but we are working on that support.
 
-### Settings search suggestions (Preview)
+### Settings search suggestions (Preview) {#settings-search-suggestions-preview}
 
 **Setting**: `setting(workbench.settings.showAISearchToggle:true)`
 
@@ -431,23 +431,23 @@ The toggle is enabled only when there are AI results available. We welcome feedb
 
 <video src="https://code.visualstudio.com/assets/updates/1_102/settings-search-toggle-stable.mp4" title="Switching between AI and non-AI results using the AI results toggle in the Settings editor" autoplay loop controls muted></video>
 
-## Tasks
+## Tasks {#tasks}
 
-### Rerun all running tasks
+### Rerun all running tasks {#rerun-all-running-tasks}
 
 You can now quickly rerun all currently running tasks with the new `Tasks: Rerun All Running Tasks command`. This is useful for workflows that involve multiple concurrent tasks, allowing you to restart them all at once without stopping and rerunning each individually.
 
-### Restart task reloads updated tasks.json
+### Restart task reloads updated tasks.json {#restart-task-reloads-updated-tasks-json}
 
 The **Restart Task** command now reloads your `tasks.json` before restarting, ensuring that any recent changes are respected. Previously, task configuration changes were not picked up when restarting a task, which could lead to confusion or outdated task behavior.
 
-## Terminal
+## Terminal {#terminal}
 
-### Terminal Suggest (Preview)
+### Terminal Suggest (Preview) {#terminal-suggest-preview}
 
 We've made significant improvements to the terminal suggest feature.
 
-#### Selection mode
+#### Selection mode {#selection-mode}
 
 A new setting, `terminal.integrated.suggest.selectionMode`, helps you understand that by default, `kbStyle(Tab)` (not `kbStyle(Enter)`) accepts suggestions. You can choose between `partial`, `always`, and `never` modes to control how suggestions are selected and accepted.
 
@@ -455,39 +455,39 @@ The default value is `partial`, which means that `kbStyle(Tab)` accepts the sugg
 
 ![Screenshot showing the first terminal suggestion can be accepted with Tab.](https://code.visualstudio.com/assets/updates/1_102/terminal-selection-mode.png)
 
-#### Learn more
+#### Learn more {#learn-more}
 
 The **Learn More** action `(kb(workbench.action.terminal.suggestLearnMore))` in the terminal suggest control's status bar is now highlighted for the first 10 times or if the control is shown for 10 seconds. This helps you discover how to configure, disable, and read about the suggest control.
 
 ![Screenshot showing the Learn More action appears in the terminal suggest control status bar.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-discoverability.png)
 
-#### Multi-command support
+#### Multi-command support {#multi-command-support}
 
 Terminal suggest now supports multi-command lines. You can link commands with `;`, `&&`, and other shell operators, and receive suggestions for all commands on the line.
 
 ![Screenshot showing the VS Code terminal showing a multi-command line with git commit and git push, and the terminal suggest widget displaying suggestions for pull, push, and other git commands.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-multi.png)
 
-#### Symlink information
+#### Symlink information {#symlink-information}
 
 We now display a symlink's realpath in the suggest details control and have unique icons for symlink files and folders to help distinguish them from other suggestions.
 
 ![Screenshot showing the terminal suggest shows the symlink's path -> real path.](https://code.visualstudio.com/assets/updates/1_102/terminal-symlink.png)
 
-#### Improved sorting
+#### Improved sorting {#improved-sorting}
 
 We've improved sorting in many ways to give you the most relevant suggestions first. For example, giving `main` and `master` priority over other branches.
 
 ![Screenshot showing the terminal suggest boosts main and master compared to other branch suggestions.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-sorting.png)
 
-#### Git bash improvements
+#### Git bash improvements {#git-bash-improvements}
 
 We now properly support Git Bash path completions for folders and files. Additionally, we source the built-in commands and present them as suggestions.
 
 ![Screenshot showing a Git Bash terminal with suggestions for builtin functions like cat, cp, and curl.](https://code.visualstudio.com/assets/updates/1_102/terminal-git-bash.png)
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### GitHub Pull Requests
+### GitHub Pull Requests {#github-pull-requests}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
 
@@ -497,7 +497,7 @@ These features require that your workspace is open to a repository that has [the
 
 Review the [changelog for the 0.114.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01140) release of the extension to learn about everything in the release.
 
-#### Start a coding agent session (Preview)
+#### Start a coding agent session (Preview) {#start-a-coding-agent-session-preview}
 
 Ask Copilot to continue a local change in the background by invoking the `#copilotCodingAgent` tool in chat.
 
@@ -507,27 +507,27 @@ This tool automatically pushes pending changes to a remote branch and initiates 
 
 **Experimental:** Deeper UI integration can be enabled with the `setting(githubPullRequests.codingAgent.uiIntegration)` setting.  Once enabled, a new **Delegate to coding agent** button appears in the Chat view for repositories that have the agent enabled.
 
-#### Status tracking
+#### Status tracking {#status-tracking}
 
 We have made improvements to notify and prominently display the status of coding agent pull requests in the **Copilot on my behalf** query. A numeric badge now indicates new changes.
 
 ![Screenshot showing status of multiple coding agent pull requests](https://code.visualstudio.com/assets/updates/1_102/coding-agent-status.png)
 
-#### Session log
+#### Session log {#session-log}
 
 You can now view the session log of a coding agent session directly in VS Code. This enables you to see the history of actions taken by the coding agent, including code changes and tool usage.
 
 ![Screenshot showing the session log of a coding agent session.](https://code.visualstudio.com/assets/updates/1_102/coding-agent-session-log.png)
 
-#### Enhancements on `#activePullRequest` tool
+#### Enhancements on `#activePullRequest` tool {#enhancements-on-activepullrequest-tool}
 
 The `#activePullRequest` tool returns information about the pull request, such as its title, description, and status for use in chat, and now you can also use it to get the coding agent session information.
 
 This tool is automatically attached to chat when opening a pull request created through the coding agent experience, so you can maintain the context and keep working on the pull request if needed to.
 
-### Python
+### Python {#python}
 
-#### Python Environments extension improvements
+#### Python Environments extension improvements {#python-environments-extension-improvements}
 
 The [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) received several improvements this release:
 
@@ -536,7 +536,7 @@ The [Python Environments extension](https://marketplace.visualstudio.com/items?i
 * The generated `.venv` folders are now git-ignored by default
 * We've improved the environment deletion process
 
-#### Python Environments included as part of the Python extension
+#### Python Environments included as part of the Python extension {#python-environments-included-as-part-of-the-python-extension}
 
 We're starting to roll-out the [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) as an optional dependency with the Python extension. What this means is that you might now begin to see the Python Environments extension automatically installed alongside the Python extension, similar to the Python Debugger and Pylance extensions. This controlled roll-out allows us to gather early feedback and ensure reliability before general availability.
 
@@ -548,17 +548,17 @@ To use the Python Environments extension during the roll-out, make sure the exte
 "python.useEnvironmentsExtension": true
 ```
 
-#### Disabled PyREPL for Python 3.13
+#### Disabled PyREPL for Python 3.13 {#disabled-pyrepl-for-python-313}
 
 We have disabled PyREPL for Python 3.13 and above to address indentation and cursor issues in the interactive terminal. For more details, see [Disable PyREPL for >= 3.13](https://github.com/microsoft/vscode-python/issues/25164).
 
-#### Pylance MCP tools (Experimental)
+#### Pylance MCP tools (Experimental) {#pylance-mcp-tools-experimental}
 
 The [Pylance extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now includes several experimental MCP tools, which offer access to Pylance's documentation, import analysis, environment management, and more. These tools are currently available in the Pylance prerelease version and are still early in development. While they offer new capabilities, we know it can be challenging to call them directly today. We are actively working to make these tools easier to use and more valuable in future updates. Your feedback in the [pylance-release](https://github.com/microsoft/pylance-release/) repository is welcome as we continue to improve the experience.
 
-### GitHub authentication
+### GitHub authentication {#github-authentication}
 
-#### Revamped GitHub sign-in flow
+#### Revamped GitHub sign-in flow {#revamped-github-sign-in-flow}
 
 This iteration, we have revamped the GitHub sign-in flow by defaulting to a loopback URL flow, rather than a flow that uses a `vscode://` protocol URL. This change is to improve the reliability of the sign-in flow and to ensure that it works across all platforms, including those that do not support custom URL schemes.
 
@@ -570,9 +570,9 @@ While we were at it, we also gave this [landing page a fresh coat of paint](#rev
 
 ![Screenshot showing the redesigned authentication landing page.](https://code.visualstudio.com/assets/updates/1_102/auth-landing.png)
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### Allow opening files when using `vscode.openFolder` command
+### Allow opening files when using `vscode.openFolder` command {#allow-opening-files-when-using-vscode-openfolder-command}
 
 Extensions that call the `vscode.openFolder` command can now pass `filesToOpen?: UriComponents[]` as options to select files to open in the workspace window that opens.
 
@@ -582,32 +582,32 @@ Example:
 vscode.commands.executeCommand('vscode.openFolder', <folder uri>, { filesToOpen: [ /* files to open */]});
 ```
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
 
-## Engineering
+## Engineering {#engineering}
 
-### CSS minification using `esbuild`
+### CSS minification using `esbuild` {#css-minification-using-esbuild}
 
 VS Code has been using `esbuild` for bundling and minifying the JavaScript sources for a long time. We now also use `esbuild` to bundle and minify our CSS files.
 
-### Strict layer checks using `tsconfig.json`
+### Strict layer checks using `tsconfig.json` {#strict-layer-checks-using-tsconfig-json}
 
 We now use multiple `tsconfig.json` files to ensure our source code adheres to our [target environment rules](https://github.com/microsoft/vscode/wiki/Source-Code-Organization#target-environments). Our CI runs `npm run valid-layers-check` and will fail the build if for example a type was added into a `browser` layer that only exists in the `node` runtime.
 
-### `vscode-bisect` for sanity testing
+### `vscode-bisect` for sanity testing {#vscode-bisect-for-sanity-testing}
 
 The [`vscode-bisect`](https://github.com/Microsoft/vscode-bisect) project has been around for a long time allowing to find regressions in VS Code builds (what `git bisect` does for `git`). We added a new `--sanity` option that allows us to quickly go through our [sanity check](https://github.com/microsoft/vscode/wiki/Sanity-Check) that is mandatory before we release a new build.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [vscode-copilot-release#6073](https://github.com/microsoft/vscode-copilot-release/issues/6073) - Agent should not suggest `&&` in Windows PowerShell
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -617,7 +617,7 @@ Contributions to our issue tracking:
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
 
-### Pull requests
+### Pull requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_102.md
+++ b/docs/release-notes/v1_102.md
@@ -1,0 +1,695 @@
+---
+Order: 111
+TOCTitle: June 2025
+PageTitle: Visual Studio Code June 2025
+MetaDescription: Learn what is new in the Visual Studio Code June 2025 Release (1.102)
+MetaSocialImage: 1_102/release-highlights.png
+Date: 2025-07-09
+DownloadVersion: 1.102.0
+---
+# June 2025 (version 1.102)
+
+_Release date: July 9, 2025_
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the June 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+* **Chat**
+  * Explore and contribute to the open sourced GitHub Copilot Chat extension ([Read our blog post](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone)).
+  * Generate custom instructions that reflect your project's conventions ([Show more](#generate-custom-instructions)).
+  * Use custom modes to tailor chat for tasks like planning or research ([Show more](#chat-mode-improvements)).
+  * Automatically approve selected terminal commands ([Show more](#terminal-auto-approval-experimental)).
+  * Edit and resubmit previous chat requests ([Show more](#edit-previous-requests-experimental)).
+
+* **MCP**
+  * MCP support is now generally available in VS Code ([Show more](#mcp-support-in-vs-code-is-generally-available)).
+  * Easily install and manage MCP servers with the MCP view and gallery ([Show more](#mcp-server-discovery-and-installation)).
+  * MCP servers as first-class resources in profiles and Settings Sync ([Show more](#mcp-servers-as-first-class-resources)).
+
+* **Editor experience**
+  * Delegate tasks to Copilot coding agent and let it handle them in the background ([Show more](#start-a-coding-agent-session-preview)).
+  * Scroll the editor on middle click ([Show more](#scroll-on-middle-click)).
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+
+## Chat
+
+### Copilot Chat is open source
+
+We're excited to announce that we've open sourced the GitHub Copilot Chat extension! The source code is now available at [`microsoft/vscode-copilot-chat`](https://github.com/microsoft/vscode-copilot-chat) under the MIT license.
+
+This marks a significant milestone in our commitment to transparency and community collaboration. By open sourcing the extension, we're enabling the community to:
+
+* **Contribute directly** to the development of AI-powered chat experiences in VS Code
+* **Understand the implementation** of chat modes, custom instructions, and AI integrations
+* **Build upon our work** to create even better AI developer tools
+* **Participate in shaping the future** of AI-assisted coding
+
+You can explore the repository to see how features like [agent mode](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/prompts/node/agent/agentPrompt.tsx), [inline chat](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/prompts/node/inline/inlineChatEditCodePrompt.tsx), and [MCP integration](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx) are implemented. We welcome contributions, feedback, and collaboration from the community.
+
+To learn more about this milestone and our broader vision for open source AI editor tooling, read our detailed blog post: [Open Source AI Editor - First Milestone](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone).
+
+### Chat mode improvements
+
+Last milestone, we previewed [custom chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes#_custom-chat-modes). In addition to the built-in chat modes 'Ask', 'Edit' and 'Agent', you can define your own chat modes with specific instructions and a set of allowed tools that you want the LLM to follow when replying to a request.
+
+This milestone, we have made several improvements and bug fixes in this area.
+
+#### Configure language model
+
+Upon popular request, you can now also specify which language model should be used for a chat mode. Add the `model` metadata property to your `chatmode.md` file and provide the model identifier (we provide IntelliSense for the model info).
+
+![Screenshot that shows the IntelliSense for the model metadata property in chat mode file.](images/1_102/prompt-file-model-code-completion.png)
+
+#### Improved editing support
+
+The editor for [chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes), [prompts](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental), and [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) now supports completions, validation, and hovers for all supported metadata properties.
+
+![Screenshot that shows the hover information for tools.](images/1_102/tools-hover.png)
+
+![Screenshot that shows the model diagnostics when a model is not available for a specific chat mode.](images/1_102/prompt-file-diagnostics.png)
+
+#### Gear menu in the chat view
+
+The **Configure Chat** action in the Chat view toolbar lets you manage custom modes as well as reusable instructions, prompts, and tool sets:
+
+![Screenshot that shows the Configure Chat menu in the Chat view.](images/1_102/chat-gear.png)
+
+Selecting **Modes** shows all currently installed custom modes and enables you to open, create new, or delete modes.
+
+#### Import modes, prompts and instructions via a `vscode` link
+
+You can now import chat mode, reusable prompt and instruction files from external links, such as a gist or our [awesome-copilot](https://github.com/github/awesome-copilot) community repository. For example, the following link will import the chat mode file for Burke's GPT 4.1 Beast Mode:
+
+[Add GPT 4.1 Beast Mode to VS Code](vscode:chat-mode/install?url=https://raw.githubusercontent.com/github/awesome-copilot/refs/heads/main/chatmodes/4.1-Beast.chatmode.md)
+
+This will prompt for a destination, either your current workspace or your user settings, and confirm the name before importing the mode file from the URL.
+
+Try it out on the 100+ community-contributed instructions, prompts, and chat modes at [awesome-copilot](https://github.com/github/awesome-copilot).
+
+### Generate custom instructions
+
+Setting up [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization) for your project can significantly improve AI suggestions by providing context about your coding standards and project conventions. However, creating effective instructions from scratch might be challenging.
+
+This milestone, we're introducing the **Chat: Generate Instructions** command to help you bootstrap custom instructions for your workspace. Run this command from the Command Palette or the Configure menu in the Chat view, and agent mode will analyze your codebase to generate tailored instructions that reflect your project's structure, technologies, and patterns.
+
+The command creates a `copilot-instructions.md` file in your `.github` folder or suggests improvements to existing instruction files. You can then review and customize the generated instructions to match your team's specific needs.
+
+Learn more about [customizing AI responses with instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
+
+
+
+### Load instruction files on demand
+
+Instruction files can be used to describe coding practices and project requirements. Instructions can be manually or automatically included as context to chat requests.
+
+There are various mechanisms supported, see the [Custom Instructions](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) section in our documentation.
+
+For larger instructions that you want to include conditionally, you can use `.instructions.md` files in combination with glob patterns defined in the `applyTo` header. The file is automatically added when the glob pattern matches one or more of the files in the context of the chat.
+
+New in this release, the large language model can load instructions on demand. Each request gets a list of all instruction files, along with glob pattern and description. In this example, the LLM has no instructions for TypeScript files explicitly added in the context. So, it looks for code style rules before creating a TypeScript file:
+
+![Screenshot showing loading instruction files on demand.](images/1_102/instructions-loading-on-demand.png)
+
+### Edit previous requests (Experimental)
+
+You can now click on previous requests to modify the text content, attached context, mode, and model. Upon submitting this change, this will remove all subsequent requests, undo any edits made, and send the new request in chat.
+
+There will be a controlled rollout of different entry points to editing requests, which will help us gather feedback on preferential edit and undo flows. However, users can set their preferred mode with the experimental `setting(chat.editRequests)` setting:
+
+* `setting(chat.editRequests.inline)`: Hover a request and select the text to begin an edit inline with the request.
+* `setting(chat.editRequests.hover)`: Hover a request to reveal a toolbar with a button to begin an edit inline with the request.
+* `setting(chat.editRequests.input)`: Hover a request to reveal a toolbar, which will start edits in the input box at the bottom of chat.
+
+<video src="images/1_102/edit-previous-requests.mp4" title="Video showing the process of editing a previous request in the Chat view." autoplay loop controls muted></video>
+
+### Terminal auto approval (Experimental)
+
+Agent mode now has a mechanism for auto approving commands in the terminal. Here's a demo of it using the defaults:
+
+<video src="images/1_102/terminal-auto-approve.mp4" title="Video showing terminal commands like 'echo' and 'ls' being auto-approved in the Chat view." autoplay loop controls muted></video>
+
+There are currently two settings: the allow list and the deny list. The allow list is a list of command _prefixes_ or regular expressions that when matched allows the command to be run without explicit approval. For example, the following will allow any command starting with `npm run test` to be run, as well as _exactly_ `git status` or `git log`:
+
+```json
+"github.copilot.chat.agent.terminal.allowList": {
+  "npm run test": true,
+  "/^git (status|log)$/": true
+}
+```
+
+These settings are merged across setting scopes, such that you can have a set of user-approved commands, as well as workspace-specific approved commands.
+
+As for chained commands, we try to detect these cases based on the shell and require all sub-commands to be approved. So `foo && bar` we check that both `foo` and `bar` are allowed, only at that point will it run without approval. We also try to detect inline commands such as `echo $(pwd)`, which would check both `echo $(pwd)` and `pwd`.
+
+The deny list has the same format as the allow list but will override it and force approval. For now this is mostly of use if you have a broad entry in the allow list and want to block certain commands that it may include. For example the following will allow all commands starting with `npm run` except if it starts with `npm run danger`:
+
+```json
+"github.copilot.chat.agent.terminal.allowList": {
+  "npm run": true
+},
+"github.copilot.chat.agent.terminal.denyList": {
+  "npm run danger": true
+}
+```
+
+Thanks to the protections that we gain against prompt injection from [workspace trust](https://code.visualstudio.com/docs/editing/workspaces/workspace-trust), the philosophy we've approached when implementing this feature with regards to security is to include a small set of innocuous commands in the allow list, and a set of particularly dangerous ones in the deny list just in case they manage to slip through. The allow list is empty by default as we're still considering what the defaults should be, but here is what we're thinking:
+
+* Allow list: `echo`, `cd`, `ls`, `cat`, `pwd`, `Write-Host`, `Set-Location`, `Get-ChildItem`, `Get-Content`, `Get-Location`
+* Deny list: `rm`, `rmdir`, `del`, `kill`, `curl`, `wget`, `eval`, `chmod`, `chown`, `Remove-Item`
+
+The two major parts we want to add to this feature are a UI entry point to more easily add new commands to the list ([#253268](https://github.com/microsoft/vscode/issues/253268)) and an opt-in option to allow an LLM to evaluate the command(s) safety ([#253267](https://github.com/microsoft/vscode/issues/253267)). We are also planning on both removing the `github.copilot.` prefix of these settings ([#253314](https://github.com/microsoft/vscode/issues/253314)) as well as merging them together ([#253472](https://github.com/microsoft/vscode/issues/253472)) in the next release before it becomes a preview setting.
+
+### Terminal command simplification
+
+Agent mode sometimes wants to run commands with a `cd` statement, just in case. We now detect this case when it matches the current working directory and simplify the command that is run.
+
+![Screenshot of the terminal, asking to run `cd C:\Github\Tyriar\xterm.js && echo hello` only runs `echo hello` when the current working directory already matches.](images/1_102/terminal-working-dir.png)
+
+### Agent awareness of tasks and terminals
+
+Agent mode now understands which background terminals it has created and which tasks are actively running. The agent can read task output by using the new `GetTaskOutput` tool, which helps prevent running duplicate tasks and improves workspace context.
+
+![Screenshot of VS Code window showing two build tasks running in the terminal panel. The left terminal displays several errors. The chat agent replies to describe status of my build tasks with a summary of each task's output.](images/1_102/task-status.png)
+
+### Maximized chat view
+
+You can now maximize the Secondary Side Bar to span the editor area and hide the Primary Side Bar and panel area. VS Code will remember this state between restarts and will restore the Chat view when you open an editor or view.
+
+<video src="images/1_102/auxmax.mp4" title="Video showing maximizing the Secondary Side Bar." autoplay loop controls muted></video>
+
+You can toggle in and out of the maximized state by using the new icon next to the close button, or use the new command `workbench.action.toggleMaximizedAuxiliaryBar` from the Command Palette.
+
+### Agent mode badge indicator
+
+We now show a badge over the application icon in the dock when the window is not focused and the agent needs user confirmation to continue. The badge will disappear as soon as the related window that triggered it receives focus.
+
+![Screenshot of the VS Code dock icon showing an agent confirmation as a badge.](./images/1_102/badge.png)
+
+You can enable or disable this badge via the `setting(chat.notifyWindowOnConfirmation)` setting.
+
+### Start chat from the command line
+
+A new subcommand `chat` is added to the VS Code CLI that enables you to start a chat session in the current working directory with the prompt provided.
+
+<video src="images/1_102/chatcli.mp4" title="Video showing the Chat CLI in action to open the Chat view from the command line and run a prompt." autoplay loop controls muted></video>
+
+The basic syntax is `code chat [options] [prompt]` and options can be any of:
+
+* `-m --mode <mode>`: The mode to use for the chat session. Available options: 'ask', 'edit', 'agent', or the identifier of a custom mode. Defaults to 'agent'
+* `-a --add-file <path>`: Add files as context to the chat session
+* `--maximize`: Maximize the chat session view
+* `-r --reuse-window`: Force to use the last active window for the chat session
+* `-n --new-window`: Force to open an empty window for the chat session
+
+Reading from stdin is supported, provided you pass in `-` at the end, for example `ps aux | grep code | code chat <prompt> -`
+
+### Fetch tool supports non-HTTP URLs
+
+We've seen that, on occasion, models want to call the Fetch tool with non-HTTP URLs, such as `file://` URLs. Rather than disallowing this, the Fetch tool now supports these URLs and returns the content of the file or resource at the URL. Images are also supported.
+
+### Clearer language model access management
+
+We've reworked the UX around managing extension access to language models provided by extensions. Previously, you saw an item in the Account menu that said **AccountName (GitHub Copilot Chat)**, which had nothing to do with what account GitHub Copilot Chat was using. Rather, it allowed you to manage which extensions had access to the language models provided by Copilot Chat.
+
+To make this clearer, we've removed the **AccountName (GitHub Copilot Chat)** item and replaced it with a new item called **Manage Language Model Access...**. This item opens a Quick Pick that enables you to manage which extensions have access to the language models provided by GitHub Copilot Chat.
+
+![Screenshot that shows the language model access Quick Pick.](images/1_102/lm-access-qp.png)
+
+We think this is clearer... That said, in a future release we will explore more granular access control for language models (for example, only allowing specific models rather than _all_ models provided by an extension), so stay tuned for that.
+
+### Reading chat requests
+
+Since the chat extension itself is open source, you now get access to one of the debugging tools that we've been using internally for awhile. To easily see the details of all requests made by Copilot Chat, run the command "Show Chat Debug View". This will show a treeview with an entry for each request made. You can see the full prompt that was sent to the model, the tools that were enabled, the response, and other key details. You can save the request log with right click > "Export As...".
+
+The view also has entries for tool calls on their own, and a prompt-tsx debug view that opens in the Simple Browser.
+
+> 🚨 **Note**: This log is very helpful in troubleshooting issues, and we will appreciate if you share it when filing an issue about the agent's behavior. But, this log may contain personal information such as the contents of your files or terminal output. Please review the contents carefully before sharing it with anyone else.
+
+### Edit Tool Improvements
+
+This release includes several changes to the predictability and reliability of the edit tools used for GPT-4 models and Sonnet models. You should see more reliable editing behavior in this release and we will continue to improve these tools in future releases.
+
+## MCP
+
+### MCP support in VS Code is generally available
+
+We've have been working on expanding MCP support in VS Code for the past few months, and [support the full range of MCP features in the specification](https://code.visualstudio.com/blogs/2025/06/12/full-mcp-spec-support). As of this release, MCP support is now generally available in VS Code!
+
+In addition, organizations can now control the availability of MCP servers with a GitHub Copilot policy. Learn more about [Managing policies and features for Copilot in your enterprise](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/administer/enterprises/managing-policies-and-features-for-copilot-in-your-enterprise) in the GitHub Copilot documentation.
+
+You can get started by installing some of the [popular MCP servers from our curated list](https://code.visualstudio.com/mcp). Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) and how you can use them to extend agent mode.
+
+![Screenshot that shows the MCP Servers page.](images/1_102/mcp-servers-page.png)
+
+If you want to build your own MCP server, check our [MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) for more details about how to take advantage of the MCP capabilities in VS Code.
+
+### Support for elicitations
+
+The latest MCP specification added support for [Elicitations](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) as a way for MCP servers to request input from MCP clients. The latest version of VS Code adopts this specification and includes support for elicitations.
+
+<video src="images/1_102/mcp-server-elicit.mp4" autoplay loop controls muted></video>
+
+### MCP server discovery and installation
+
+The new **MCP Servers** section in the Extensions view includes welcome content that links directly to the [popular MCP servers from our curated list](https://code.visualstudio.com/mcp). Visit the website to explore available MCP servers and select **Install** on any MCP server. This automatically launches VS Code and opens the MCP server editor that displays the server's readme and manifest information. You can review the server details and select **Install** to add the server to your VS Code instance.
+
+Once installed, MCP servers automatically appear in your Extensions view under the **MCP SERVERS - INSTALLED** section, and their tools become available in the Chat view's tools Quick Pick. This makes it easy to verify that your MCP server is working correctly and access its capabilities immediately.
+
+<video src="images/1_102/mcp-servers-discovery-install.mp4" title="Video showing installing an MCP server from the MCP page on the VS Code website." autoplay loop controls muted></video>
+
+### MCP server management view
+
+The new **MCP SERVERS - INSTALLED** view in the Extensions view makes it easy to monitor, configure, and control your installed MCP servers.
+
+![Screenshot showing the MCP Servers management view with installed servers.](images/1_102/mcp-servers-installed-view.png)
+
+The view lists the installed MCP servers and provides several management actions through the context menu:
+
+![Screenshot showing the context menu actions for an MCP server.](images/1_102/mcp-server-context-menu.png)
+
+* **Start Server** / **Stop Server** / **Restart Server**: Control the server's running state
+* **Disconnect Account**: Remove account access from the server
+* **Show Output**: View the server's output logs for troubleshooting
+* **Show Configuration**: Open the server's runtime configuration
+* **Configure Model Access**: Manage which language models the server can access
+* **Show Sampling Requests**: View sampling requests for debugging
+* **Browse Resources**: Explore resources provided by the server
+* **Uninstall**: Remove the server from your VS Code instance
+
+When you select an installed MCP server, VS Code opens the MCP server editor displaying the server's readme details, manifest, and its runtime configuration. This provides an overview of the server's capabilities and current settings, making it easy to understand what the server does and how it's configured.
+
+![Screenshot showing the MCP server editor with runtime configuration.](images/1_102/mcp-server-editor-configuration.png)
+
+The **MCP SERVERS - INSTALLED** view also provides a **Browse MCP Servers...** action that takes you directly to the community website, making server discovery always accessible from within VS Code.
+
+![Screenshot that shows the Browse MCP Servers action in the MCP Servers view.](images/1_102/mcp-servers-browse-action.png)
+
+### MCP servers as first class resources
+
+MCP servers are now treated as first-class resources in VS Code, similar to user tasks and other profile-specific configurations. This represents a significant architectural improvement from the previous approach where MCP servers were stored in user settings. This change makes MCP server management more robust and provides better separation of concerns between your general VS Code settings and your MCP server configurations. When you install or configure MCP servers, they're automatically stored in the appropriate [profile](https://code.visualstudio.com/docs/configure/profiles)-specific location to ensure that your main settings file stays clean and focused.
+
+* **Dedicated storage**: MCP servers are now stored in a dedicated `mcp.json` file within each profile, rather than cluttering your user settings file
+* **Profile-specific**: Each VS Code profile maintains its own set of MCP servers, enabling you to have different server configurations for different workflows or projects
+* **Settings Sync integration**: MCP servers sync seamlessly across your devices through [Settings Sync](https://code.visualstudio.com/docs/configure/settings-sync), with granular control over what gets synchronized
+
+#### MCP migration support
+
+With MCP servers being first-class resources and the associated change to their configuration, VS Code provides comprehensive migration support for users upgrading from the previous MCP server configuration format:
+
+* **Automatic detection**: Existing MCP servers in `settings.json` are automatically detected and migrated to the new profile-specific `mcp.json` format
+* **Real-time migration**: When you add MCP servers to user settings, VS Code immediately migrates them with a helpful notification explaining the change
+* **Cross-platform support**: Migration works seamlessly across all development scenarios including local, remote, WSL, and Codespaces environments
+
+This migration ensures that your existing MCP server configurations continue to work without any manual intervention while providing the enhanced management capabilities of the new architecture.
+
+#### Dev Container support for MCP configuration
+
+The Dev Container configuration `devcontainer.json` and the Dev Container Feature configuration `devcontainer-feature.json` support MCP server configurations at the path `customizations.vscode.mcp`. When a Dev Container is created the collected MCP server configurations are written to the remote MCP configuration file `mcp.json`.
+
+Sample `devcontainer.json` configuring the Playwright MCP server:
+```json
+{
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:latest",
+
+	"customizations": {
+		"vscode": {
+			"mcp": {
+				"servers": {
+					"playwright": {
+						"command": "npx",
+						"args": [
+							"@playwright/mcp@latest"
+						]
+					}
+				}
+			}
+		}
+	}
+}
+```
+
+#### Commands to access MCP resources
+
+To make working with MCP servers more accessible, we've added commands to help you manage and access your MCP configuration files:
+
+* **MCP: Open User Configuration** - Direct access to your user-level `mcp.json` file
+* **MCP: Open Remote User Configuration** - Direct access to your remote user-level `mcp.json` file
+
+These commands provide quick access to your MCP configuration files, making it easy to view and manage your server configurations directly.
+
+### Quick management of MCP authentication
+
+You are now able to sign out or disconnect accounts from the MCP gear menu and quick picks.
+
+* MCP view gear menu:
+    ![Screenshot showing the Disconnect Account action shown in MCP view gear menu.](images/1_102/mcp-view-signout.png)
+
+* MCP editor gear menu:
+    ![Screenshot showing the Disconnect Account action shown in MCP editor gear menu.](images/1_102/mcp-editor-signout.png)
+
+* MCP quick pick:
+    ![Screenshot showing the Disconnect Account action shown in MCP quick pick menu.](images/1_102/mcp-qp-signout.png)
+
+The **Disconnect** action is shown when the account is used by either other MCP servers or extensions, while **Sign Out** is shown when the account is only used by the MCP server. The sign out action completely removes the account from VS Code, while disconnect only removes access to the account from the MCP server.
+
+## Accessibility
+
+### Keep all edits from within the editor
+
+Formerly, to accept all edits, focus would need to be in the Chat view. Now, with focus in the editor, you can run the command **Keep All Edits** (`kb(chatEditor.action.acceptAllEdits)`).
+
+### User action required sound
+
+We’ve fine-tuned the accessibility signal to indicate when chat requires user action and set the default value to `auto`, so screen reader users will hear this signal. You can configure this behavior with the `setting(accessibility.signals.chatUserActionRequired)` setting.
+
+### Alert when rendering errors occur in chat
+
+Previously, screen reader users were not alerted when a chat rendering error occurred . Users are now alerted with this information and can also focus it via keyboard.
+
+## Code Editing
+
+### Scroll on middle click
+
+**Setting**: `setting(editor.scrollOnMiddleClick:true)`
+
+Scroll the editor by simply clicking, or holding down your middle mouse button (the scroll wheel) and moving around.
+
+Once activated, the cursor changes to a panning icon and moving the mouse up or down then smoothly scrolls the editor in that direction. The scrolling speed is determined by how far you move the mouse from the initial click point. Release the middle mouse button or click it again to stop scrolling and return to the standard cursor.
+
+<video src="images/1_102/middle-scroll.mp4" title="Screenrecording of the editor scrolling when the middle mouse button is clicked." autoplay loop controls muted></video>
+
+**Known Conflicts**
+
+Enabling this feature might interfere with other actions tied to the middle mouse button. For example, if you have column selection (`setting(editor.columnSelection)`) enabled, holding down the middle mouse button selects text. Similarly, on Linux, selection clipboard (`setting(editor.selectionClipboard)`) pastes content from your clipboard when the middle mouse button is clicked.
+
+To avoid these conflicts, please enable only one of these settings at a time.
+
+### Snooze code completions
+
+You can now temporarily pause inline suggestions and next edit suggestions (NES) by using the new **Snooze** feature. This is helpful when you want to focus without distraction from suggestions.
+
+To snooze suggestions, select the Copilot dashboard in the Status Bar, or run the **Snooze Inline Suggestions** command from the Command Palette and select a duration from the dropdown menu. During the snooze period, no inline suggestions or NES will appear.
+
+![Screenshot showing the Copilot dashboard with the snooze button at the bottom.](images/1_102/nes-snooze.png)
+
+You can also assign a custom keybinding to quickly snooze suggestions for a specific duration by passing the desired duration as an argument to the command. For example:
+
+```json
+{
+  "key": "...",
+  "command": "editor.action.inlineSuggest.snooze",
+  "args": 10
+}
+```
+
+## Editor Experience
+
+### Windows accent color
+
+**Setting**: `setting(window.border)`
+
+VS Code on Windows now supports using the accent color as the window frame border if that is enabled in Windows settings ("Show accent color on title bars and window borders").
+
+![Screenshot of the VS Code window with a red accent color border.](images/1_102/window-accent.png)
+
+The new `setting(window.border)` setting enables you to control the color of the window border. Use `default` to use the Windows accent color, `off` to disable the border, or provide a specific color value to use a custom color.
+
+**Note**: the border is only visible when the related Windows setting is enabled. It can not yet be set per workspace, but we are working on that support.
+
+### Settings search suggestions (Preview)
+
+**Setting**: `setting(workbench.settings.showAISearchToggle:true)`
+
+This milestone, we modified the sparkle toggle in the Settings editor, so that it acts as a toggle between the AI and non-AI search results. The AI settings search results are semantically similar results instead of results that are based on string matching. For example, `editor.fontSize` appears as an AI settings search result when you search for "increase text size".
+
+The toggle is enabled only when there are AI results available. We welcome feedback on when the AI settings search did not find an expected setting, and we plan to enable the setting by default over the next iteration.
+
+<video src="images/1_102/settings-search-toggle-stable.mp4" title="Switching between AI and non-AI results using the AI results toggle in the Settings editor" autoplay loop controls muted></video>
+
+## Tasks
+
+### Rerun all running tasks
+
+You can now quickly rerun all currently running tasks with the new `Tasks: Rerun All Running Tasks command`. This is useful for workflows that involve multiple concurrent tasks, allowing you to restart them all at once without stopping and rerunning each individually.
+
+### Restart task reloads updated tasks.json
+
+The **Restart Task** command now reloads your `tasks.json` before restarting, ensuring that any recent changes are respected. Previously, task configuration changes were not picked up when restarting a task, which could lead to confusion or outdated task behavior.
+
+## Terminal
+
+### Terminal Suggest (Preview)
+
+We've made significant improvements to the terminal suggest feature.
+
+#### Selection mode
+
+A new setting, `terminal.integrated.suggest.selectionMode`, helps you understand that by default, `kbStyle(Tab)` (not `kbStyle(Enter)`) accepts suggestions. You can choose between `partial`, `always`, and `never` modes to control how suggestions are selected and accepted.
+
+The default value is `partial`, which means that `kbStyle(Tab)` accepts the suggestion until navigation has occurred.
+
+![Screenshot showing the first terminal suggestion can be accepted with Tab.](images/1_102/terminal-selection-mode.png)
+
+#### Learn more
+
+The **Learn More** action `(kb(workbench.action.terminal.suggestLearnMore))` in the terminal suggest control's status bar is now highlighted for the first 10 times or if the control is shown for 10 seconds. This helps you discover how to configure, disable, and read about the suggest control.
+
+![Screenshot showing the Learn More action appears in the terminal suggest control status bar.](images/1_102/terminal-suggest-discoverability.png)
+
+#### Multi-command support
+
+Terminal suggest now supports multi-command lines. You can link commands with `;`, `&&`, and other shell operators, and receive suggestions for all commands on the line.
+
+![Screenshot showing the VS Code terminal showing a multi-command line with git commit and git push, and the terminal suggest widget displaying suggestions for pull, push, and other git commands.](images/1_102/terminal-suggest-multi.png)
+
+#### Symlink information
+
+We now display a symlink's realpath in the suggest details control and have unique icons for symlink files and folders to help distinguish them from other suggestions.
+
+![Screenshot showing the terminal suggest shows the symlink's path -> real path.](images/1_102/terminal-symlink.png)
+
+#### Improved sorting
+
+We've improved sorting in many ways to give you the most relevant suggestions first. For example, giving `main` and `master` priority over other branches.
+
+![Screenshot showing the terminal suggest boosts main and master compared to other branch suggestions.](images/1_102/terminal-suggest-sorting.png)
+
+#### Git bash improvements
+
+We now properly support Git Bash path completions for folders and files. Additionally, we source the built-in commands and present them as suggestions.
+
+![Screenshot showing a Git Bash terminal with suggestions for builtin functions like cat, cp, and curl.](images/1_102/terminal-git-bash.png)
+
+## Contributions to extensions
+
+### GitHub Pull Requests
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
+
+Deeper integration has been made between the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension and [Copilot coding agent](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent), allowing you to begin, view, and manage coding agent sessions directly from VS Code.
+
+These features require that your workspace is open to a repository that has [the Copilot coding agent enabled](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/enabling-copilot-coding-agent).
+
+Review the [changelog for the 0.114.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01140) release of the extension to learn about everything in the release.
+
+#### Start a coding agent session (Preview)
+
+Ask Copilot to continue a local change in the background by invoking the `#copilotCodingAgent` tool in chat.
+
+This tool automatically pushes pending changes to a remote branch and initiates a coding agent session from that branch along with the user's instruction.
+
+![Screenshot showing handing off a session to Copilot coding agent](images/1_102/coding-agent-start.png)
+
+**Experimental:** Deeper UI integration can be enabled with the `setting(githubPullRequests.codingAgent.uiIntegration)` setting.  Once enabled, a new **Delegate to coding agent** button appears in the Chat view for repositories that have the agent enabled.
+
+#### Status tracking
+
+We have made improvements to notify and prominently display the status of coding agent pull requests in the **Copilot on my behalf** query. A numeric badge now indicates new changes.
+
+![Screenshot showing status of multiple coding agent pull requests](images/1_102/coding-agent-status.png)
+
+#### Session log
+
+You can now view the session log of a coding agent session directly in VS Code. This enables you to see the history of actions taken by the coding agent, including code changes and tool usage.
+
+![Screenshot showing the session log of a coding agent session.](images/1_102/coding-agent-session-log.png)
+
+#### Enhancements on `#activePullRequest` tool
+
+The `#activePullRequest` tool returns information about the pull request, such as its title, description, and status for use in chat, and now you can also use it to get the coding agent session information.
+
+This tool is automatically attached to chat when opening a pull request created through the coding agent experience, so you can maintain the context and keep working on the pull request if needed to.
+
+### Python
+
+#### Python Environments extension improvements
+
+The [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) received several improvements this release:
+
+* We've polished terminal activation support for Poetry versions greater than 2.0.0
+* You can now use the Quick Create environment creation option to set up multiple virtual environments which are uniquely named within the same workspace
+* The generated `.venv` folders are now git-ignored by default
+* We've improved the environment deletion process
+
+#### Python Environments included as part of the Python extension
+
+We're starting to roll-out the [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) as an optional dependency with the Python extension. What this means is that you might now begin to see the Python Environments extension automatically installed alongside the Python extension, similar to the Python Debugger and Pylance extensions. This controlled roll-out allows us to gather early feedback and ensure reliability before general availability.
+
+The Python Environments extension includes all the core capabilities we've introduced so far including: [one-click environment setup using Quick Create](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2025-release/#python-environments-quick-create-command), automatic terminal activation (via "python-envs.terminal.autoActivationType" setting), and all supported [UI for environment and package management](https://devblogs.microsoft.com/python/python-in-visual-studio-code-december-2024-release/).
+
+To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code settings.json file:
+
+```json
+"python.useEnvironmentsExtension": true
+```
+
+#### Disabled PyREPL for Python 3.13
+
+We have disabled PyREPL for Python 3.13 and above to address indentation and cursor issues in the interactive terminal. For more details, see [Disable PyREPL for >= 3.13](https://github.com/microsoft/vscode-python/issues/25164).
+
+#### Pylance MCP tools (Experimental)
+
+The [Pylance extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now includes several experimental MCP tools, which offer access to Pylance's documentation, import analysis, environment management, and more. These tools are currently available in the Pylance prerelease version and are still early in development. While they offer new capabilities, we know it can be challenging to call them directly today. We are actively working to make these tools easier to use and more valuable in future updates. Your feedback in the [pylance-release](https://github.com/microsoft/pylance-release/) repository is welcome as we continue to improve the experience.
+
+### GitHub authentication
+
+#### Revamped GitHub sign-in flow
+
+This iteration, we have revamped the GitHub sign-in flow by defaulting to a loopback URL flow, rather than a flow that uses a `vscode://` protocol URL. This change is to improve the reliability of the sign-in flow and to ensure that it works across all platforms, including those that do not support custom URL schemes.
+
+When you sign in with GitHub, you are now redirected to a loopback URL that looks like `http://localhost:PORT/`. This allows the sign-in flow to complete successfully without relying on custom URL schemes. That said, once you land on the loopback URL, you are still redirected to a `vscode://` URL to return to VS Code, however this doesn't need to resolve for the sign-in flow to complete successfully.
+
+In other words, we get the best of both worlds: a reliable sign-in flow that works across all platforms and a return to VS Code that uses the `vscode://` URL scheme.
+
+While we were at it, we also gave this [landing page a fresh coat of paint](#revamped-github-sign-in-flow). In future iterations, we'll apply this new design to other sign-in experiences.
+
+![Screenshot showing the redesigned authentication landing page.](./images/1_102/auth-landing.png)
+
+## Extension Authoring
+
+### Allow opening files when using `vscode.openFolder` command
+
+Extensions that call the `vscode.openFolder` command can now pass `filesToOpen?: UriComponents[]` as options to select files to open in the workspace window that opens.
+
+Example:
+
+```ts
+vscode.commands.executeCommand('vscode.openFolder', <folder uri>, { filesToOpen: [ /* files to open */]});
+```
+
+## Proposed APIs
+
+
+## Engineering
+
+### CSS minification using `esbuild`
+
+VS Code has been using `esbuild` for bundling and minifying the JavaScript sources for a long time. We now also use `esbuild` to bundle and minify our CSS files.
+
+### Strict layer checks using `tsconfig.json`
+
+We now use multiple `tsconfig.json` files to ensure our source code adheres to our [target environment rules](https://github.com/microsoft/vscode/wiki/Source-Code-Organization#target-environments). Our CI runs `npm run valid-layers-check` and will fail the build if for example a type was added into a `browser` layer that only exists in the `node` runtime.
+
+### `vscode-bisect` for sanity testing
+
+The [`vscode-bisect`](https://github.com/Microsoft/vscode-bisect) project has been around for a long time allowing to find regressions in VS Code builds (what `git bisect` does for `git`). We added a new `--sanity` option that allows us to quickly go through our [sanity check](https://github.com/microsoft/vscode/wiki/Sanity-Check) that is mandatory before we release a new build.
+
+## Notable fixes
+
+* [vscode-copilot-release#6073](https://github.com/microsoft/vscode-copilot-release/issues/6073) - Agent should not suggest `&&` in Windows PowerShell
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
+
+### Pull requests
+
+Contributions to `vscode`:
+
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Fix typing in asyncDataTree.test.ts [PR #209394](https://github.com/microsoft/vscode/pull/209394)
+* [@charles7668 (charles)](https://github.com/charles7668): Fix #215925 [PR #219321](https://github.com/microsoft/vscode/pull/219321)
+* [@chengluyu (Luyu Cheng)](https://github.com/chengluyu): Apply `font-variation-settings` to the suggestion widget (fix #199954) [PR #200000](https://github.com/microsoft/vscode/pull/200000)
+* [@DrSergei](https://github.com/DrSergei): Improve debug adapter capabilities checking [PR #250779](https://github.com/microsoft/vscode/pull/250779)
+* [@emmanuel-ferdman (Emmanuel Ferdman)](https://github.com/emmanuel-ferdman): Fix launch.json reference [PR #250187](https://github.com/microsoft/vscode/pull/250187)
+* [@Enzo-Nunes (Enzo Nunes)](https://github.com/Enzo-Nunes): Fix line comment action for makefiles (Fixes #234464) [PR #243283](https://github.com/microsoft/vscode/pull/243283)
+* [@Gallaecio (Adrián Chaves)](https://github.com/Gallaecio): Fix typo (an language model call → a language model call) [PR #252202](https://github.com/microsoft/vscode/pull/252202)
+* [@ghLcd9dG (Liu)](https://github.com/ghLcd9dG): Update copyFiles.ts [PR #250773](https://github.com/microsoft/vscode/pull/250773)
+* [@heoh (HeoHeo)](https://github.com/heoh): Fix markdown preview scroll crawls at EOF (fix #249278) [PR #251228](https://github.com/microsoft/vscode/pull/251228)
+* [@hyrious (hyrious)](https://github.com/hyrious): fix: missing translations of remote built-in extensions [PR #249430](https://github.com/microsoft/vscode/pull/249430)
+* [@jeanp413 (Jean Pierre)](https://github.com/jeanp413)
+  * Do not check for navigator to detect web environment in built-in extensions [PR #251688](https://github.com/microsoft/vscode/pull/251688)
+  * Fix "Assertion Failed: Argument is undefined or null" when renaming custom editor [PR #252071](https://github.com/microsoft/vscode/pull/252071)
+* [@JJJJJJ-git](https://github.com/JJJJJJ-git): Fixing ChatService undo bug [PR #253478](https://github.com/microsoft/vscode/pull/253478)
+* [@liuxingbaoyu](https://github.com/liuxingbaoyu): fix: PowerShell not working with username having Unicode [PR #251534](https://github.com/microsoft/vscode/pull/251534)
+* [@matthew-godin](https://github.com/matthew-godin): fix patternIndices typo [PR #250085](https://github.com/microsoft/vscode/pull/250085)
+* [@mohiuddin-khan-shiam (S. M. Mohiuddin Khan Shiam)](https://github.com/mohiuddin-khan-shiam): Fix incorrect SHA-1 commit regex in [version_manager.rs](cci:7://file:///d:/Github/vscode/cli/src/desktop/version_manager.rs:0:0-0:0) [PR #251329](https://github.com/microsoft/vscode/pull/251329)
+* [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango)
+  * feat: add font ligatures to webview theme [PR #250998](https://github.com/microsoft/vscode/pull/250998)
+  * feat: add rerun and debug actions for failed tests from last run [PR #251679](https://github.com/microsoft/vscode/pull/251679)
+* [@raffaeu (Raffaele Garofalo)](https://github.com/raffaeu): Refactoring editor sticky scroll [PR #248131](https://github.com/microsoft/vscode/pull/248131)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+  * Disable `installation folder` banner warning when debugging extensions [PR #244305](https://github.com/microsoft/vscode/pull/244305)
+  * TypeScript restrict Comment onEnterRules inside comment body [PR #251692](https://github.com/microsoft/vscode/pull/251692)
+* [@ssigwart (Stephen Sigwart)](https://github.com/ssigwart): Update indentation for PHP, JS, and TS [PR #251465](https://github.com/microsoft/vscode/pull/251465)
+* [@Sublimeful (Jian Qiang Wu)](https://github.com/Sublimeful): Implements Terminal: Run Recent Command when there are no terminals [PR #250799](https://github.com/microsoft/vscode/pull/250799)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): [engineering] remove dead references to Swc transpile [PR #252375](https://github.com/microsoft/vscode/pull/252375)
+* [@UziTech (Tony Brix)](https://github.com/UziTech): feat: add middle mouse button scrolling [PR #245882](https://github.com/microsoft/vscode/pull/245882)
+* [@yiliang114 (易良)](https://github.com/yiliang114): Fix #250737,  Match count result overflow in Notebook findWidget [PR #250738](https://github.com/microsoft/vscode/pull/250738)
+
+Contributions to `vscode-copilot-chat`:
+
+* [@caohy1988 (Hai-Yuan Cao)](https://github.com/caohy1988): update the summary prompt for agent mode [PR #13](https://github.com/microsoft/vscode-copilot-chat/pull/13)
+* [@CharlesCNorton](https://github.com/CharlesCNorton): Update README.md [PR #54](https://github.com/microsoft/vscode-copilot-chat/pull/54)
+* [@gmacario (Gianpaolo Macario)](https://github.com/gmacario): docs(CONTRIBUTING): sync Table of Contents [PR #79](https://github.com/microsoft/vscode-copilot-chat/pull/79)
+* [@moonboxing (ASSEMAR MOHAMED)](https://github.com/moonboxing): update devcontainer-lock after pylint removal [PR #76](https://github.com/microsoft/vscode-copilot-chat/pull/76)
+
+Contributions to `vscode-json-languageservice`:
+
+* [@aedenmurray (Aeden Murray)](https://github.com/aedenmurray): feat: Notify Invalid RegExp Patterns [PR #261](https://github.com/microsoft/vscode-json-languageservice/pull/261)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@dyhagho (Dyhagho Briceño)](https://github.com/dyhagho): fix: Allow Github.com auth when `github-enterprise.uri` is set [PR #7002](https://github.com/microsoft/vscode-pull-request-github/pull/7002)
+
+Contributions to `vscode-ripgrep`:
+
+* [@benz0li (Olivier Benz)](https://github.com/benz0li): Add linux riscv64 target [PR #73](https://github.com/microsoft/vscode-ripgrep/pull/73)
+* [@Vector341](https://github.com/Vector341): Fix invalid download crash install [PR #66](https://github.com/microsoft/vscode-ripgrep/pull/66)
+
+Contributions to `vscode-test`:
+
+* [@coliff (Christian Oliff)](https://github.com/coliff): Update .npmignore [PR #312](https://github.com/microsoft/vscode-test/pull/312)
+
+Contributions to `language-server-protocol`:
+
+* [@billybonks (Sebastien Stettler)](https://github.com/billybonks): fix: improve readability of comment, [PR #2155](https://github.com/microsoft/language-server-protocol/pull/2155)
+* [@rcjsuen (Remy Suen)](https://github.com/rcjsuen): Add the Docker Language Server to the list [PR #2153](https://github.com/microsoft/language-server-protocol/pull/2153)
+* [@yangdanny97 (Danny Yang)](https://github.com/yangdanny97): Add Pyrefly to language servers list  [PR #2160](https://github.com/microsoft/language-server-protocol/pull/2160)
+
+Contributions to `monaco-editor`:
+
+* [@Ho1yShif (Shifra Williams)](https://github.com/Ho1yShif): Add snowflake sql keywords [PR #4915](https://github.com/microsoft/monaco-editor/pull/4915)
+
+Contributions to `ripgrep-prebuilt`:
+
+* [@kxxt (Levi Zim)](https://github.com/kxxt)
+  * Build binaries for riscv64 [PR #41](https://github.com/microsoft/ripgrep-prebuilt/pull/41)
+  * Publish binary for riscv64 linux [PR #51](https://github.com/microsoft/ripgrep-prebuilt/pull/51)
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_102.md
+++ b/docs/release-notes/v1_102.md
@@ -1,139 +1,139 @@
 ---
 Order: 111
-TOCTitle: June 2025
-PageTitle: Visual Studio Code June 2025
-MetaDescription: Learn what is new in the Visual Studio Code June 2025 Release (1.102)
+TOCTitle: 2025 年 6 月
+PageTitle: Visual Studio Code 2025 年 6 月
+MetaDescription: Visual Studio Code 2025 年 6 月リリース (1.102) の新機能を紹介
 MetaSocialImage: 1_102/release-highlights.png
 Date: 2025-07-09
 DownloadVersion: 1.102.0
 ---
-# June 2025 (version 1.102) {#june-2025-version-1102}
+# 2025 年 6 月 (バージョン 1.102) {#june-2025-version-1102}
 
-_Release date: July 9, 2025_
+_リリース日: 2025 年 7 月 9 日_
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the June 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code 2025 年 6 月リリースへようこそ。 このバージョンには多くのアップデートが含まれており、きっと気に入っていただけると思います。 主なハイライトは以下の通りです:
 
-* **Chat**
-  * Explore and contribute to the open sourced GitHub Copilot Chat extension ([Read our blog post](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone)).
-  * Generate custom instructions that reflect your project's conventions ([Show more](#generate-custom-instructions)).
-  * Use custom modes to tailor chat for tasks like planning or research ([Show more](#chat-mode-improvements)).
-  * Automatically approve selected terminal commands ([Show more](#terminal-auto-approval-experimental)).
-  * Edit and resubmit previous chat requests ([Show more](#edit-previous-requests-experimental)).
+* **チャット**
+  * オープンソース化された GitHub Copilot Chat 拡張機能の探索とコントリビュート ([ブログ記事を読む](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone))
+  * プロジェクトの規約を反映したカスタムインストラクションの生成 ([詳細](#generate-custom-instructions))
+  * 計画やリサーチなどのタスクに合わせてチャットをカスタマイズできるモードの利用 ([詳細](#chat-mode-improvements))
+  * 選択したターミナルコマンドの自動承認 ([詳細](#terminal-auto-approval-experimental))
+  * 過去のチャットリクエストの編集と再送信 ([詳細](#edit-previous-requests-experimental))
 
 * **MCP**
-  * MCP support is now generally available in VS Code ([Show more](#mcp-support-in-vs-code-is-generally-available)).
-  * Easily install and manage MCP servers with the MCP view and gallery ([Show more](#mcp-server-discovery-and-installation)).
-  * MCP servers as first-class resources in profiles and Settings Sync ([Show more](#mcp-servers-as-first-class-resources)).
+  * VS Code での MCP サポートが正式リリース ([詳細](#mcp-support-in-vs-code-is-generally-available))
+  * MCP ビューとギャラリーによる MCP サーバーの簡単なインストールと管理 ([詳細](#mcp-server-discovery-and-installation))
+  * プロファイルや設定同期での MCP サーバーのファーストクラスリソース化 ([詳細](#mcp-servers-as-first-class-resources))
 
-* **Editor experience**
-  * Delegate tasks to Copilot coding agent and let it handle them in the background ([Show more](#start-a-coding-agent-session-preview)).
-  * Scroll the editor on middle click ([Show more](#scroll-on-middle-click)).
+* **エディター体験**
+  * Copilot コーディングエージェントにタスクを委任し、バックグラウンドで処理 ([詳細](#start-a-coding-agent-session-preview))
+  * ミドルクリックによるエディターのスクロール ([詳細](#scroll-on-middle-click))
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
-**Insiders:** Want to try new features as soon as possible? You can download the nightly [Insiders](https://code.visualstudio.com/insiders) build and try the latest updates as soon as they are available.
+> これらのリリースノートをオンラインでご覧になりたい場合は、[code.visualstudio.com](https://code.visualstudio.com/updates) の [Updates](https://code.visualstudio.com/updates) をご参照ください。
+**Insiders:** 新機能をいち早く試したい方は、[Insiders](https://code.visualstudio.com/insiders) ビルドをダウンロードして、最新のアップデートをすぐにお試しいただけます。
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Copilot Chat is open source {#copilot-chat-is-open-source}
+### Copilot Chat のオープンソース化 {#copilot-chat-is-open-source}
 
-We're excited to announce that we've open sourced the GitHub Copilot Chat extension! The source code is now available at [`microsoft/vscode-copilot-chat`](https://github.com/microsoft/vscode-copilot-chat) under the MIT license.
+GitHub Copilot Chat 拡張機能をオープンソース化したことをお知らせします！ ソースコードは [`microsoft/vscode-copilot-chat`](https://github.com/microsoft/vscode-copilot-chat) で MIT ライセンスのもと公開されています。
 
-This marks a significant milestone in our commitment to transparency and community collaboration. By open sourcing the extension, we're enabling the community to:
+この取り組みは、透明性とコミュニティ協働への大きな一歩です。 拡張機能をオープンソース化することで、コミュニティは以下のことが可能になります:
 
-* **Contribute directly** to the development of AI-powered chat experiences in VS Code
-* **Understand the implementation** of chat modes, custom instructions, and AI integrations
-* **Build upon our work** to create even better AI developer tools
-* **Participate in shaping the future** of AI-assisted coding
+* **AI チャット体験の開発に直接貢献**
+* **チャットモード、カスタムインストラクション、AI 連携の実装を理解**
+* **私たちの成果を基に、より優れた AI 開発者ツールを構築**
+* **AI 支援コーディングの未来を共に形作る**
 
-You can explore the repository to see how features like [agent mode](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/prompts/node/agent/agentPrompt.tsx), [inline chat](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/prompts/node/inline/inlineChatEditCodePrompt.tsx), and [MCP integration](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx) are implemented. We welcome contributions, feedback, and collaboration from the community.
+リポジトリでは、[エージェントモード](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/prompts/node/agent/agentPrompt.tsx)、[インラインチャット](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/prompts/node/inline/inlineChatEditCodePrompt.tsx)、[MCP 連携](https://github.com/microsoft/vscode-copilot-chat/blob/e1222084830244174e6aa64683286561fa7e7607/src/extension/mcp/vscode-node/mcpToolCallingLoop.tsx) などの実装もご覧いただけます。 ご意見・ご提案・コントリビュートをお待ちしています。
 
-To learn more about this milestone and our broader vision for open source AI editor tooling, read our detailed blog post: [Open Source AI Editor - First Milestone](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone).
+このマイルストーンやオープンソース AI エディターツールのビジョンについては、[詳細なブログ記事](https://code.visualstudio.com/blogs/2025/06/30/openSourceAIEditorFirstMilestone) もご覧ください。
 
-### Chat mode improvements {#chat-mode-improvements}
+### チャットモードの改善 {#chat-mode-improvements}
 
-Last milestone, we previewed [custom chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes#_custom-chat-modes). In addition to the built-in chat modes 'Ask', 'Edit' and 'Agent', you can define your own chat modes with specific instructions and a set of allowed tools that you want the LLM to follow when replying to a request.
+前回のマイルストーンでは、[カスタムチャットモード](https://code.visualstudio.com/docs/copilot/chat/chat-modes#_custom-chat-modes) のプレビューを行いました。 標準の「Ask」「Edit」「Agent」モードに加え、独自の指示や利用可能なツールセットを定義したカスタムモードを作成できます。
 
-This milestone, we have made several improvements and bug fixes in this area.
+今回のリリースでは、この分野でいくつかの改善とバグ修正を行いました。
 
-#### Configure language model {#configure-language-model}
+#### 言語モデルの指定 {#configure-language-model}
 
-Upon popular request, you can now also specify which language model should be used for a chat mode. Add the `model` metadata property to your `chatmode.md` file and provide the model identifier (we provide IntelliSense for the model info).
+ご要望の多かった機能として、チャットモードごとに使用する言語モデルを指定できるようになりました。 `chatmode.md` ファイルの `model` メタデータプロパティにモデル識別子を記載してください (モデル情報の IntelliSense も提供されます)。
 
-![Screenshot that shows the IntelliSense for the model metadata property in chat mode file.](https://code.visualstudio.com/assets/updates/1_102/prompt-file-model-code-completion.png)
+![チャットモードファイルの model メタデータプロパティの IntelliSense を示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/prompt-file-model-code-completion.png)
 
-#### Improved editing support {#improved-editing-support}
+#### 編集サポートの向上 {#improved-editing-support}
 
-The editor for [chat modes](https://code.visualstudio.com/docs/copilot/chat/chat-modes), [prompts](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental), and [instruction files](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) now supports completions, validation, and hovers for all supported metadata properties.
+[チャットモード](https://code.visualstudio.com/docs/copilot/chat/chat-modes)、[プロンプト](https://code.visualstudio.com/docs/copilot/copilot-customization#_prompt-files-experimental)、[インストラクションファイル](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) のエディターで、すべてのサポートされているメタデータプロパティに対して補完・バリデーション・ホバーが利用できるようになりました。
 
-![Screenshot that shows the hover information for tools.](https://code.visualstudio.com/assets/updates/1_102/tools-hover.png)
+![ツールのホバー情報を示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/tools-hover.png)
 
-![Screenshot that shows the model diagnostics when a model is not available for a specific chat mode.](https://code.visualstudio.com/assets/updates/1_102/prompt-file-diagnostics.png)
+![特定のチャットモードで利用できないモデルの診断を示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/prompt-file-diagnostics.png)
 
-#### Gear menu in the chat view {#gear-menu-in-the-chat-view}
+#### チャットビューのギアメニュー {#gear-menu-in-the-chat-view}
 
-The **Configure Chat** action in the Chat view toolbar lets you manage custom modes as well as reusable instructions, prompts, and tool sets:
+チャットビューのツールバーにある **Configure Chat** アクションから、カスタムモードや再利用可能なインストラクション・プロンプト・ツールセットの管理ができます:
 
-![Screenshot that shows the Configure Chat menu in the Chat view.](https://code.visualstudio.com/assets/updates/1_102/chat-gear.png)
+![チャットビューの Configure Chat メニューを示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/chat-gear.png)
 
-Selecting **Modes** shows all currently installed custom modes and enables you to open, create new, or delete modes.
+**Modes** を選択すると、現在インストールされているカスタムモードの一覧が表示され、新規作成や削除も可能です。
 
-#### Import modes, prompts and instructions via a `vscode` link {#import-modes-prompts-and-instructions-via-a-vscode-link}
+#### `vscode` リンク経由でモード・プロンプト・インストラクションをインポート {#import-modes-prompts-and-instructions-via-a-vscode-link}
 
-You can now import chat mode, reusable prompt and instruction files from external links, such as a gist or our [awesome-copilot](https://github.com/github/awesome-copilot) community repository. For example, the following link will import the chat mode file for Burke's GPT 4.1 Beast Mode:
+外部リンク (gist や [awesome-copilot](https://github.com/github/awesome-copilot) コミュニティリポジトリなど) からチャットモード・プロンプト・インストラクションファイルをインポートできるようになりました。 たとえば、以下のリンクで Burke の GPT 4.1 Beast Mode のチャットモードファイルをインポートできます:
 
-[Add GPT 4.1 Beast Mode to VS Code](vscode:chat-mode/install?url=https://raw.githubusercontent.com/github/awesome-copilot/refs/heads/main/chatmodes/4.1-Beast.chatmode.md)
+[GPT 4.1 Beast Mode を VS Code に追加](vscode:chat-mode/install?url=https://raw.githubusercontent.com/github/awesome-copilot/refs/heads/main/chatmodes/4.1-Beast.chatmode.md)
 
-This will prompt for a destination, either your current workspace or your user settings, and confirm the name before importing the mode file from the URL.
+インポート時は、ワークスペースまたはユーザー設定のどちらに保存するか選択し、ファイル名を確認してから URL からモードファイルを取得します。
 
-Try it out on the 100+ community-contributed instructions, prompts, and chat modes at [awesome-copilot](https://github.com/github/awesome-copilot).
+100 以上のコミュニティ提供のインストラクション・プロンプト・チャットモードは [awesome-copilot](https://github.com/github/awesome-copilot) でご覧いただけます。
 
-### Generate custom instructions {#generate-custom-instructions}
+### カスタムインストラクションの生成 {#generate-custom-instructions}
 
-Setting up [custom instructions](https://code.visualstudio.com/docs/copilot/copilot-customization) for your project can significantly improve AI suggestions by providing context about your coding standards and project conventions. However, creating effective instructions from scratch might be challenging.
+[カスタムインストラクション](https://code.visualstudio.com/docs/copilot/copilot-customization) をプロジェクトに設定することで、コーディング規約やプロジェクトの慣習を AI に伝え、提案の質を大きく向上できます。 しかし、効果的なインストラクションを一から作成するのは難しい場合もあります。
 
-This milestone, we're introducing the **Chat: Generate Instructions** command to help you bootstrap custom instructions for your workspace. Run this command from the Command Palette or the Configure menu in the Chat view, and agent mode will analyze your codebase to generate tailored instructions that reflect your project's structure, technologies, and patterns.
+今回のリリースでは、**Chat: Generate Instructions** コマンドを新たに導入しました。 コマンドパレットやチャットビューの Configure メニューから実行すると、エージェントモードがコードベースを分析し、プロジェクト構造や技術・パターンに合わせたカスタムインストラクションを自動生成します。
 
-The command creates a `copilot-instructions.md` file in your `.github` folder or suggests improvements to existing instruction files. You can then review and customize the generated instructions to match your team's specific needs.
+このコマンドは `.github` フォルダーに `copilot-instructions.md` ファイルを作成するか、既存のインストラクションファイルの改善案を提案します。 生成されたインストラクションは、チームのニーズに合わせて自由に編集できます。
 
-Learn more about [customizing AI responses with instructions](https://code.visualstudio.com/docs/copilot/copilot-customization).
+[AI の応答をインストラクションでカスタマイズする方法](https://code.visualstudio.com/docs/copilot/copilot-customization) もご参照ください。
 
 
 
-### Load instruction files on demand {#load-instruction-files-on-demand}
+### インストラクションファイルのオンデマンド読み込み {#load-instruction-files-on-demand}
 
-Instruction files can be used to describe coding practices and project requirements. Instructions can be manually or automatically included as context to chat requests.
+インストラクションファイルは、コーディング規約やプロジェクト要件を記述するために利用できます。 インストラクションは手動または自動でチャットリクエストのコンテキストに追加可能です。
 
-There are various mechanisms supported, see the [Custom Instructions](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) section in our documentation.
+さまざまな仕組みがサポートされています。 詳細は [カスタムインストラクション](https://code.visualstudio.com/docs/copilot/copilot-customization#_custom-instructions) ドキュメントをご覧ください。
 
-For larger instructions that you want to include conditionally, you can use `.instructions.md` files in combination with glob patterns defined in the `applyTo` header. The file is automatically added when the glob pattern matches one or more of the files in the context of the chat.
+条件付きで大きなインストラクションを含めたい場合は、`applyTo` ヘッダーでグロブパターンを定義した `.instructions.md` ファイルを利用できます。 グロブパターンがチャットのコンテキスト内のファイルに一致すると、自動的にファイルが追加されます。
 
-New in this release, the large language model can load instructions on demand. Each request gets a list of all instruction files, along with glob pattern and description. In this example, the LLM has no instructions for TypeScript files explicitly added in the context. So, it looks for code style rules before creating a TypeScript file:
+本リリースでは、大規模言語モデルがインストラクションをオンデマンドで読み込めるようになりました。 各リクエストで、すべてのインストラクションファイルのリスト (グロブパターン・説明付き) が LLM に渡されます。 たとえば、TypeScript ファイル用のインストラクションが明示的に追加されていない場合、LLM はコードスタイルルールを探してから TypeScript ファイルを作成します:
 
-![Screenshot showing loading instruction files on demand.](https://code.visualstudio.com/assets/updates/1_102/instructions-loading-on-demand.png)
+![オンデマンドでインストラクションファイルを読み込む様子のスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/instructions-loading-on-demand.png)
 
-### Edit previous requests (Experimental) {#edit-previous-requests-experimental}
+### 過去リクエストの編集 (実験的) {#edit-previous-requests-experimental}
 
-You can now click on previous requests to modify the text content, attached context, mode, and model. Upon submitting this change, this will remove all subsequent requests, undo any edits made, and send the new request in chat.
+過去のリクエストをクリックして、テキスト内容・添付コンテキスト・モード・モデルを変更できるようになりました。 変更を送信すると、それ以降のリクエストはすべて削除され、編集内容が反映された新しいリクエストが送信されます。
 
-There will be a controlled rollout of different entry points to editing requests, which will help us gather feedback on preferential edit and undo flows. However, users can set their preferred mode with the experimental `setting(chat.editRequests)` setting:
+編集や元に戻すフローの好みを把握するため、さまざまなエントリーポイントを段階的に展開します。 ユーザーは実験的な `setting(chat.editRequests)` 設定で好みのモードを選択できます:
 
-* `setting(chat.editRequests.inline)`: Hover a request and select the text to begin an edit inline with the request.
-* `setting(chat.editRequests.hover)`: Hover a request to reveal a toolbar with a button to begin an edit inline with the request.
-* `setting(chat.editRequests.input)`: Hover a request to reveal a toolbar, which will start edits in the input box at the bottom of chat.
+* `setting(chat.editRequests.inline)`: リクエストにホバーしてテキストを選択し、その場で編集を開始
+* `setting(chat.editRequests.hover)`: リクエストにホバーしてツールバーのボタンから編集を開始
+* `setting(chat.editRequests.input)`: リクエストにホバーしてツールバーから入力ボックスで編集を開始
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/edit-previous-requests.mp4" title="Video showing the process of editing a previous request in the Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/edit-previous-requests.mp4" title="Chat ビューで過去リクエストを編集する様子の動画" autoplay loop controls muted></video>
 
-### Terminal auto approval (Experimental) {#terminal-auto-approval-experimental}
+### ターミナル自動承認 (実験的) {#terminal-auto-approval-experimental}
 
-Agent mode now has a mechanism for auto approving commands in the terminal. Here's a demo of it using the defaults:
+エージェントモードに、ターミナルコマンドの自動承認機能が追加されました。 デフォルト設定でのデモはこちら:
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/terminal-auto-approve.mp4" title="Video showing terminal commands like 'echo' and 'ls' being auto-approved in the Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/terminal-auto-approve.mp4" title="Chat ビューで 'echo' や 'ls' などのコマンドが自動承認される様子の動画" autoplay loop controls muted></video>
 
-There are currently two settings: the allow list and the deny list. The allow list is a list of command _prefixes_ or regular expressions that when matched allows the command to be run without explicit approval. For example, the following will allow any command starting with `npm run test` to be run, as well as _exactly_ `git status` or `git log`:
+現在、許可リストと拒否リストの 2 つの設定があります。 許可リストはコマンドの _プレフィックス_ または正規表現で、マッチした場合は明示的な承認なしでコマンドが実行されます。 たとえば、次の設定では `npm run test` で始まるコマンドや、`git status`・`git log` だけが自動承認されます:
 
 ```json
 "github.copilot.chat.agent.terminal.allowList": {
@@ -142,11 +142,11 @@ There are currently two settings: the allow list and the deny list. The allow li
 }
 ```
 
-These settings are merged across setting scopes, such that you can have a set of user-approved commands, as well as workspace-specific approved commands.
+これらの設定はスコープごとにマージされるため、ユーザー承認済みコマンドとワークスペース固有の承認コマンドを組み合わせて利用できます。
 
-As for chained commands, we try to detect these cases based on the shell and require all sub-commands to be approved. So `foo && bar` we check that both `foo` and `bar` are allowed, only at that point will it run without approval. We also try to detect inline commands such as `echo $(pwd)`, which would check both `echo $(pwd)` and `pwd`.
+複数コマンドの連結 (`foo && bar` など) の場合、すべてのサブコマンドが許可されている必要があります。 `echo $(pwd)` のようなインラインコマンドも同様に、両方のコマンドが許可されているかチェックします。
 
-The deny list has the same format as the allow list but will override it and force approval. For now this is mostly of use if you have a broad entry in the allow list and want to block certain commands that it may include. For example the following will allow all commands starting with `npm run` except if it starts with `npm run danger`:
+拒否リストも同じ形式で、許可リストより優先されます。 たとえば、`npm run` で始まるコマンドは許可しつつ、`npm run danger` だけは拒否する設定も可能です:
 
 ```json
 "github.copilot.chat.agent.terminal.allowList": {
@@ -157,161 +157,161 @@ The deny list has the same format as the allow list but will override it and for
 }
 ```
 
-Thanks to the protections that we gain against prompt injection from [workspace trust](https://code.visualstudio.com/docs/editing/workspaces/workspace-trust), the philosophy we've approached when implementing this feature with regards to security is to include a small set of innocuous commands in the allow list, and a set of particularly dangerous ones in the deny list just in case they manage to slip through. The allow list is empty by default as we're still considering what the defaults should be, but here is what we're thinking:
+[ワークスペースの信頼](https://code.visualstudio.com/docs/editing/workspaces/workspace-trust) によるプロンプトインジェクション対策もあり、デフォルトでは安全なコマンドのみ許可リストに、危険なコマンドは拒否リストに入れる方針です。 デフォルト値はまだ検討中ですが、現時点の案は以下の通りです:
 
-* Allow list: `echo`, `cd`, `ls`, `cat`, `pwd`, `Write-Host`, `Set-Location`, `Get-ChildItem`, `Get-Content`, `Get-Location`
-* Deny list: `rm`, `rmdir`, `del`, `kill`, `curl`, `wget`, `eval`, `chmod`, `chown`, `Remove-Item`
+* 許可リスト: `echo`, `cd`, `ls`, `cat`, `pwd`, `Write-Host`, `Set-Location`, `Get-ChildItem`, `Get-Content`, `Get-Location`
+* 拒否リスト: `rm`, `rmdir`, `del`, `kill`, `curl`, `wget`, `eval`, `chmod`, `chown`, `Remove-Item`
 
-The two major parts we want to add to this feature are a UI entry point to more easily add new commands to the list ([#253268](https://github.com/microsoft/vscode/issues/253268)) and an opt-in option to allow an LLM to evaluate the command(s) safety ([#253267](https://github.com/microsoft/vscode/issues/253267)). We are also planning on both removing the `github.copilot.` prefix of these settings ([#253314](https://github.com/microsoft/vscode/issues/253314)) as well as merging them together ([#253472](https://github.com/microsoft/vscode/issues/253472)) in the next release before it becomes a preview setting.
+今後は、許可コマンド追加用 UI ([#253268](https://github.com/microsoft/vscode/issues/253268)) や LLM による安全性評価のオプション ([#253267](https://github.com/microsoft/vscode/issues/253267)) も追加予定です。 また、次回リリースでは `github.copilot.` プレフィックスの削除 ([#253314](https://github.com/microsoft/vscode/issues/253314)) や設定の統合 ([#253472](https://github.com/microsoft/vscode/issues/253472)) も予定しています。
 
-### Terminal command simplification {#terminal-command-simplification}
+### ターミナルコマンドの簡略化 {#terminal-command-simplification}
 
-Agent mode sometimes wants to run commands with a `cd` statement, just in case. We now detect this case when it matches the current working directory and simplify the command that is run.
+エージェントモードが `cd` コマンドを含む場合、現在の作業ディレクトリと一致していればコマンドを簡略化して実行します。
 
-![Screenshot of the terminal, asking to run `cd C:\Github\Tyriar\xterm.js && echo hello` only runs `echo hello` when the current working directory already matches.](https://code.visualstudio.com/assets/updates/1_102/terminal-working-dir.png)
+![カレントディレクトリが一致している場合、`cd ... && echo hello` ではなく `echo hello` だけが実行される様子のスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-working-dir.png)
 
-### Agent awareness of tasks and terminals {#agent-awareness-of-tasks-and-terminals}
+### タスク・ターミナルの認識 {#agent-awareness-of-tasks-and-terminals}
 
-Agent mode now understands which background terminals it has created and which tasks are actively running. The agent can read task output by using the new `GetTaskOutput` tool, which helps prevent running duplicate tasks and improves workspace context.
+エージェントモードは、作成したバックグラウンドターミナルや実行中のタスクを把握できるようになりました。 新しい `GetTaskOutput` ツールでタスク出力を読み取ることで、重複タスクの実行防止やワークスペースの状況把握が向上します。
 
-![Screenshot of VS Code window showing two build tasks running in the terminal panel. The left terminal displays several errors. The chat agent replies to describe status of my build tasks with a summary of each task's output.](https://code.visualstudio.com/assets/updates/1_102/task-status.png)
+![複数のビルドタスクが実行中の VS Code ウィンドウと、タスク出力の要約を返すチャットエージェントのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/task-status.png)
 
-### Maximized chat view {#maximized-chat-view}
+### チャットビューの最大化 {#maximized-chat-view}
 
-You can now maximize the Secondary Side Bar to span the editor area and hide the Primary Side Bar and panel area. VS Code will remember this state between restarts and will restore the Chat view when you open an editor or view.
+セカンダリサイドバーをエディター領域全体に広げ、プライマリサイドバーやパネル領域を非表示にできるようになりました。 VS Code はこの状態を再起動後も記憶し、エディターやビューを開いた際にチャットビューを復元します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/auxmax.mp4" title="Video showing maximizing the Secondary Side Bar." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/auxmax.mp4" title="セカンダリサイドバーを最大化する様子の動画" autoplay loop controls muted></video>
 
-You can toggle in and out of the maximized state by using the new icon next to the close button, or use the new command `workbench.action.toggleMaximizedAuxiliaryBar` from the Command Palette.
+最大化・解除は、閉じるボタン横の新しいアイコンや、コマンドパレットの `workbench.action.toggleMaximizedAuxiliaryBar` コマンドで切り替えられます。
 
-### Agent mode badge indicator {#agent-mode-badge-indicator}
+### エージェントモードのバッジインジケーター {#agent-mode-badge-indicator}
 
-We now show a badge over the application icon in the dock when the window is not focused and the agent needs user confirmation to continue. The badge will disappear as soon as the related window that triggered it receives focus.
+ウィンドウが非アクティブ時、エージェントがユーザーの確認を必要とする場合はアプリケーションアイコンにバッジが表示されます。 該当ウィンドウにフォーカスが戻るとバッジは消えます。
 
-![Screenshot of the VS Code dock icon showing an agent confirmation as a badge.](https://code.visualstudio.com/assets/updates/1_102/badge.png)
+![エージェント確認バッジが表示された VS Code ドックアイコンのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/badge.png)
 
-You can enable or disable this badge via the `setting(chat.notifyWindowOnConfirmation)` setting.
+このバッジは `setting(chat.notifyWindowOnConfirmation)` 設定で有効・無効を切り替えられます。
 
-### Start chat from the command line {#start-chat-from-the-command-line}
+### コマンドラインからチャット開始 {#start-chat-from-the-command-line}
 
-A new subcommand `chat` is added to the VS Code CLI that enables you to start a chat session in the current working directory with the prompt provided.
+VS Code CLI に新しいサブコマンド `chat` が追加され、カレントディレクトリでプロンプト付きのチャットセッションを開始できるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/chatcli.mp4" title="Video showing the Chat CLI in action to open the Chat view from the command line and run a prompt." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/chatcli.mp4" title="コマンドラインから Chat ビューを開きプロンプトを実行する様子の動画" autoplay loop controls muted></video>
 
-The basic syntax is `code chat [options] [prompt]` and options can be any of:
+基本構文は `code chat [options] [prompt]` で、オプションは以下の通りです:
 
-* `-m --mode <mode>`: The mode to use for the chat session. Available options: 'ask', 'edit', 'agent', or the identifier of a custom mode. Defaults to 'agent'
-* `-a --add-file <path>`: Add files as context to the chat session
-* `--maximize`: Maximize the chat session view
-* `-r --reuse-window`: Force to use the last active window for the chat session
-* `-n --new-window`: Force to open an empty window for the chat session
+* `-m --mode <mode>`: チャットセッションで使用するモード。 'ask'、'edit'、'agent'、またはカスタムモードの識別子。 デフォルトは 'agent'
+* `-a --add-file <path>`: チャットセッションのコンテキストにファイルを追加
+* `--maximize`: チャットセッションビューを最大化
+* `-r --reuse-window`: 最後にアクティブだったウィンドウを再利用
+* `-n --new-window`: 空のウィンドウで開く
 
-Reading from stdin is supported, provided you pass in `-` at the end, for example `ps aux | grep code | code chat <prompt> -`
+標準入力からの読み込みもサポートされており、たとえば `ps aux | grep code | code chat <prompt> -` のように使えます。
 
-### Fetch tool supports non-HTTP URLs {#fetch-tool-supports-nonhttp-urls}
+### Fetch ツールの非 HTTP URL 対応 {#fetch-tool-supports-nonhttp-urls}
 
-We've seen that, on occasion, models want to call the Fetch tool with non-HTTP URLs, such as `file://` URLs. Rather than disallowing this, the Fetch tool now supports these URLs and returns the content of the file or resource at the URL. Images are also supported.
+モデルが `file://` などの非 HTTP URL で Fetch ツールを呼び出すケースがあるため、これらの URL もサポートし、ファイルやリソースの内容を返すようになりました。 画像も対応しています。
 
-### Clearer language model access management {#clearer-language-model-access-management}
+### 言語モデルアクセス管理の明確化 {#clearer-language-model-access-management}
 
-We've reworked the UX around managing extension access to language models provided by extensions. Previously, you saw an item in the Account menu that said **AccountName (GitHub Copilot Chat)**, which had nothing to do with what account GitHub Copilot Chat was using. Rather, it allowed you to manage which extensions had access to the language models provided by Copilot Chat.
+拡張機能が提供する言語モデルへのアクセス管理 UX を刷新しました。 以前はアカウントメニューに **AccountName (GitHub Copilot Chat)** という項目がありましたが、これは Copilot Chat が使用しているアカウントとは無関係で、Copilot Chat が提供する言語モデルへのアクセス権を管理するものでした。
 
-To make this clearer, we've removed the **AccountName (GitHub Copilot Chat)** item and replaced it with a new item called **Manage Language Model Access...**. This item opens a Quick Pick that enables you to manage which extensions have access to the language models provided by GitHub Copilot Chat.
+今回、この項目を削除し、新たに **Manage Language Model Access...** を追加しました。 この項目から Quick Pick を開き、GitHub Copilot Chat が提供する言語モデルへのアクセス権を持つ拡張機能を管理できます。
 
-![Screenshot that shows the language model access Quick Pick.](https://code.visualstudio.com/assets/updates/1_102/lm-access-qp.png)
+![言語モデルアクセス Quick Pick のスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/lm-access-qp.png)
 
-We think this is clearer... That said, in a future release we will explore more granular access control for language models (for example, only allowing specific models rather than _all_ models provided by an extension), so stay tuned for that.
+今後は、拡張機能単位だけでなく、特定モデル単位でのアクセス制御も検討しています。
 
-### Reading chat requests {#reading-chat-requests}
+### チャットリクエストの閲覧 {#reading-chat-requests}
 
-Since the chat extension itself is open source, you now get access to one of the debugging tools that we've been using internally for awhile. To easily see the details of all requests made by Copilot Chat, run the command "Show Chat Debug View". This will show a treeview with an entry for each request made. You can see the full prompt that was sent to the model, the tools that were enabled, the response, and other key details. You can save the request log with right click > "Export As...".
+チャット拡張機能自体がオープンソース化されたことで、これまで内部で使っていたデバッグツールの一部が利用可能になりました。 Copilot Chat の全リクエスト詳細を簡単に確認するには「Show Chat Debug View」コマンドを実行してください。 各リクエストのエントリがツリービューで表示され、モデルに送信されたプロンプト全文・有効化されたツール・応答内容などが確認できます。 右クリック > "Export As..." でリクエストログの保存も可能です。
 
-The view also has entries for tool calls on their own, and a prompt-tsx debug view that opens in the Simple Browser.
+ツールコール単体や prompt-tsx デバッグビューも Simple Browser で開けます。
 
-> 🚨 **Note**: This log is very helpful in troubleshooting issues, and we will appreciate if you share it when filing an issue about the agent's behavior. But, this log may contain personal information such as the contents of your files or terminal output. Please review the contents carefully before sharing it with anyone else.
+> 🚨 **注意**: このログはトラブルシューティングに非常に役立ちます。 エージェントの挙動に関する issue を報告する際はぜひ共有してください。 ただし、ファイル内容やターミナル出力など個人情報が含まれる場合があるため、共有前に内容をよくご確認ください。
 
-### Edit Tool Improvements {#edit-tool-improvements}
+### 編集ツールの改善 {#edit-tool-improvements}
 
-This release includes several changes to the predictability and reliability of the edit tools used for GPT-4 models and Sonnet models. You should see more reliable editing behavior in this release and we will continue to improve these tools in future releases.
+本リリースでは、GPT-4 モデルや Sonnet モデルで使用される編集ツールの予測性・信頼性が大きく向上しました。 今後もさらなる改善を続けていきます。
 
 ## MCP {#mcp}
 
-### MCP support in VS Code is generally available {#mcp-support-in-vs-code-is-generally-available}
+### VS Code での MCP サポートが正式リリース {#mcp-support-in-vs-code-is-generally-available}
 
-We've have been working on expanding MCP support in VS Code for the past few months, and [support the full range of MCP features in the specification](https://code.visualstudio.com/blogs/2025/06/12/full-mcp-spec-support). As of this release, MCP support is now generally available in VS Code!
+ここ数か月、VS Code の MCP サポート拡充に取り組んできましたが、[MCP 仕様の全機能](https://code.visualstudio.com/blogs/2025/06/12/full-mcp-spec-support) に対応し、今回のリリースで正式リリースとなりました！
 
-In addition, organizations can now control the availability of MCP servers with a GitHub Copilot policy. Learn more about [Managing policies and features for Copilot in your enterprise](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/administer/enterprises/managing-policies-and-features-for-copilot-in-your-enterprise) in the GitHub Copilot documentation.
+また、組織は GitHub Copilot ポリシーで MCP サーバーの利用可否を制御できるようになりました。 詳細は GitHub Copilot ドキュメントの [エンタープライズでの Copilot のポリシーと機能管理](https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/administer/enterprises/managing-policies-and-features-for-copilot-in-your-enterprise) をご覧ください。
 
-You can get started by installing some of the [popular MCP servers from our curated list](https://code.visualstudio.com/mcp). Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) and how you can use them to extend agent mode.
+[厳選された人気 MCP サーバー](https://code.visualstudio.com/mcp) のインストールから始められます。 VS Code での [MCP サーバーの利用方法](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) や、エージェントモード拡張への活用方法もご参照ください。
 
-![Screenshot that shows the MCP Servers page.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-page.png)
+![MCP サーバーページのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-page.png)
 
-If you want to build your own MCP server, check our [MCP developer guide](https://code.visualstudio.com/api/extension-guides/ai/mcp) for more details about how to take advantage of the MCP capabilities in VS Code.
+独自の MCP サーバーを構築したい場合は、[MCP 開発者ガイド](https://code.visualstudio.com/api/extension-guides/ai/mcp) もご覧ください。
 
-### Support for elicitations {#support-for-elicitations}
+### Elicitation サポート {#support-for-elicitations}
 
-The latest MCP specification added support for [Elicitations](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) as a way for MCP servers to request input from MCP clients. The latest version of VS Code adopts this specification and includes support for elicitations.
+最新の MCP 仕様で [Elicitation](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation) 機能が追加され、MCP サーバーがクライアントに入力を求めることができるようになりました。 VS Code もこの仕様に対応しています。
 
 <video src="https://code.visualstudio.com/assets/updates/1_102/mcp-server-elicit.mp4" autoplay loop controls muted></video>
 
-### MCP server discovery and installation {#mcp-server-discovery-and-installation}
+### MCP サーバーの発見とインストール {#mcp-server-discovery-and-installation}
 
-The new **MCP Servers** section in the Extensions view includes welcome content that links directly to the [popular MCP servers from our curated list](https://code.visualstudio.com/mcp). Visit the website to explore available MCP servers and select **Install** on any MCP server. This automatically launches VS Code and opens the MCP server editor that displays the server's readme and manifest information. You can review the server details and select **Install** to add the server to your VS Code instance.
+拡張機能ビューの新しい **MCP Servers** セクションには、[厳選 MCP サーバー](https://code.visualstudio.com/mcp) へのリンク付きウェルカムコンテンツが表示されます。 Web サイトで MCP サーバーを選択し **Install** を押すと、VS Code が自動で起動し、サーバーの readme・マニフェスト情報を表示する MCP サーバーエディターが開きます。 内容を確認し **Install** で VS Code に追加できます。
 
-Once installed, MCP servers automatically appear in your Extensions view under the **MCP SERVERS - INSTALLED** section, and their tools become available in the Chat view's tools Quick Pick. This makes it easy to verify that your MCP server is working correctly and access its capabilities immediately.
+インストール済み MCP サーバーは拡張機能ビューの **MCP SERVERS - INSTALLED** セクションに自動表示され、ツールもチャットビューのツールクイックピックからすぐ利用できます。 これにより、サーバーの動作確認や機能利用が簡単になります。
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/mcp-servers-discovery-install.mp4" title="Video showing installing an MCP server from the MCP page on the VS Code website." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/mcp-servers-discovery-install.mp4" title="MCP サーバーを Web サイトからインストールする様子の動画" autoplay loop controls muted></video>
 
-### MCP server management view {#mcp-server-management-view}
+### MCP サーバー管理ビュー {#mcp-server-management-view}
 
-The new **MCP SERVERS - INSTALLED** view in the Extensions view makes it easy to monitor, configure, and control your installed MCP servers.
+拡張機能ビューの新しい **MCP SERVERS - INSTALLED** で、インストール済み MCP サーバーの監視・設定・制御が簡単に行えます。
 
-![Screenshot showing the MCP Servers management view with installed servers.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-installed-view.png)
+![MCP サーバー管理ビューのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-installed-view.png)
 
-The view lists the installed MCP servers and provides several management actions through the context menu:
+インストール済み MCP サーバーの一覧や、コンテキストメニューからの各種操作が可能です:
 
-![Screenshot showing the context menu actions for an MCP server.](https://code.visualstudio.com/assets/updates/1_102/mcp-server-context-menu.png)
+![MCP サーバーのコンテキストメニューのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-server-context-menu.png)
 
-* **Start Server** / **Stop Server** / **Restart Server**: Control the server's running state
-* **Disconnect Account**: Remove account access from the server
-* **Show Output**: View the server's output logs for troubleshooting
-* **Show Configuration**: Open the server's runtime configuration
-* **Configure Model Access**: Manage which language models the server can access
-* **Show Sampling Requests**: View sampling requests for debugging
-* **Browse Resources**: Explore resources provided by the server
-* **Uninstall**: Remove the server from your VS Code instance
+* **Start Server** / **Stop Server** / **Restart Server**: サーバーの起動・停止・再起動
+* **Disconnect Account**: サーバーからアカウントアクセスを削除
+* **Show Output**: サーバーの出力ログ表示
+* **Show Configuration**: サーバーのランタイム設定表示
+* **Configure Model Access**: サーバーがアクセスできる言語モデルの管理
+* **Show Sampling Requests**: サンプリングリクエストのデバッグ表示
+* **Browse Resources**: サーバーが提供するリソースの閲覧
+* **Uninstall**: サーバーのアンインストール
 
-When you select an installed MCP server, VS Code opens the MCP server editor displaying the server's readme details, manifest, and its runtime configuration. This provides an overview of the server's capabilities and current settings, making it easy to understand what the server does and how it's configured.
+インストール済み MCP サーバーを選択すると、readme・マニフェスト・ランタイム設定が表示され、サーバーの機能や設定状況が一目で分かります。
 
-![Screenshot showing the MCP server editor with runtime configuration.](https://code.visualstudio.com/assets/updates/1_102/mcp-server-editor-configuration.png)
+![MCP サーバーエディターのランタイム設定画面のスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-server-editor-configuration.png)
 
-The **MCP SERVERS - INSTALLED** view also provides a **Browse MCP Servers...** action that takes you directly to the community website, making server discovery always accessible from within VS Code.
+**MCP SERVERS - INSTALLED** ビューには **Browse MCP Servers...** アクションもあり、コミュニティサイトへすぐアクセスできます。
 
-![Screenshot that shows the Browse MCP Servers action in the MCP Servers view.](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-browse-action.png)
+![MCP サーバービューの Browse MCP Servers アクションのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-servers-browse-action.png)
 
-### MCP servers as first class resources {#mcp-servers-as-first-class-resources}
+### MCP サーバーのファーストクラスリソース化 {#mcp-servers-as-first-class-resources}
 
-MCP servers are now treated as first-class resources in VS Code, similar to user tasks and other profile-specific configurations. This represents a significant architectural improvement from the previous approach where MCP servers were stored in user settings. This change makes MCP server management more robust and provides better separation of concerns between your general VS Code settings and your MCP server configurations. When you install or configure MCP servers, they're automatically stored in the appropriate [profile](https://code.visualstudio.com/docs/configure/profiles)-specific location to ensure that your main settings file stays clean and focused.
+MCP サーバーは、ユーザータスクやプロファイル固有の設定と同様に、VS Code 内でファーストクラスリソースとして扱われるようになりました。 従来のユーザー設定ファイル内管理から、より堅牢で分離された MCP サーバー管理が可能になっています。 インストールや設定変更時は、[プロファイル](https://code.visualstudio.com/docs/configure/profiles)ごとの `mcp.json` に自動保存され、メイン設定ファイルが煩雑になりません。
 
-* **Dedicated storage**: MCP servers are now stored in a dedicated `mcp.json` file within each profile, rather than cluttering your user settings file
-* **Profile-specific**: Each VS Code profile maintains its own set of MCP servers, enabling you to have different server configurations for different workflows or projects
-* **Settings Sync integration**: MCP servers sync seamlessly across your devices through [Settings Sync](https://code.visualstudio.com/docs/configure/settings-sync), with granular control over what gets synchronized
+* **専用ストレージ**: MCP サーバーは各プロファイルの `mcp.json` に保存
+* **プロファイル単位**: プロファイルごとに異なる MCP サーバー構成が可能
+* **設定同期対応**: [設定同期](https://code.visualstudio.com/docs/configure/settings-sync) でデバイス間同期も柔軟に制御
 
-#### MCP migration support {#mcp-migration-support}
+#### MCP 移行サポート {#mcp-migration-support}
 
-With MCP servers being first-class resources and the associated change to their configuration, VS Code provides comprehensive migration support for users upgrading from the previous MCP server configuration format:
+MCP サーバーのファーストクラスリソース化に伴い、従来形式からの移行もサポートしています:
 
-* **Automatic detection**: Existing MCP servers in `settings.json` are automatically detected and migrated to the new profile-specific `mcp.json` format
-* **Real-time migration**: When you add MCP servers to user settings, VS Code immediately migrates them with a helpful notification explaining the change
-* **Cross-platform support**: Migration works seamlessly across all development scenarios including local, remote, WSL, and Codespaces environments
+* **自動検出**: `settings.json` 内の既存 MCP サーバーを自動検出し、新形式へ移行
+* **リアルタイム移行**: ユーザー設定に MCP サーバーを追加すると即座に移行し、通知で案内
+* **クロスプラットフォーム対応**: ローカル・リモート・WSL・Codespaces など全開発環境でシームレスに移行
 
-This migration ensures that your existing MCP server configurations continue to work without any manual intervention while providing the enhanced management capabilities of the new architecture.
+この移行により、既存の MCP サーバー設定も手間なく新アーキテクチャで利用できます。
 
-#### Dev Container support for MCP configuration {#dev-container-support-for-mcp-configuration}
+#### Dev Container での MCP 設定サポート {#dev-container-support-for-mcp-configuration}
 
-The Dev Container configuration `devcontainer.json` and the Dev Container Feature configuration `devcontainer-feature.json` support MCP server configurations at the path `customizations.vscode.mcp`. When a Dev Container is created the collected MCP server configurations are written to the remote MCP configuration file `mcp.json`.
+Dev Container の `devcontainer.json` や Dev Container Feature の `devcontainer-feature.json` で、`customizations.vscode.mcp` パスに MCP サーバー設定を記述できます。 Dev Container 作成時に、収集した MCP サーバー設定がリモートの `mcp.json` に書き込まれます。
 
-Sample `devcontainer.json` configuring the Playwright MCP server:
+Playwright MCP サーバーを設定した `devcontainer.json` の例:
 ```json
 {
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:latest",
@@ -333,71 +333,71 @@ Sample `devcontainer.json` configuring the Playwright MCP server:
 }
 ```
 
-#### Commands to access MCP resources {#commands-to-access-mcp-resources}
+#### MCP リソースへのコマンドアクセス {#commands-to-access-mcp-resources}
 
-To make working with MCP servers more accessible, we've added commands to help you manage and access your MCP configuration files:
+MCP サーバーの設定ファイル管理を容易にするため、以下のコマンドを追加しました:
 
-* **MCP: Open User Configuration** - Direct access to your user-level `mcp.json` file
-* **MCP: Open Remote User Configuration** - Direct access to your remote user-level `mcp.json` file
+* **MCP: Open User Configuration** - ユーザーレベルの `mcp.json` へ直接アクセス
+* **MCP: Open Remote User Configuration** - リモートユーザーレベルの `mcp.json` へ直接アクセス
 
-These commands provide quick access to your MCP configuration files, making it easy to view and manage your server configurations directly.
+これらのコマンドで MCP 設定ファイルをすぐに開いて管理できます。
 
-### Quick management of MCP authentication {#quick-management-of-mcp-authentication}
+### MCP 認証のクイック管理 {#quick-management-of-mcp-authentication}
 
-You are now able to sign out or disconnect accounts from the MCP gear menu and quick picks.
+MCP ギアメニューやクイックピックから、アカウントのサインアウトや切断ができるようになりました。
 
-* MCP view gear menu:
-    ![Screenshot showing the Disconnect Account action shown in MCP view gear menu.](https://code.visualstudio.com/assets/updates/1_102/mcp-view-signout.png)
+* MCP ビューのギアメニュー:
+    ![MCP ビューギアメニューの Disconnect Account アクションのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-view-signout.png)
 
-* MCP editor gear menu:
-    ![Screenshot showing the Disconnect Account action shown in MCP editor gear menu.](https://code.visualstudio.com/assets/updates/1_102/mcp-editor-signout.png)
+* MCP エディターのギアメニュー:
+    ![MCP エディターギアメニューの Disconnect Account アクションのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-editor-signout.png)
 
-* MCP quick pick:
-    ![Screenshot showing the Disconnect Account action shown in MCP quick pick menu.](https://code.visualstudio.com/assets/updates/1_102/mcp-qp-signout.png)
+* MCP クイックピック:
+    ![MCP クイックピックメニューの Disconnect Account アクションのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/mcp-qp-signout.png)
 
-The **Disconnect** action is shown when the account is used by either other MCP servers or extensions, while **Sign Out** is shown when the account is only used by the MCP server. The sign out action completely removes the account from VS Code, while disconnect only removes access to the account from the MCP server.
+**Disconnect** アクションは、アカウントが他の MCP サーバーや拡張機能でも使われている場合に表示され、**Sign Out** は MCP サーバー専用の場合に表示されます。 Sign Out は VS Code からアカウントを完全に削除し、Disconnect は MCP サーバーからのみアクセスを削除します。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Keep all edits from within the editor {#keep-all-edits-from-within-the-editor}
+### エディター内からすべての編集を保持 {#keep-all-edits-from-within-the-editor}
 
-Formerly, to accept all edits, focus would need to be in the Chat view. Now, with focus in the editor, you can run the command **Keep All Edits** (`kb(chatEditor.action.acceptAllEdits)`).
+これまではすべての編集を受け入れるには Chat ビューにフォーカスする必要がありましたが、エディターにフォーカスしたまま **Keep All Edits** (`kb(chatEditor.action.acceptAllEdits)`) コマンドを実行できるようになりました。
 
-### User action required sound {#user-action-required-sound}
+### ユーザー操作要求音 {#user-action-required-sound}
 
-We’ve fine-tuned the accessibility signal to indicate when chat requires user action and set the default value to `auto`, so screen reader users will hear this signal. You can configure this behavior with the `setting(accessibility.signals.chatUserActionRequired)` setting.
+チャットでユーザー操作が必要な場合のアクセシビリティ信号を調整し、デフォルト値を `auto` に設定しました。 これによりスクリーンリーダーユーザーに通知されます。 この動作は `setting(accessibility.signals.chatUserActionRequired)` 設定で変更できます。
 
-### Alert when rendering errors occur in chat {#alert-when-rendering-errors-occur-in-chat}
+### チャット描画エラー時のアラート {#alert-when-rendering-errors-occur-in-chat}
 
-Previously, screen reader users were not alerted when a chat rendering error occurred . Users are now alerted with this information and can also focus it via keyboard.
+これまでチャット描画エラーが発生してもスクリーンリーダーユーザーには通知されませんでしたが、今後は通知され、キーボードでもフォーカスできます。
 
-## Code Editing {#code-editing}
+## コード編集 {#code-editing}
 
-### Scroll on middle click {#scroll-on-middle-click}
+### ミドルクリックでスクロール {#scroll-on-middle-click}
 
-**Setting**: `setting(editor.scrollOnMiddleClick:true)`
+**設定**: `setting(editor.scrollOnMiddleClick:true)`
 
-Scroll the editor by simply clicking, or holding down your middle mouse button (the scroll wheel) and moving around.
+エディター上でミドルマウスボタン (ホイール) をクリックまたは押しながら動かすだけでスクロールできます。
 
-Once activated, the cursor changes to a panning icon and moving the mouse up or down then smoothly scrolls the editor in that direction. The scrolling speed is determined by how far you move the mouse from the initial click point. Release the middle mouse button or click it again to stop scrolling and return to the standard cursor.
+有効化すると、カーソルがパンニングアイコンに変わり、上下に動かすとその方向にスムーズにスクロールします。 スクロール速度は最初のクリック位置からの距離で決まります。 ミドルボタンを離すか再度クリックすると通常のカーソルに戻ります。
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/middle-scroll.mp4" title="Screenrecording of the editor scrolling when the middle mouse button is clicked." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/middle-scroll.mp4" title="ミドルマウスボタンでエディターをスクロールする様子の動画" autoplay loop controls muted></video>
 
-**Known Conflicts**
+**既知の競合**
 
-Enabling this feature might interfere with other actions tied to the middle mouse button. For example, if you have column selection (`setting(editor.columnSelection)`) enabled, holding down the middle mouse button selects text. Similarly, on Linux, selection clipboard (`setting(editor.selectionClipboard)`) pastes content from your clipboard when the middle mouse button is clicked.
+この機能を有効にすると、ミドルマウスボタンに割り当てられた他の操作と競合する場合があります。 たとえば、`setting(editor.columnSelection)` が有効な場合はミドルボタンでテキスト選択、Linux では `setting(editor.selectionClipboard)` でクリップボード内容の貼り付けが行われます。
 
-To avoid these conflicts, please enable only one of these settings at a time.
+競合を避けるため、これらの設定は同時に有効にしないでください。
 
-### Snooze code completions {#snooze-code-completions}
+### コード補完のスヌーズ {#snooze-code-completions}
 
-You can now temporarily pause inline suggestions and next edit suggestions (NES) by using the new **Snooze** feature. This is helpful when you want to focus without distraction from suggestions.
+新しい **Snooze** 機能で、インライン提案や次の編集提案 (NES) を一時停止できるようになりました。 集中したいときに提案を非表示にできます。
 
-To snooze suggestions, select the Copilot dashboard in the Status Bar, or run the **Snooze Inline Suggestions** command from the Command Palette and select a duration from the dropdown menu. During the snooze period, no inline suggestions or NES will appear.
+スヌーズするには、ステータスバーの Copilot ダッシュボードを選択するか、コマンドパレットから **Snooze Inline Suggestions** を実行し、ドロップダウンで期間を選択します。 スヌーズ中はインライン提案や NES は表示されません。
 
-![Screenshot showing the Copilot dashboard with the snooze button at the bottom.](https://code.visualstudio.com/assets/updates/1_102/nes-snooze.png)
+![Copilot ダッシュボード下部のスヌーズボタンのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/nes-snooze.png)
 
-You can also assign a custom keybinding to quickly snooze suggestions for a specific duration by passing the desired duration as an argument to the command. For example:
+コマンドに引数で期間を渡すことで、特定の時間だけスヌーズするカスタムキーバインドも設定できます。 例:
 
 ```json
 {
@@ -407,209 +407,209 @@ You can also assign a custom keybinding to quickly snooze suggestions for a spec
 }
 ```
 
-## Editor Experience {#editor-experience}
+## エディター体験 {#editor-experience}
 
-### Windows accent color {#windows-accent-color}
+### Windows アクセントカラー {#windows-accent-color}
 
-**Setting**: `setting(window.border)`
+**設定**: `setting(window.border)`
 
-VS Code on Windows now supports using the accent color as the window frame border if that is enabled in Windows settings ("Show accent color on title bars and window borders").
+Windows で「タイトルバーとウィンドウの枠線にアクセントカラーを表示」が有効な場合、VS Code のウィンドウ枠線にアクセントカラーを適用できるようになりました。
 
-![Screenshot of the VS Code window with a red accent color border.](https://code.visualstudio.com/assets/updates/1_102/window-accent.png)
+![赤いアクセントカラー枠線の VS Code ウィンドウのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/window-accent.png)
 
-The new `setting(window.border)` setting enables you to control the color of the window border. Use `default` to use the Windows accent color, `off` to disable the border, or provide a specific color value to use a custom color.
+新しい `setting(window.border)` 設定で、Windows アクセントカラー (default)、枠線なし (off)、任意の色値 (カスタムカラー) を選択できます。
 
-**Note**: the border is only visible when the related Windows setting is enabled. It can not yet be set per workspace, but we are working on that support.
+**注意**: 枠線は関連する Windows 設定が有効な場合のみ表示されます。 現時点ではワークスペース単位での設定はできませんが、今後対応予定です。
 
-### Settings search suggestions (Preview) {#settings-search-suggestions-preview}
+### 設定検索の AI サジェスト (プレビュー) {#settings-search-suggestions-preview}
 
-**Setting**: `setting(workbench.settings.showAISearchToggle:true)`
+**設定**: `setting(workbench.settings.showAISearchToggle:true)`
 
-This milestone, we modified the sparkle toggle in the Settings editor, so that it acts as a toggle between the AI and non-AI search results. The AI settings search results are semantically similar results instead of results that are based on string matching. For example, `editor.fontSize` appears as an AI settings search result when you search for "increase text size".
+今回のリリースで、設定エディターのスパークル切り替えボタンが AI/非 AI 検索結果のトグルになりました。 AI 設定検索結果は文字列一致ではなく意味的に類似した結果を返します。 たとえば「increase text size」と検索すると `editor.fontSize` が AI 検索結果に表示されます。
 
-The toggle is enabled only when there are AI results available. We welcome feedback on when the AI settings search did not find an expected setting, and we plan to enable the setting by default over the next iteration.
+AI 結果がある場合のみトグルが有効になります。 期待した設定が見つからない場合はフィードバックをお寄せください。 今後、デフォルトで有効化する予定です。
 
-<video src="https://code.visualstudio.com/assets/updates/1_102/settings-search-toggle-stable.mp4" title="Switching between AI and non-AI results using the AI results toggle in the Settings editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_102/settings-search-toggle-stable.mp4" title="設定エディターで AI/非AI 結果を切り替える様子の動画" autoplay loop controls muted></video>
 
-## Tasks {#tasks}
+## タスク {#tasks}
 
-### Rerun all running tasks {#rerun-all-running-tasks}
+### 実行中のタスクをすべて再実行 {#rerun-all-running-tasks}
 
-You can now quickly rerun all currently running tasks with the new `Tasks: Rerun All Running Tasks command`. This is useful for workflows that involve multiple concurrent tasks, allowing you to restart them all at once without stopping and rerunning each individually.
+新しい `Tasks: Rerun All Running Tasks` コマンドで、現在実行中のすべてのタスクを素早く再実行できるようになりました。 複数のタスクを同時に扱うワークフローで便利です。
 
-### Restart task reloads updated tasks.json {#restart-task-reloads-updated-tasks-json}
+### タスク再起動時に tasks.json を再読み込み {#restart-task-reloads-updated-tasks-json}
 
-The **Restart Task** command now reloads your `tasks.json` before restarting, ensuring that any recent changes are respected. Previously, task configuration changes were not picked up when restarting a task, which could lead to confusion or outdated task behavior.
+**Restart Task** コマンドでタスクを再起動する際、`tasks.json` の最新内容が反映されるようになりました。 これまでは再起動時に設定変更が反映されず、混乱や古い動作の原因となっていました。
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Terminal Suggest (Preview) {#terminal-suggest-preview}
+### ターミナルサジェスト (プレビュー) {#terminal-suggest-preview}
 
-We've made significant improvements to the terminal suggest feature.
+ターミナルサジェスト機能が大幅に強化されました。
 
-#### Selection mode {#selection-mode}
+#### 選択モード {#selection-mode}
 
-A new setting, `terminal.integrated.suggest.selectionMode`, helps you understand that by default, `kbStyle(Tab)` (not `kbStyle(Enter)`) accepts suggestions. You can choose between `partial`, `always`, and `never` modes to control how suggestions are selected and accepted.
+新しい `terminal.integrated.suggest.selectionMode` 設定で、デフォルトでは `kbStyle(Tab)` (`kbStyle(Enter)` ではない) がサジェストを受け入れることが分かりやすくなりました。 `partial`、`always`、`never` の各モードでサジェストの選択・受け入れ方法を制御できます。
 
-The default value is `partial`, which means that `kbStyle(Tab)` accepts the suggestion until navigation has occurred.
+デフォルト値は `partial` で、ナビゲーションが発生するまで `kbStyle(Tab)` でサジェストを受け入れます。
 
-![Screenshot showing the first terminal suggestion can be accepted with Tab.](https://code.visualstudio.com/assets/updates/1_102/terminal-selection-mode.png)
+![Tab で最初のターミナルサジェストを受け入れる様子のスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-selection-mode.png)
 
-#### Learn more {#learn-more}
+#### 詳細を学ぶ {#learn-more}
 
-The **Learn More** action `(kb(workbench.action.terminal.suggestLearnMore))` in the terminal suggest control's status bar is now highlighted for the first 10 times or if the control is shown for 10 seconds. This helps you discover how to configure, disable, and read about the suggest control.
+ターミナルサジェストコントロールのステータスバーにある **Learn More** アクション (`kb(workbench.action.terminal.suggestLearnMore)`) が、最初の 10 回または 10 秒間表示された場合にハイライトされるようになりました。 これにより、サジェストコントロールの設定・無効化・詳細情報の確認方法が分かりやすくなります。
 
-![Screenshot showing the Learn More action appears in the terminal suggest control status bar.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-discoverability.png)
+![ターミナルサジェストコントロールのステータスバーに Learn More アクションが表示される様子のスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-discoverability.png)
 
-#### Multi-command support {#multi-command-support}
+#### 複数コマンド対応 {#multi-command-support}
 
-Terminal suggest now supports multi-command lines. You can link commands with `;`, `&&`, and other shell operators, and receive suggestions for all commands on the line.
+ターミナルサジェストが複数コマンド行に対応しました。 `;` や `&&` などのシェル演算子でコマンドを連結し、すべてのコマンドに対してサジェストが表示されます。
 
-![Screenshot showing the VS Code terminal showing a multi-command line with git commit and git push, and the terminal suggest widget displaying suggestions for pull, push, and other git commands.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-multi.png)
+![git commit と git push を含む複数コマンド行と、サジェストウィジェットのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-multi.png)
 
-#### Symlink information {#symlink-information}
+#### シンボリックリンク情報 {#symlink-information}
 
-We now display a symlink's realpath in the suggest details control and have unique icons for symlink files and folders to help distinguish them from other suggestions.
+サジェスト詳細コントロールでシンボリックリンクの realpath を表示し、ファイル・フォルダーのアイコンも区別できるようになりました。
 
-![Screenshot showing the terminal suggest shows the symlink's path -> real path.](https://code.visualstudio.com/assets/updates/1_102/terminal-symlink.png)
+![シンボリックリンクのパスと real path を表示するターミナルサジェストのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-symlink.png)
 
-#### Improved sorting {#improved-sorting}
+#### ソートの改善 {#improved-sorting}
 
-We've improved sorting in many ways to give you the most relevant suggestions first. For example, giving `main` and `master` priority over other branches.
+さまざまな方法でソートが改善され、より関連性の高いサジェストが優先表示されるようになりました。 たとえば `main` や `master` ブランチが他より優先されます。
 
-![Screenshot showing the terminal suggest boosts main and master compared to other branch suggestions.](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-sorting.png)
+![main/master ブランチが優先されるサジェストのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-suggest-sorting.png)
 
-#### Git bash improvements {#git-bash-improvements}
+#### Git Bash の改善 {#git-bash-improvements}
 
-We now properly support Git Bash path completions for folders and files. Additionally, we source the built-in commands and present them as suggestions.
+Git Bash のパス補完が正しく動作するようになり、組み込みコマンドもサジェストに表示されます。
 
-![Screenshot showing a Git Bash terminal with suggestions for builtin functions like cat, cp, and curl.](https://code.visualstudio.com/assets/updates/1_102/terminal-git-bash.png)
+![cat, cp, curl などの組み込み関数がサジェストされる Git Bash ターミナルのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/terminal-git-bash.png)
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### GitHub Pull Requests {#github-pull-requests}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
+[GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能の開発がさらに進み、プルリクエストや issue の作成・管理がより便利になりました。
 
-Deeper integration has been made between the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension and [Copilot coding agent](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent), allowing you to begin, view, and manage coding agent sessions directly from VS Code.
+[GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能と [Copilot コーディングエージェント](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent) の連携も強化され、VS Code からコーディングエージェントセッションの開始・表示・管理が可能になりました。
 
-These features require that your workspace is open to a repository that has [the Copilot coding agent enabled](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/enabling-copilot-coding-agent).
+これらの機能は、[Copilot コーディングエージェントの有効化](https://docs.github.com/en/copilot/how-tos/agents/copilot-coding-agent/enabling-copilot-coding-agent) されたリポジトリをワークスペースで開いている場合に利用できます。
 
-Review the [changelog for the 0.114.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01140) release of the extension to learn about everything in the release.
+[バージョン 0.114.0 の変更履歴](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01140) もご参照ください。
 
-#### Start a coding agent session (Preview) {#start-a-coding-agent-session-preview}
+#### コーディングエージェントセッションの開始 (プレビュー) {#start-a-coding-agent-session-preview}
 
-Ask Copilot to continue a local change in the background by invoking the `#copilotCodingAgent` tool in chat.
+チャットで `#copilotCodingAgent` ツールを呼び出すことで、ローカルの変更をバックグラウンドで継続できます。
 
-This tool automatically pushes pending changes to a remote branch and initiates a coding agent session from that branch along with the user's instruction.
+このツールは、保留中の変更をリモートブランチに自動プッシュし、ユーザーの指示とともにコーディングエージェントセッションを開始します。
 
-![Screenshot showing handing off a session to Copilot coding agent](https://code.visualstudio.com/assets/updates/1_102/coding-agent-start.png)
+![Copilot コーディングエージェントへのセッション引き継ぎのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/coding-agent-start.png)
 
-**Experimental:** Deeper UI integration can be enabled with the `setting(githubPullRequests.codingAgent.uiIntegration)` setting.  Once enabled, a new **Delegate to coding agent** button appears in the Chat view for repositories that have the agent enabled.
+**実験的:** `setting(githubPullRequests.codingAgent.uiIntegration)` 設定を有効にすると、エージェント有効リポジトリの Chat ビューに **Delegate to coding agent** ボタンが表示されます。
 
-#### Status tracking {#status-tracking}
+#### ステータストラッキング {#status-tracking}
 
-We have made improvements to notify and prominently display the status of coding agent pull requests in the **Copilot on my behalf** query. A numeric badge now indicates new changes.
+コーディングエージェントのプルリクエスト状況を **Copilot on my behalf** クエリで通知・表示する機能が強化されました。 新しい変更がある場合は数値バッジで表示されます。
 
-![Screenshot showing status of multiple coding agent pull requests](https://code.visualstudio.com/assets/updates/1_102/coding-agent-status.png)
+![複数のコーディングエージェント PR のステータスを示すスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/coding-agent-status.png)
 
-#### Session log {#session-log}
+#### セッションログ {#session-log}
 
-You can now view the session log of a coding agent session directly in VS Code. This enables you to see the history of actions taken by the coding agent, including code changes and tool usage.
+コーディングエージェントセッションのログを VS Code で直接確認できるようになりました。 エージェントの操作履歴 (コード変更やツール利用など) が一覧できます。
 
-![Screenshot showing the session log of a coding agent session.](https://code.visualstudio.com/assets/updates/1_102/coding-agent-session-log.png)
+![コーディングエージェントセッションログのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/coding-agent-session-log.png)
 
-#### Enhancements on `#activePullRequest` tool {#enhancements-on-activepullrequest-tool}
+#### `#activePullRequest` ツールの強化 {#enhancements-on-activepullrequest-tool}
 
-The `#activePullRequest` tool returns information about the pull request, such as its title, description, and status for use in chat, and now you can also use it to get the coding agent session information.
+`#activePullRequest` ツールで、プルリクエストのタイトル・説明・ステータスなどに加え、コーディングエージェントセッション情報も取得できるようになりました。
 
-This tool is automatically attached to chat when opening a pull request created through the coding agent experience, so you can maintain the context and keep working on the pull request if needed to.
+このツールは、コーディングエージェント体験で作成されたプルリクエストを開くと自動でチャットに添付され、コンテキストを維持したまま作業を継続できます。
 
 ### Python {#python}
 
-#### Python Environments extension improvements {#python-environments-extension-improvements}
+#### Python Environments 拡張機能の改善 {#python-environments-extension-improvements}
 
-The [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) received several improvements this release:
+[Python Environments 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) がいくつか改善されました:
 
-* We've polished terminal activation support for Poetry versions greater than 2.0.0
-* You can now use the Quick Create environment creation option to set up multiple virtual environments which are uniquely named within the same workspace
-* The generated `.venv` folders are now git-ignored by default
-* We've improved the environment deletion process
+* Poetry 2.0.0 以降のバージョンでのターミナルアクティベーション対応を強化
+* クイック作成オプションで、同一ワークスペース内に一意な仮想環境を複数作成可能に
+* 生成された `.venv` フォルダーがデフォルトで gitignore 対象に
+* 環境削除プロセスの改善
 
-#### Python Environments included as part of the Python extension {#python-environments-included-as-part-of-the-python-extension}
+#### Python 拡張機能に Python Environments を同梱 {#python-environments-included-as-part-of-the-python-extension}
 
-We're starting to roll-out the [Python Environments extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) as an optional dependency with the Python extension. What this means is that you might now begin to see the Python Environments extension automatically installed alongside the Python extension, similar to the Python Debugger and Pylance extensions. This controlled roll-out allows us to gather early feedback and ensure reliability before general availability.
+[Python Environments 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) を Python 拡張機能のオプション依存として段階的に同梱し始めました。 今後、Python 拡張機能のインストール時に自動で追加される場合があります (Python Debugger や Pylance と同様)。 この段階的展開で早期フィードバックを収集し、一般提供前の信頼性を確保します。
 
-The Python Environments extension includes all the core capabilities we've introduced so far including: [one-click environment setup using Quick Create](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2025-release/#python-environments-quick-create-command), automatic terminal activation (via "python-envs.terminal.autoActivationType" setting), and all supported [UI for environment and package management](https://devblogs.microsoft.com/python/python-in-visual-studio-code-december-2024-release/).
+Python Environments 拡張機能には、[ワンクリック環境セットアップ](https://devblogs.microsoft.com/python/python-in-visual-studio-code-may-2025-release/#python-environments-quick-create-command)、自動ターミナルアクティベーション ("python-envs.terminal.autoActivationType" 設定)、[環境・パッケージ管理 UI](https://devblogs.microsoft.com/python/python-in-visual-studio-code-december-2024-release/) など、これまで導入した主要機能がすべて含まれています。
 
-To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code settings.json file:
+展開期間中に利用するには、拡張機能がインストールされていることを確認し、VS Code の settings.json に以下を追加してください:
 
 ```json
 "python.useEnvironmentsExtension": true
 ```
 
-#### Disabled PyREPL for Python 3.13 {#disabled-pyrepl-for-python-313}
+#### Python 3.13 での PyREPL 無効化 {#disabled-pyrepl-for-python-313}
 
-We have disabled PyREPL for Python 3.13 and above to address indentation and cursor issues in the interactive terminal. For more details, see [Disable PyREPL for >= 3.13](https://github.com/microsoft/vscode-python/issues/25164).
+Python 3.13 以降では、インタラクティブターミナルでのインデントやカーソル問題に対応するため PyREPL を無効化しました。 詳細は [Disable PyREPL for >= 3.13](https://github.com/microsoft/vscode-python/issues/25164) をご覧ください。
 
-#### Pylance MCP tools (Experimental) {#pylance-mcp-tools-experimental}
+#### Pylance MCP ツール (実験的) {#pylance-mcp-tools-experimental}
 
-The [Pylance extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) now includes several experimental MCP tools, which offer access to Pylance's documentation, import analysis, environment management, and more. These tools are currently available in the Pylance prerelease version and are still early in development. While they offer new capabilities, we know it can be challenging to call them directly today. We are actively working to make these tools easier to use and more valuable in future updates. Your feedback in the [pylance-release](https://github.com/microsoft/pylance-release/) repository is welcome as we continue to improve the experience.
+[Pylance 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance) に実験的な MCP ツールが追加されました。 Pylance のドキュメント・インポート解析・環境管理などにアクセスできます。 これらのツールはプレリリース版で利用可能で、今後さらに使いやすく・価値あるものに進化予定です。 ご意見は [pylance-release](https://github.com/microsoft/pylance-release/) リポジトリまでお寄せください。
 
-### GitHub authentication {#github-authentication}
+### GitHub 認証 {#github-authentication}
 
-#### Revamped GitHub sign-in flow {#revamped-github-sign-in-flow}
+#### GitHub サインインフローの刷新 {#revamped-github-sign-in-flow}
 
-This iteration, we have revamped the GitHub sign-in flow by defaulting to a loopback URL flow, rather than a flow that uses a `vscode://` protocol URL. This change is to improve the reliability of the sign-in flow and to ensure that it works across all platforms, including those that do not support custom URL schemes.
+今回のリリースでは、`vscode://` プロトコル URL ではなくループバック URL フローをデフォルトにし、GitHub サインインフローを刷新しました。 これにより、カスタム URL スキームをサポートしないプラットフォームでも信頼性の高いサインインが可能です。
 
-When you sign in with GitHub, you are now redirected to a loopback URL that looks like `http://localhost:PORT/`. This allows the sign-in flow to complete successfully without relying on custom URL schemes. That said, once you land on the loopback URL, you are still redirected to a `vscode://` URL to return to VS Code, however this doesn't need to resolve for the sign-in flow to complete successfully.
+GitHub でサインインすると、`http://localhost:PORT/` のようなループバック URL にリダイレクトされます。 これにより、カスタム URL スキームに依存せずサインインが完了します。 その後、`vscode://` URL にリダイレクトされますが、VS Code への復帰にこの URL の解決は不要です。
 
-In other words, we get the best of both worlds: a reliable sign-in flow that works across all platforms and a return to VS Code that uses the `vscode://` URL scheme.
+つまり、すべてのプラットフォームで信頼性の高いサインインと、`vscode://` URL を使った VS Code への復帰の両方を実現しています。
 
-While we were at it, we also gave this [landing page a fresh coat of paint](#revamped-github-sign-in-flow). In future iterations, we'll apply this new design to other sign-in experiences.
+また、この [ランディングページも新デザイン](#revamped-github-sign-in-flow) になりました。 今後、他のサインイン体験にも順次適用予定です。
 
-![Screenshot showing the redesigned authentication landing page.](https://code.visualstudio.com/assets/updates/1_102/auth-landing.png)
+![新しい認証ランディングページのスクリーンショット](https://code.visualstudio.com/assets/updates/1_102/auth-landing.png)
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能開発 {#extension-authoring}
 
-### Allow opening files when using `vscode.openFolder` command {#allow-opening-files-when-using-vscode-openfolder-command}
+### vscode.openFolder コマンドでファイルを開くオプション追加 {#allow-opening-files-when-using-vscode-openfolder-command}
 
-Extensions that call the `vscode.openFolder` command can now pass `filesToOpen?: UriComponents[]` as options to select files to open in the workspace window that opens.
+`vscode.openFolder` コマンドを呼び出す拡張機能で、`filesToOpen?: UriComponents[]` オプションを指定し、ワークスペースウィンドウで開くファイルを選択できるようになりました。
 
-Example:
+例:
 
 ```ts
 vscode.commands.executeCommand('vscode.openFolder', <folder uri>, { filesToOpen: [ /* files to open */]});
 ```
 
-## Proposed APIs {#proposed-apis}
+## 提案 API {#proposed-apis}
 
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### CSS minification using `esbuild` {#css-minification-using-esbuild}
+### esbuild による CSS の最小化 {#css-minification-using-esbuild}
 
-VS Code has been using `esbuild` for bundling and minifying the JavaScript sources for a long time. We now also use `esbuild` to bundle and minify our CSS files.
+VS Code では長らく JavaScript のバンドル・最小化に `esbuild` を使ってきましたが、CSS ファイルのバンドル・最小化にも対応しました。
 
-### Strict layer checks using `tsconfig.json` {#strict-layer-checks-using-tsconfig-json}
+### tsconfig.json によるレイヤーチェックの厳格化 {#strict-layer-checks-using-tsconfig-json}
 
-We now use multiple `tsconfig.json` files to ensure our source code adheres to our [target environment rules](https://github.com/microsoft/vscode/wiki/Source-Code-Organization#target-environments). Our CI runs `npm run valid-layers-check` and will fail the build if for example a type was added into a `browser` layer that only exists in the `node` runtime.
+複数の `tsconfig.json` を使い、[ターゲット環境ルール](https://github.com/microsoft/vscode/wiki/Source-Code-Organization#target-environments) に準拠しているかを CI でチェックします。 たとえば node 専用型が browser レイヤーに追加された場合など、`npm run valid-layers-check` でビルドが失敗します。
 
-### `vscode-bisect` for sanity testing {#vscode-bisect-for-sanity-testing}
+### vscode-bisect によるサニティテスト {#vscode-bisect-for-sanity-testing}
 
-The [`vscode-bisect`](https://github.com/Microsoft/vscode-bisect) project has been around for a long time allowing to find regressions in VS Code builds (what `git bisect` does for `git`). We added a new `--sanity` option that allows us to quickly go through our [sanity check](https://github.com/microsoft/vscode/wiki/Sanity-Check) that is mandatory before we release a new build.
+[`vscode-bisect`](https://github.com/Microsoft/vscode-bisect) プロジェクトは、VS Code ビルドのリグレッション特定 (git の `git bisect` のようなもの) に長く使われてきました。 新たに `--sanity` オプションを追加し、[サニティチェック](https://github.com/microsoft/vscode/wiki/Sanity-Check) を素早く実施できるようになりました。
 
-## Notable fixes {#notable-fixes}
+## 主な修正 {#notable-fixes}
 
-* [vscode-copilot-release#6073](https://github.com/microsoft/vscode-copilot-release/issues/6073) - Agent should not suggest `&&` in Windows PowerShell
+* [vscode-copilot-release#6073](https://github.com/microsoft/vscode-copilot-release/issues/6073) - エージェントが Windows PowerShell で `&&` を提案しないよう修正
 
-## Thank you {#thank-you}
+## 謝辞 {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code のコントリビューターの皆様に心から感謝いたします。
 
-### Issue tracking {#issue-tracking}
+### イシュートラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+イシュートラッキングへの貢献:
 
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
@@ -617,79 +617,79 @@ Contributions to our issue tracking:
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
 
-### Pull requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): Fix typing in asyncDataTree.test.ts [PR #209394](https://github.com/microsoft/vscode/pull/209394)
-* [@charles7668 (charles)](https://github.com/charles7668): Fix #215925 [PR #219321](https://github.com/microsoft/vscode/pull/219321)
-* [@chengluyu (Luyu Cheng)](https://github.com/chengluyu): Apply `font-variation-settings` to the suggestion widget (fix #199954) [PR #200000](https://github.com/microsoft/vscode/pull/200000)
-* [@DrSergei](https://github.com/DrSergei): Improve debug adapter capabilities checking [PR #250779](https://github.com/microsoft/vscode/pull/250779)
-* [@emmanuel-ferdman (Emmanuel Ferdman)](https://github.com/emmanuel-ferdman): Fix launch.json reference [PR #250187](https://github.com/microsoft/vscode/pull/250187)
-* [@Enzo-Nunes (Enzo Nunes)](https://github.com/Enzo-Nunes): Fix line comment action for makefiles (Fixes #234464) [PR #243283](https://github.com/microsoft/vscode/pull/243283)
-* [@Gallaecio (Adrián Chaves)](https://github.com/Gallaecio): Fix typo (an language model call → a language model call) [PR #252202](https://github.com/microsoft/vscode/pull/252202)
-* [@ghLcd9dG (Liu)](https://github.com/ghLcd9dG): Update copyFiles.ts [PR #250773](https://github.com/microsoft/vscode/pull/250773)
-* [@heoh (HeoHeo)](https://github.com/heoh): Fix markdown preview scroll crawls at EOF (fix #249278) [PR #251228](https://github.com/microsoft/vscode/pull/251228)
-* [@hyrious (hyrious)](https://github.com/hyrious): fix: missing translations of remote built-in extensions [PR #249430](https://github.com/microsoft/vscode/pull/249430)
+* [@a-stewart (Anthony Stewart)](https://github.com/a-stewart): asyncDataTree.test.ts の型修正 [PR #209394](https://github.com/microsoft/vscode/pull/209394)
+* [@charles7668 (charles)](https://github.com/charles7668): #215925 [PR #219321](https://github.com/microsoft/vscode/pull/219321) の修正
+* [@chengluyu (Luyu Cheng)](https://github.com/chengluyu): suggestion widget への `font-variation-settings` 適用 (fix #199954) [PR #200000](https://github.com/microsoft/vscode/pull/200000)
+* [@DrSergei](https://github.com/DrSergei): デバッグアダプター機能チェックの改善 [PR #250779](https://github.com/microsoft/vscode/pull/250779)
+* [@emmanuel-ferdman (Emmanuel Ferdman)](https://github.com/emmanuel-ferdman): launch.json 参照修正 [PR #250187](https://github.com/microsoft/vscode/pull/250187)
+* [@Enzo-Nunes (Enzo Nunes)](https://github.com/Enzo-Nunes): makefiles の行コメントアクション修正 (Fixes #234464) [PR #243283](https://github.com/microsoft/vscode/pull/243283)
+* [@Gallaecio (Adrián Chaves)](https://github.com/Gallaecio): typo 修正 (an language model call → a language model call) [PR #252202](https://github.com/microsoft/vscode/pull/252202)
+* [@ghLcd9dG (Liu)](https://github.com/ghLcd9dG): copyFiles.ts 更新 [PR #250773](https://github.com/microsoft/vscode/pull/250773)
+* [@heoh (HeoHeo)](https://github.com/heoh): Markdown プレビューの EOF スクロール問題修正 (fix #249278) [PR #251228](https://github.com/microsoft/vscode/pull/251228)
+* [@hyrious (hyrious)](https://github.com/hyrious): リモート組み込み拡張の翻訳漏れ修正 [PR #249430](https://github.com/microsoft/vscode/pull/249430)
 * [@jeanp413 (Jean Pierre)](https://github.com/jeanp413)
-  * Do not check for navigator to detect web environment in built-in extensions [PR #251688](https://github.com/microsoft/vscode/pull/251688)
-  * Fix "Assertion Failed: Argument is undefined or null" when renaming custom editor [PR #252071](https://github.com/microsoft/vscode/pull/252071)
-* [@JJJJJJ-git](https://github.com/JJJJJJ-git): Fixing ChatService undo bug [PR #253478](https://github.com/microsoft/vscode/pull/253478)
-* [@liuxingbaoyu](https://github.com/liuxingbaoyu): fix: PowerShell not working with username having Unicode [PR #251534](https://github.com/microsoft/vscode/pull/251534)
-* [@matthew-godin](https://github.com/matthew-godin): fix patternIndices typo [PR #250085](https://github.com/microsoft/vscode/pull/250085)
-* [@mohiuddin-khan-shiam (S. M. Mohiuddin Khan Shiam)](https://github.com/mohiuddin-khan-shiam): Fix incorrect SHA-1 commit regex in [version_manager.rs](cci:7://file:///d:/Github/vscode/cli/src/desktop/version_manager.rs:0:0-0:0) [PR #251329](https://github.com/microsoft/vscode/pull/251329)
+  * web 環境検出で navigator チェックを行わないよう修正 [PR #251688](https://github.com/microsoft/vscode/pull/251688)
+  * カスタムエディターのリネーム時の "Assertion Failed: Argument is undefined or null" 修正 [PR #252071](https://github.com/microsoft/vscode/pull/252071)
+* [@JJJJJJ-git](https://github.com/JJJJJJ-git): ChatService の undo バグ修正 [PR #253478](https://github.com/microsoft/vscode/pull/253478)
+* [@liuxingbaoyu](https://github.com/liuxingbaoyu): ユーザー名に Unicode を含む場合の PowerShell 問題修正 [PR #251534](https://github.com/microsoft/vscode/pull/251534)
+* [@matthew-godin](https://github.com/matthew-godin): patternIndices typo 修正 [PR #250085](https://github.com/microsoft/vscode/pull/250085)
+* [@mohiuddin-khan-shiam (S. M. Mohiuddin Khan Shiam)](https://github.com/mohiuddin-khan-shiam): [version_manager.rs](cci:7://file:///d:/Github/vscode/cli/src/desktop/version_manager.rs:0:0-0:0) の SHA-1 コミット正規表現修正 [PR #251329](https://github.com/microsoft/vscode/pull/251329)
 * [@notoriousmango (Seong Min Park)](https://github.com/notoriousmango)
-  * feat: add font ligatures to webview theme [PR #250998](https://github.com/microsoft/vscode/pull/250998)
-  * feat: add rerun and debug actions for failed tests from last run [PR #251679](https://github.com/microsoft/vscode/pull/251679)
-* [@raffaeu (Raffaele Garofalo)](https://github.com/raffaeu): Refactoring editor sticky scroll [PR #248131](https://github.com/microsoft/vscode/pull/248131)
+  * webview テーマへのフォントリガチャ追加 [PR #250998](https://github.com/microsoft/vscode/pull/250998)
+  * 直近の失敗テストの再実行・デバッグアクション追加 [PR #251679](https://github.com/microsoft/vscode/pull/251679)
+* [@raffaeu (Raffaele Garofalo)](https://github.com/raffaeu): editor sticky scroll のリファクタリング [PR #248131](https://github.com/microsoft/vscode/pull/248131)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
-  * Disable `installation folder` banner warning when debugging extensions [PR #244305](https://github.com/microsoft/vscode/pull/244305)
-  * TypeScript restrict Comment onEnterRules inside comment body [PR #251692](https://github.com/microsoft/vscode/pull/251692)
-* [@ssigwart (Stephen Sigwart)](https://github.com/ssigwart): Update indentation for PHP, JS, and TS [PR #251465](https://github.com/microsoft/vscode/pull/251465)
-* [@Sublimeful (Jian Qiang Wu)](https://github.com/Sublimeful): Implements Terminal: Run Recent Command when there are no terminals [PR #250799](https://github.com/microsoft/vscode/pull/250799)
-* [@tmm1 (Aman Karmani)](https://github.com/tmm1): [engineering] remove dead references to Swc transpile [PR #252375](https://github.com/microsoft/vscode/pull/252375)
-* [@UziTech (Tony Brix)](https://github.com/UziTech): feat: add middle mouse button scrolling [PR #245882](https://github.com/microsoft/vscode/pull/245882)
-* [@yiliang114 (易良)](https://github.com/yiliang114): Fix #250737,  Match count result overflow in Notebook findWidget [PR #250738](https://github.com/microsoft/vscode/pull/250738)
+  * 拡張機能デバッグ時の `installation folder` バナー警告無効化 [PR #244305](https://github.com/microsoft/vscode/pull/244305)
+  * TypeScript の Comment onEnterRules 制限 [PR #251692](https://github.com/microsoft/vscode/pull/251692)
+* [@ssigwart (Stephen Sigwart)](https://github.com/ssigwart): PHP/JS/TS のインデント更新 [PR #251465](https://github.com/microsoft/vscode/pull/251465)
+* [@Sublimeful (Jian Qiang Wu)](https://github.com/Sublimeful): ターミナルがない場合の Terminal: Run Recent Command 実装 [PR #250799](https://github.com/microsoft/vscode/pull/250799)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): [engineering] Swc transpile の不要参照削除 [PR #252375](https://github.com/microsoft/vscode/pull/252375)
+* [@UziTech (Tony Brix)](https://github.com/UziTech): ミドルマウスボタンによるスクロール機能追加 [PR #245882](https://github.com/microsoft/vscode/pull/245882)
+* [@yiliang114 (易良)](https://github.com/yiliang114): Notebook findWidget のマッチ数オーバーフロー修正 [PR #250738](https://github.com/microsoft/vscode/pull/250738)
 
-Contributions to `vscode-copilot-chat`:
+`vscode-copilot-chat` への貢献:
 
-* [@caohy1988 (Hai-Yuan Cao)](https://github.com/caohy1988): update the summary prompt for agent mode [PR #13](https://github.com/microsoft/vscode-copilot-chat/pull/13)
-* [@CharlesCNorton](https://github.com/CharlesCNorton): Update README.md [PR #54](https://github.com/microsoft/vscode-copilot-chat/pull/54)
-* [@gmacario (Gianpaolo Macario)](https://github.com/gmacario): docs(CONTRIBUTING): sync Table of Contents [PR #79](https://github.com/microsoft/vscode-copilot-chat/pull/79)
-* [@moonboxing (ASSEMAR MOHAMED)](https://github.com/moonboxing): update devcontainer-lock after pylint removal [PR #76](https://github.com/microsoft/vscode-copilot-chat/pull/76)
+* [@caohy1988 (Hai-Yuan Cao)](https://github.com/caohy1988): agent mode 用 summary prompt 更新 [PR #13](https://github.com/microsoft/vscode-copilot-chat/pull/13)
+* [@CharlesCNorton](https://github.com/CharlesCNorton): README.md 更新 [PR #54](https://github.com/microsoft/vscode-copilot-chat/pull/54)
+* [@gmacario (Gianpaolo Macario)](https://github.com/gmacario): docs(CONTRIBUTING): Table of Contents 同期 [PR #79](https://github.com/microsoft/vscode-copilot-chat/pull/79)
+* [@moonboxing (ASSEMAR MOHAMED)](https://github.com/moonboxing): pylint 削除後の devcontainer-lock 更新 [PR #76](https://github.com/microsoft/vscode-copilot-chat/pull/76)
 
-Contributions to `vscode-json-languageservice`:
+`vscode-json-languageservice` への貢献:
 
-* [@aedenmurray (Aeden Murray)](https://github.com/aedenmurray): feat: Notify Invalid RegExp Patterns [PR #261](https://github.com/microsoft/vscode-json-languageservice/pull/261)
+* [@aedenmurray (Aeden Murray)](https://github.com/aedenmurray): 無効な正規表現パターンの通知機能追加 [PR #261](https://github.com/microsoft/vscode-json-languageservice/pull/261)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@dyhagho (Dyhagho Briceño)](https://github.com/dyhagho): fix: Allow Github.com auth when `github-enterprise.uri` is set [PR #7002](https://github.com/microsoft/vscode-pull-request-github/pull/7002)
+* [@dyhagho (Dyhagho Briceño)](https://github.com/dyhagho): `github-enterprise.uri` 設定時の Github.com 認証許可 [PR #7002](https://github.com/microsoft/vscode-pull-request-github/pull/7002)
 
-Contributions to `vscode-ripgrep`:
+`vscode-ripgrep` への貢献:
 
-* [@benz0li (Olivier Benz)](https://github.com/benz0li): Add linux riscv64 target [PR #73](https://github.com/microsoft/vscode-ripgrep/pull/73)
-* [@Vector341](https://github.com/Vector341): Fix invalid download crash install [PR #66](https://github.com/microsoft/vscode-ripgrep/pull/66)
+* [@benz0li (Olivier Benz)](https://github.com/benz0li): linux riscv64 ターゲット追加 [PR #73](https://github.com/microsoft/vscode-ripgrep/pull/73)
+* [@Vector341](https://github.com/Vector341): 無効なダウンロード時のクラッシュ修正 [PR #66](https://github.com/microsoft/vscode-ripgrep/pull/66)
 
-Contributions to `vscode-test`:
+`vscode-test` への貢献:
 
-* [@coliff (Christian Oliff)](https://github.com/coliff): Update .npmignore [PR #312](https://github.com/microsoft/vscode-test/pull/312)
+* [@coliff (Christian Oliff)](https://github.com/coliff): .npmignore 更新 [PR #312](https://github.com/microsoft/vscode-test/pull/312)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@billybonks (Sebastien Stettler)](https://github.com/billybonks): fix: improve readability of comment, [PR #2155](https://github.com/microsoft/language-server-protocol/pull/2155)
-* [@rcjsuen (Remy Suen)](https://github.com/rcjsuen): Add the Docker Language Server to the list [PR #2153](https://github.com/microsoft/language-server-protocol/pull/2153)
-* [@yangdanny97 (Danny Yang)](https://github.com/yangdanny97): Add Pyrefly to language servers list  [PR #2160](https://github.com/microsoft/language-server-protocol/pull/2160)
+* [@billybonks (Sebastien Stettler)](https://github.com/billybonks): コメントの可読性向上 [PR #2155](https://github.com/microsoft/language-server-protocol/pull/2155)
+* [@rcjsuen (Remy Suen)](https://github.com/rcjsuen): Docker Language Server 追加 [PR #2153](https://github.com/microsoft/language-server-protocol/pull/2153)
+* [@yangdanny97 (Danny Yang)](https://github.com/yangdanny97): Pyrefly を language servers リストに追加 [PR #2160](https://github.com/microsoft/language-server-protocol/pull/2160)
 
-Contributions to `monaco-editor`:
+`monaco-editor` への貢献:
 
-* [@Ho1yShif (Shifra Williams)](https://github.com/Ho1yShif): Add snowflake sql keywords [PR #4915](https://github.com/microsoft/monaco-editor/pull/4915)
+* [@Ho1yShif (Shifra Williams)](https://github.com/Ho1yShif): snowflake sql キーワード追加 [PR #4915](https://github.com/microsoft/monaco-editor/pull/4915)
 
-Contributions to `ripgrep-prebuilt`:
+`ripgrep-prebuilt` への貢献:
 
 * [@kxxt (Levi Zim)](https://github.com/kxxt)
-  * Build binaries for riscv64 [PR #41](https://github.com/microsoft/ripgrep-prebuilt/pull/41)
-  * Publish binary for riscv64 linux [PR #51](https://github.com/microsoft/ripgrep-prebuilt/pull/51)
+  * riscv64 用バイナリビルド [PR #41](https://github.com/microsoft/ripgrep-prebuilt/pull/41)
+  * riscv64 linux 用バイナリ公開 [PR #51](https://github.com/microsoft/ripgrep-prebuilt/pull/51)
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_102.md
     - release-notes/v1_101.md
     - release-notes/v1_100.md
     - release-notes/v1_99.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/7035be7095f9074c2392f29d420f34d6d705ddd8

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_102.md https://github.com/microsoft/vscode-docs/raw/7035be7095f9074c2392f29d420f34d6d705ddd8/release-notes/v1_102.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```