### PR TITLE
Translate July 2025 (version 1.103)

### DIFF
--- a/docs/release-notes/v1_103.md
+++ b/docs/release-notes/v1_103.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_103/release-highlights.png
 Date: 2025-08-07
 DownloadVersion: 1.103.0
 ---
-# July 2025 (version 1.103)
+# July 2025 (version 1.103) {#july-2025-version-1103}
 
 _Release date: August 7, 2025_
 
@@ -67,9 +67,9 @@ Welcome to the July 2025 release of Visual Studio Code. There are many updates i
   <div class="notes-main">
 Navigation End -->
 
-## Chat
+## Chat {#chat}
 
-### GPT 5 availability
+### GPT 5 availability {#gpt-5-availability}
 
 Starting today, GPT-5 is rolling out to all paid GitHub Copilot plans. GPT-5 is OpenAI's most capable model yet, bringing new advances in reasoning, coding, and chat. Learn more about the GPT-5 model availability in the [GitHub Changelog](https://github.blog/changelog/2025-08-07-openai-gpt-5-is-now-in-public-preview-for-github-copilot).
 
@@ -77,7 +77,7 @@ Open the Chat view and choose GPT-5 from the model picker to start using it for 
 
 Learn more about [using language models in VS Code](https://code.visualstudio.com/docs/copilot/language-models).
 
-### Chat checkpoints
+### Chat checkpoints {#chat-checkpoints}
 
 **Setting**: `setting(chat.checkpoints.enabled)`
 
@@ -89,7 +89,7 @@ When you select a checkpoint, VS Code reverts workspace changes and the chat his
 
 Checkpoints will be enabled by default and can be controlled with `setting(chat.checkpoints.enabled)`.
 
-### Tool picker improvements
+### Tool picker improvements {#tool-picker-improvements}
 
 We've totally revamped the tool picker this iteration and adopted a new component called Quick Tree to display all the tools.
 
@@ -104,7 +104,7 @@ Notable features:
 
 Let us know what you think!
 
-### Tool grouping (Experimental)
+### Tool grouping (Experimental) {#tool-grouping-experimental}
 
 **Setting**: `setting(github.copilot.chat.virtualTools.threshold)`
 
@@ -114,7 +114,7 @@ In this release of VS Code, we have enabled an experimental tool-calling mode fo
 
 This behavior, including the threshold, is configurable via the setting `setting(github.copilot.chat.virtualTools.threshold)`.
 
-### Terminal auto-approve improvements
+### Terminal auto-approve improvements {#terminal-auto-approve-improvements}
 
 **Setting**: `setting(chat.tools.terminal.autoApprove)`
 
@@ -142,7 +142,7 @@ Early terminal auto-approve settings were introduced last month. This release, t
 - The auto approve reasoning is now logged to the Terminal Output channel. We plan to [surface this in the UI soon](https://github.com/microsoft/vscode/issues/256780).
 - For now auto approve will only be allowed in either User or Remote settings. We do plan to allow their use in workspace settings again in an upcoming release.
 
-### Track progress with task lists (Experimental)
+### Track progress with task lists (Experimental) {#track-progress-with-task-lists-experimental}
 
 **Setting**: `setting(chat.todoListTool.enabled)`
 
@@ -156,7 +156,7 @@ Get started by giving the agent a high-level task and ask it to track its work i
 
 This feature is still experimental and you can enable it with the `setting(chat.todoListTool.enabled)` setting.
 
-### Improved model management experience
+### Improved model management experience {#improved-model-management-experience}
 
 This iteration, we've revamped the chat provider API, which is responsible for language model access. Users are now able to select which models appear in their model picker, creating a more personalized and focused experience.
 
@@ -164,7 +164,7 @@ This iteration, we've revamped the chat provider API, which is responsible for l
 
 We plan to finalize this new API in the coming months and would appreciate any feedback. Finalization of this API will open up the extension ecosystem to implement their own model providers and further expand the bring your own key offering.
 
-### Azure DevOps repos remote index support
+### Azure DevOps repos remote index support {#azure-devops-repos-remote-index-support}
 
 The [`#codebase` tool](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context#_perform-a-codebase-search) now supports remote indexes for workspaces that are linked to Azure DevOps repos. This enables `#codebase` to search for relevant snippets almost instantly without any initialization. This even works for larger repos with tens of thousands of indexable files. Previously, this feature only worked with GitHub linked repos.
 
@@ -172,11 +172,11 @@ Remote indexes are used automatically when working in a workspace that is linked
 
 We're gradually rolling out support for this feature on the services side, so not every organization might be able to use it initially. Based on the success of the rollout, we hope to turn on remote indexing for Azure DevOps for as many organizations as possible.
 
-### Improved reliability and performance of the run in terminal and task tools
+### Improved reliability and performance of the run in terminal and task tools {#improved-reliability-and-performance-of-the-run-in-terminal-and-task-tools}
 
 We have migrated the tools for running tasks and commands within the terminal from the Copilot extension into the core [microsoft/vscode repository](https://github.com/microsoft/vscode). This gives the tools access to lower-level and richer APIs, allowing us to fix many of the terminal hanging issues. This update also comes with the benefit of more easily implementing features going forward, as we're no longer restricted to the capabilities of the extension API, especially any changes that need custom UI within the Chat view.
 
-### Warning about no shell integration when using chat
+### Warning about no shell integration when using chat {#warning-about-no-shell-integration-when-using-chat}
 
 While we strive to allow agent mode to run commands in terminals without shell integration, the experience will always be inferior as the terminal is essentially a black box at that point. Examples of issues that can occur without shell integration are: no exit code reporting and the inability to differentiate between a command idling and a prompt idling, resulting in output possibly not being reported to the agent.
 
@@ -184,29 +184,29 @@ When the `run in terminal` tool is used but [shell integration](https://code.vis
 
 ![Screenshot of a message in the Chat view saying "Enable shell integration to improve command detection".](https://code.visualstudio.com/assets/updates/1_103/terminal-chat-si-none.png)
 
-### Output polling for tasks and terminals
+### Output polling for tasks and terminals {#output-polling-for-tasks-and-terminals}
 
 The agent now waits for tasks and background terminals to complete before proceeding by using output polling. If a process takes longer than 20 seconds, you are prompted to continue waiting or move on. The agent will monitor the process for up to two minutes, summarizing the current state or reporting if the process is still running. This improves reliability when running long or error-prone commands in chat.
 
-### Task awareness improvement
+### Task awareness improvement {#task-awareness-improvement}
 
 Previously, the agent could only monitor active tasks. Now, it can track and analyze the output of both active and completed tasks, including those that have failed or finished running. This enhancement enables better troubleshooting and more comprehensive insights into task execution history.
 
-### Agent awareness of user created terminals
+### Agent awareness of user created terminals {#agent-awareness-of-user-created-terminals}
 
 The agent now maintains awareness of all user-created terminals in the workspace. This enables it to track recent commands and access terminal output, providing better context for assisting with terminals and troubleshooting.
 
-### Terminal inline chat improvements
+### Terminal inline chat improvements {#terminal-inline-chat-improvements}
 
 Terminal inline chat now better detects your active shell, even when working within subshells (for example, launching Python or Node from PowerShell or zsh). This dynamic shell detection improves the accuracy of inline chat responses by providing more relevant command suggestions for your current shell type.
 
 ![Screenshot of terminal inline chat showing node specific suggestions.](https://code.visualstudio.com/assets/updates/1_103/hello_node.png)
 
-### Improved test runner tool
+### Improved test runner tool {#improved-test-runner-tool}
 
 The test runner tool has been reworked. It now shows progress inline within chat, and numerous bugs in the tool have been fixed.
 
-### Edit previous requests
+### Edit previous requests {#edit-previous-requests}
 
 **Setting**: `setting(chat.editRequests)`
 
@@ -216,7 +216,7 @@ Last iteration, we enabled users to edit previous requests and rolled out a few 
 
 You can control the chat editing behavior with the `setting(chat.editRequests)` setting if you prefer editing via the toolbar hovers above each request.
 
-### Open chat as maximized
+### Open chat as maximized {#open-chat-as-maximized}
 
 **Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
 
@@ -227,13 +227,13 @@ We added two extra options for configuring the default visibility of the Seconda
 
 ![Screenshot that shows the Chat view maximized.](https://code.visualstudio.com/assets/updates/1_103/max-chat.png)
 
-### Pending chat confirmation
+### Pending chat confirmation {#pending-chat-confirmation}
 
 To help prevent accidentally closing a workspace where an agent session is actively changing files or responding to your request, we now show a dialog when you try to quit VS Code or close its window when a chat response is in progress:
 
 ![Screenshot of confirmation to exit with running chat.](https://code.visualstudio.com/assets/updates/1_103/confirm-chat-exit.png)
 
-### OS notification on user action
+### OS notification on user action {#os-notification-on-user-action}
 
 **Setting**: `setting(chat.notifyWindowOnConfirmation)`
 
@@ -243,7 +243,7 @@ We now leverage the OS native notification system to show a toast when user conf
 
 We plan to improve this experience in the future to allow for displaying more information and for allowing you to approve directly from the toast. For now, selecting the toast focuses the window where the confirmation originated from.
 
-### Math support in chat (Preview)
+### Math support in chat (Preview) {#math-support-in-chat-preview}
 
 **Setting**: `setting(chat.math.enabled)`
 
@@ -255,15 +255,15 @@ This feature is powered by [KaTeX](https://katex.org) and supports both inline a
 
 Math rendering can be enabled using `setting(chat.math.enabled)`. Currently, it is off by default but we plan to enable it in a future release, after further testing.
 
-### Context7 integration for project scaffolding (Experimental)
+### Context7 integration for project scaffolding (Experimental) {#context7-integration-for-project-scaffolding-experimental}
 
 **Setting**: `setting(github.copilot.chat.newWorkspace.useContext7)`
 
 When you scaffold a new project with `#new` in chat, you can now make sure that it uses the latest documentation and APIs from **Context7**, if you have already installed the Context7 MCP server.
 
-## MCP
+## MCP {#mcp}
 
-### Server autostart and trust
+### Server autostart and trust {#server-autostart-and-trust}
 
 **Setting**: `setting(chat.mcp.autostart:newAndOutdated)`
 
@@ -277,7 +277,7 @@ The first time an MCP server is started after being updated or changed, we now s
 
 Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) in our documentation.
 
-### Client credentials flow for remote MCP servers
+### Client credentials flow for remote MCP servers {#client-credentials-flow-for-remote-mcp-servers}
 
 The ideal flow for a remote MCP server that wants to support authentication is to use an auth provider that supports Dynamic Client Registration (DCR). This enables the client (VS Code) to register itself with that auth provider, so the auth flow is seamless.
 
@@ -299,7 +299,7 @@ However, not every auth provider supports DCR, so we introduced a client-credent
 
     At that point, you'll be taken through the typical auth flow to authenticate the MCP server you're working with.
 
-### Remove dynamic auth provider from Account menu
+### Remove dynamic auth provider from Account menu {#remove-dynamic-auth-provider-from-account-menu}
 
 Since the addition of remote MCP authentication, there has been a command available in the Command Palette called **Authentication: Remove Dynamic Authentication Providers**, which enables you to remove client credentials (client ID and, if available, a client secret) and all account information associated with that provider.
 
@@ -311,35 +311,35 @@ or at the root of the menu if you don't have any MCP server accounts yet:
 
 ![Screenshot of the Account menu showing the manage dynamic auth option in the root of account menu.](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth2.png)
 
-### Support for `resource_link` and structured output
+### Support for `resource_link` and structured output {#support-for-resourcelink-and-structured-output}
 
 VS Code now fully supports the latest MCP specification, version `2025-06-18`, with support for `resource_link`s and structured output in tool results.
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Accessible chat elicitations
+### Accessible chat elicitations {#accessible-chat-elicitations}
 
 When the agent prompts for user input, such as whether to keep waiting for a process, the chat elicitation is now accessible to screen readers. You are alerted when the prompt appears, can navigate to it with the keyboard, and can review the message in the accessible view.
 
-### Control file opening for chat edits
+### Control file opening for chat edits {#control-file-opening-for-chat-edits}
 
 A new setting, `setting(accessibility.openChatEditedFiles)`, lets you choose whether files are automatically opened as the agent edits them in chat. Enable this setting for more control over which files appear in your editor.
 
-### View all and previous edits commands
+### View all and previous edits commands {#view-all-and-previous-edits-commands}
 
 The **View All Edits** and **View Previous Edits** commands are now available throughout the editor, making it easy to review changes made by the agent. These commands are especially helpful when `setting(accessibility.openChatEditedFiles)` is disabled, allowing you to track edits without opening each file.
 
-### Side Bar visibility announcements
+### Side Bar visibility announcements {#side-bar-visibility-announcements}
 
 When the Primary or Secondary Side Bar is shown or hidden, an ARIA announcement now notifies you of this change. This improves accessibility by ensuring screen reader users are aware of Side Bar visibility updates.
 
-### Accessibility testing with Playwright
+### Accessibility testing with Playwright {#accessibility-testing-with-playwright}
 
 We have added automated accessibility tests for the editor using Playwright. These tests help us continuously validate that Visual Studio Code meets accessibility standards and best practices, ensuring a better experience for all users.
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Settings search suggestions
+### Settings search suggestions {#settings-search-suggestions}
 
 The AI search results toggle in the search box of the Settings editor, indicated by a sparkle, is now available for all users. The toggle is enabled when AI search results have loaded and are available. Pressing the toggle switches between the AI and non-AI search results.
 
@@ -347,13 +347,13 @@ The AI settings search results are based on semantic similarity instead of strin
 
 ![Screenshot of AI results in the Settings editor for "increase text size" showing editor.fontSize setting.](https://code.visualstudio.com/assets/updates/1_103/settings-editor-toggle.png)
 
-### Editor tab context menu
+### Editor tab context menu {#editor-tab-context-menu}
 
 We cleaned up the editor tab context menu to group related options for splitting and moving into a submenu:
 
 ![Screenshot that shows the 'Split and Move' editor tab context menu.](https://code.visualstudio.com/assets/updates/1_103/editor-menu.png)
 
-### AI statistics (Preview)
+### AI statistics (Preview) {#ai-statistics-preview}
 
 **Setting**: `setting(editor.aiStats.enabled:true)`
 
@@ -363,9 +363,9 @@ This feature shows you, per project, the percentage of characters that was inser
 
 ![Screenshot showing the AI statistic hover information in the Status Bar.](https://code.visualstudio.com/assets/updates/1_103/ai-stats.png)
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Notebook inline chat with agent tools
+### Notebook inline chat with agent tools {#notebook-inline-chat-with-agent-tools}
 
 **Setting**: `setting(inlineChat.notebookAgent:true)`
 
@@ -375,15 +375,15 @@ The notebook inline chat control can now use the full suite of notebook agent to
 
 To enable agent tools in notebooks, enable the new experimental setting `setting(inlineChat.notebookAgent:true)`. This also currently requires enabling the setting for inline chat v2 `setting(inlineChat.enableV2:true)`.
 
-### Install dependencies in Virtual Environments created with uv
+### Install dependencies in Virtual Environments created with uv {#install-dependencies-in-virtual-environments-created-with-uv}
 
 We now support installing required dependencies when you run Jupyter Notebooks against a Virtual Environment created using [uv](https://docs.astral.sh/uv/pip/environments/).
 
 <video src="https://code.visualstudio.com/assets/updates/1_103/uv-install-ipykernel.mp4" title="Video that shows installing IPyKernel in uv Virtual Environment." autoplay loop controls muted></video>
 
-## Source Control
+## Source Control {#source-control}
 
-### Git worktree support
+### Git worktree support {#git-worktree-support}
 
 **Setting**: `setting(git.detectWorktrees)`
 
@@ -395,15 +395,15 @@ When opening a folder or workspace that contains a git repository, we now automa
 
 ![Screenshot of open and delete worktree commands in the Source Control view.](https://code.visualstudio.com/assets/updates/1_103/worktree_specific_submenu.png)
 
-### Repositories view
+### Repositories view {#repositories-view}
 
 The Source Control Repositories view displays all source control providers that were discovered in the current folder/workspace. This milestone, we have updated the rendering of the view in order to visually distinguish between repositories, submodules, and worktrees. We also show the parent-child relationship between repositories, submodules and worktrees.
 
 ![Screenshot of the Source Control Repositories view showing two repositories and a worktree associated with one of the repos.](https://code.visualstudio.com/assets/updates/1_103/repositories-view.png)
 
-## Terminal
+## Terminal {#terminal}
 
-### Documentation support in terminal suggest
+### Documentation support in terminal suggest {#documentation-support-in-terminal-suggest}
 
 Terminal suggestions powered by language servers (LSP) now include inline documentation, similar to what you see in the editor. Starting with the Python REPL, you'll get helpful descriptions and usage details for commands as you type.
 
@@ -414,11 +414,11 @@ You currently need these settings to enable LSP suggestions in the terminal:
 
 <video src="https://code.visualstudio.com/assets/updates/1_103/lsp_documentation.mp4" title="Video showing terminal suggest completions items with LSP now show code docs." autoplay loop controls muted></video>
 
-### Voice dictation
+### Voice dictation {#voice-dictation}
 
 Now that natural language input is supported in terminals, including those enabled by the Gemini and Claude extensions, we have reintroduced voice dictation in the terminal. You can start or stop dictation by using the **Terminal: Start Dictation in Terminal** and **Terminal: Stop Dictation in Terminal** commands.
 
-### Improved shell integration diagnostics
+### Improved shell integration diagnostics {#improved-shell-integration-diagnostics}
 
 [Shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) is the foundation that many features in the integrated terminal are built upon such as [sticky scroll](https://code.visualstudio.com/docs/terminal/shell-integration#_sticky-scroll), [quick fixes](https://code.visualstudio.com/docs/terminal/shell-integration#_quick-fixes) and [agent mode's](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) ability to understand what's happening inside the terminal.
 
@@ -428,27 +428,27 @@ This release features some improved diagnostics when you hover the terminal and 
 
 This is one of the first places to look if one of these rich features isn't working as expected.
 
-## Languages
+## Languages {#languages}
 
-### Python
+### Python {#python}
 
-#### Shell integration support for Python 3.13 and above
+#### Shell integration support for Python 3.13 and above {#shell-integration-support-for-python-3-13-and-above}
 
 We now support shell integration for Python when using version 3.13 or later. When enabled, PyREPL is automatically disabled to ensure compatibility. You can disable shell integration if you prefer to continue using PyREPL.
 
 ![Screenshot showing the Python shell integration setting in the Settings editor.](https://code.visualstudio.com/assets/updates/1_103/python_shellIntegration.png)
 
-#### Python Environments extension improvements
+#### Python Environments extension improvements {#python-environments-extension-improvements}
 
 The [Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) continued to receive bug fixes and improvements as part of the controlled roll-out to stable users. To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code `settings.json` file: `"python.useEnvironmentsExtension": true`.
 
-### TypeScript 5.9
+### TypeScript 5.9 {#typescript-59}
 
 VS Code now includes TypeScript 5.9.2. This major update brings a few new language improvements, including [support for import defer](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer), along with tooling improvements such as [improved docs for many DOM apis](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer).
 
 Check out the [TypeScript 5.9 release blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/) for more details on this update.
 
-### Expandable hovers for JavaScript and TypeScript
+### Expandable hovers for JavaScript and TypeScript {#expandable-hovers-for-javascript-and-typescript}
 
 When you hover over a symbol in JavaScript or TypeScript, VS Code tries to show the most useful IntelliSense type information about that symbol. Types can be very complex, so one challenge for us has been trying to find the right balance between showing enough details to be useful, while not showing so much info that it becomes overwhelming. It's hard to come up with a good one size fits all approach, and also the level of type detail you want might change depending on what you are working on.
 
@@ -458,21 +458,21 @@ That's why this iteration, we've added new UI that gives you more control over h
 
 Hovers can be expanded multiple times, which recursively expands types from the previous expansion. If you ever expand too much, just select the `-` icon to go back to the previous level. Also keep in mind that not every type is expandable and that we still need some limits on just how much expansion we can support. [Let us know](https://github.com/microsoft/vscode/issues/new?template=bug_report.md) if there are any cases where expandable hovers aren't working how you'd like.
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### GitHub Pull Requests
+### GitHub Pull Requests {#github-pull-requests}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
 
 Review the [changelog for the 0.116.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01160) release of the extension to learn about everything in the release.
 
-#### Pull request header cleanup
+#### Pull request header cleanup {#pull-request-header-cleanup}
 
 We've simplified the button bar in the pull request description header. The copy actions are now in the right-click context menu of the PR link.
 
 ![Screenshot of the simplified PR header when opening the PR details.](https://code.visualstudio.com/assets/updates/1_103/simplified-pr-header-buttons.png)
 
-#### Show coding agent PRs in chat
+#### Show coding agent PRs in chat {#show-coding-agent-prs-in-chat}
 
 **Setting**: `setting(githubPullRequests.codingAgent.uiIntegration)`
 
@@ -482,9 +482,9 @@ When you start a coding agent session (via `#copilotCodingAgent` or with the **D
 
 Enable the `setting(githubPullRequests.codingAgent.uiIntegration)` setting to enable the new **Delegate to coding agent** button in the Chat view, for repositories that have the agent enabled.
 
-#### Chat sessions (Experimental)
+#### Chat sessions (Experimental) {#chat-sessions-experimental}
 
-##### Coding agent chats
+##### Coding agent chats {#coding-agent-chats}
 
 Building off [last iteration's Copilot coding agent integration](https://code.visualstudio.com/updates/v1_102#_github-pull-requests), you can now manage a coding agent session from a dedicated chat editor. This enables you to follow the progress of the coding agent, provide follow-up instructions, and see the agent's responses in a dedicated chat editor.
 
@@ -500,7 +500,7 @@ Building off [last iteration's Copilot coding agent integration](https://code.vi
 
     ![Screenshot showing providing a followup in chat to coding agent.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-follow-up.png)
 
-##### Chat sessions view
+##### Chat sessions view {#chat-sessions-view}
 
 **Setting**: `setting(chat.agentSessionsViewLocation)`
 
@@ -518,9 +518,9 @@ This integration requires the latest GitHub Pull Request extension and a reposit
 
 _Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### Terminal activation events
+### Terminal activation events {#terminal-activation-events}
 
 Two new activation events are available for extensions:
 
@@ -529,9 +529,9 @@ Two new activation events are available for extensions:
 
 You can specify a `shellType` to target specific shells. For example, `onTerminalShellIntegration:bash` activates when shell integration is enabled for a Bash terminal.
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Render custom webviews in chat responses
+### Render custom webviews in chat responses {#render-custom-webviews-in-chat-responses}
 
 The Chat Output Renderer API lets extensions take chat responses beyond text and images. With it, your extension can use a [webview](https://code.visualstudio.com/api/extension-capabilities/extending-workbench) to render arbitrary HTML content in the chat output. Example use cases include custom visualizations, inline previews, and even interactive controls.
 
@@ -553,17 +553,17 @@ Check out the [extension sample](https://github.com/microsoft/vscode-extension-s
 
 This API has the potential to be very powerful and enable some amazing new chat experiences, so give it a try and let us know what you think!
 
-### Chat Session Provider API
+### Chat Session Provider API {#chat-session-provider-api}
 
 The new Chat Session Provider API proposal enables extensions to integrate their own chat backend into VS Code's native chat UI. Using it, your extension can open a new chat session, populate the history for that session, and respond to new user prompts.
 
 This API is still in early stages and is likely to change. However we're already using it to power the new [GitHub coding agent session flow](#chat-sessions-experimental), which loads chats from GitHub and allows you to chat with an agent that is controlled entirely by GitHub.
 
-### Task execution terminal
+### Task execution terminal {#task-execution-terminal}
 
 Extension authors can now access the terminal associated with a running task via the new `taskExecution.terminal` property. This makes it easier to identify which terminal is linked to a specific task and interact with it programmatically.
 
-### SecretStorage `keys()` API
+### SecretStorage `keys()` API {#secretstorage-keys-api}
 
 If you have ever wanted to get the list of keys that your extension has stored in `SecretStorage`, you can now do so with the new proposed `keys()` API:
 
@@ -578,25 +578,25 @@ export async function activate(context: ExtensionContext) {
 
 > **NOTE**: This change is dependent on a change to anything that provides an alternative implementation of a Secret Storage, notably <https://vscode.dev>, which has adopted the new API, and <https://github.dev>, which will adopt the new API soon. In an environment where it is not supported, this API will throw an exception.
 
-## Engineering
+## Engineering {#engineering}
 
-### packages.microsoft.com key update
+### packages.microsoft.com key update {#packages-microsoft-com-key-update}
 
 `packages.microsoft.com` has updated their signing key and as a result, Linux users on newer distributions should stop seeing key-related warnings or errors while installing VS Code. Debian-based distributions automatically receive the new key, whereas users on other distributions may have to manually remove the old key before [importing the new key](https://code.visualstudio.com/docs/setup/linux#_install-vs-code-on-linux).
 
-### Electron 37 update
+### Electron 37 update {#electron-37-update}
 
 In this milestone, we are promoting the Electron 37 update to users on our Stable release. This update comes with Chromium 138.0.7204.100 and Node.js 22.17.0. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [vscode#252384](https://github.com/microsoft/vscode/issues/252384) - Agent Mode pauses when VS Code loses focus
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -605,7 +605,7 @@ Contributions to our issue tracking:
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull Requests
+### Pull Requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_103.md
+++ b/docs/release-notes/v1_103.md
@@ -1,46 +1,46 @@
 ---
 Order: 112
-TOCTitle: July 2025
-PageTitle: Visual Studio Code July 2025
-MetaDescription: Learn what is new in the Visual Studio Code July 2025 Release (1.103)
+TOCTitle: 2025 年 7 月
+PageTitle: Visual Studio Code 2025 年 7 月
+MetaDescription: Visual Studio Code 2025 年 7 月リリース (1.103) の新機能を紹介します。
 MetaSocialImage: 1_103/release-highlights.png
 Date: 2025-08-07
 DownloadVersion: 1.103.0
 ---
-# July 2025 (version 1.103) {#july-2025-version-1103}
+# 2025 年 7 月 (バージョン 1.103) {#july-2025-version-1103}
 
-_Release date: August 7, 2025_
+_リリース日: 2025 年 8 月 7 日_
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the July 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2025 年 7 月リリースへようこそ。今月も多くの改善をお届けします。主なハイライトは次のとおりです。
 
 <table class="highlights-table">
   <tr>
     <th>MCP</th>
-    <th>Chat</th>
-    <th>Productivity</th>
+    <th>チャット</th>
+    <th>生産性</th>
   </tr>
   <tr>
-    <td>Revamped tool picker experience <a href="#tool-picker-improvements"><br>Show more</a></td>
-    <td>Use GPT-5 in VS Code <a href="#gpt-5-availability"><br>Show more</a></td>
-    <td>Check out multiple branches simultaneously with Git worktrees <a href="#git-worktree-support"><br>Show more</a></td>
+    <td>刷新したツールピッカー体験 <a href="#tool-picker-improvements"><br>さらに表示</a></td>
+    <td>VS Code で GPT‑5 を利用 <a href="#gpt-5-availability"><br>さらに表示</a></td>
+    <td>Git worktree で複数ブランチを同時チェックアウト <a href="#git-worktree-support"><br>さらに表示</a></td>
   </tr>
   <tr>
-    <td>Enable more than 128 tools per agent request <a href="#tool-grouping-experimental"><br>Show more</a></td>
-    <td>Restore to a previous good state with chat checkpoints <a href="#chat-checkpoints"><br>Show more</a></td>
-    <td>Manage coding agent sessions in a dedicated view <a href="#chat-sessions-experimental"><br>Show more</a></td>
+    <td>1 回のエージェント要求で 128 個超のツールを可能に <a href="#tool-grouping-experimental"><br>さらに表示</a></td>
+    <td>チャットのチェックポイントで良好な状態へ戻す <a href="#chat-checkpoints"><br>さらに表示</a></td>
+    <td>専用ビューでコーディングエージェントセッションを管理 <a href="#chat-sessions-experimental"><br>さらに表示</a></td>
   </tr>
 </table>
 
 <br>
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+> これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) をご覧ください。<br>
 
-> **Insiders: Want to try new features as soon as possible?**<br>
-> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> **Insiders: 新機能をいち早く試したいですか?**<br>
+> Nightly Insiders ビルドをダウンロードして、利用可能になり次第最新の更新をお試しください。<br>
 > [Download Insiders](https://code.visualstudio.com/insiders)<br>
 
 <!-- TOC
@@ -67,505 +67,505 @@ Welcome to the July 2025 release of Visual Studio Code. There are many updates i
   <div class="notes-main">
 Navigation End -->
 
-## Chat {#chat}
+## チャット {#chat}
 
-### GPT 5 availability {#gpt-5-availability}
+### GPT 5 の提供状況 {#gpt-5-availability}
 
-Starting today, GPT-5 is rolling out to all paid GitHub Copilot plans. GPT-5 is OpenAI's most capable model yet, bringing new advances in reasoning, coding, and chat. Learn more about the GPT-5 model availability in the [GitHub Changelog](https://github.blog/changelog/2025-08-07-openai-gpt-5-is-now-in-public-preview-for-github-copilot).
+本日より、GPT‑5 はすべての有料 GitHub Copilot プランに順次ロールアウトされます。GPT‑5 は OpenAI のこれまでで最も高性能なモデルで、推論・コーディング・チャットの各分野で新たな進歩をもたらします。GPT‑5 の提供状況の詳細は [GitHub Changelog](https://github.blog/changelog/2025-08-07-openai-gpt-5-is-now-in-public-preview-for-github-copilot) を参照してください。
 
-Open the Chat view and choose GPT-5 from the model picker to start using it for your chat conversations in VS Code.
+Chat ビューを開き、モデルピッカーから GPT‑5 を選択すると、VS Code でチャット会話に利用できます。
 
-Learn more about [using language models in VS Code](https://code.visualstudio.com/docs/copilot/language-models).
+[VS Code での言語モデルの使い方](https://code.visualstudio.com/docs/copilot/language-models) もご覧ください。
 
-### Chat checkpoints {#chat-checkpoints}
+### チャットのチェックポイント {#chat-checkpoints}
 
-**Setting**: `setting(chat.checkpoints.enabled)`
+**設定**: `setting(chat.checkpoints.enabled)`
 
-We've introduced checkpoints that enable you to restore different states of your chat conversations. You can easily revert edits and go back to certain points in your chat conversation. This can be particularly useful if multiple files were changed in a chat session.
+チャット会話の異なる状態を復元できるチェックポイントを導入しました。編集を簡単に元に戻し、会話の特定の時点に戻れます。チャットセッションで複数ファイルが変更された場合に特に有用です。
 
-When you select a checkpoint, VS Code reverts workspace changes and the chat history to that point. After restoring a checkpoint, you can redo that action as well!
+チェックポイントを選択すると、その時点までのワークスペースの変更とチャット履歴を VS Code が復元します。チェックポイント復元後にやり直すこともできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/chat-checkpoints.mp4" title="Video that shows creating and managing chat checkpoints." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/chat-checkpoints.mp4" title="チェックポイントの作成と管理のデモ。" autoplay loop controls muted></video>
 
-Checkpoints will be enabled by default and can be controlled with `setting(chat.checkpoints.enabled)`.
+チェックポイントは既定で有効で、`setting(chat.checkpoints.enabled)` で制御できます。
 
-### Tool picker improvements {#tool-picker-improvements}
+### ツールピッカーの改善 {#tool-picker-improvements}
 
-We've totally revamped the tool picker this iteration and adopted a new component called Quick Tree to display all the tools.
+今イテレーションではツールピッカーを全面刷新し、すべてのツールを表示する新コンポーネント Quick Tree を採用しました。
 
-![Screenshot showing the new tool picker using a quick tree, enabling collapsing and expanding nodes.](https://code.visualstudio.com/assets/updates/1_103/tool-picker-quick-tree.png)
+![クイックツリーによる新しいツールピッカー。ノードの折りたたみ/展開が可能。](https://code.visualstudio.com/assets/updates/1_103/tool-picker-quick-tree.png)
 
-Notable features:
+主な機能:
 
-* Expand or collapse
-* Configuration options moved to the title bar
-* Sticky scrolling
-* Icon rendering
+* 展開 / 折りたたみ
+* 設定オプションをタイトルバーへ移動
+* スティッキースクロール
+* アイコン表示
 
-Let us know what you think!
+ぜひご意見をお寄せください。
 
-### Tool grouping (Experimental) {#tool-grouping-experimental}
+### ツールのグループ化 (実験的) {#tool-grouping-experimental}
 
-**Setting**: `setting(github.copilot.chat.virtualTools.threshold)`
+**設定**: `setting(github.copilot.chat.virtualTools.threshold)`
 
-The maximum number of tools that you can use for a single chat request is currently 128. Previously, you could quickly reach this limit by installing MCP servers with many tools, requiring you to deselect some tools in order to proceed.
+1 回のチャット要求で利用できるツールの最大数は現在 128 です。以前は、ツール数の多い MCP サーバーを導入するとすぐにこの上限に達し、続行するにはいくつかのツールの選択を解除する必要がありました。
 
-In this release of VS Code, we have enabled an experimental tool-calling mode for when the number of tools exceeds the maximum limit. Tools are automatically grouped and the model is given the ability to activate and call groups of tools.
+このリリースでは、ツール数が上限を超えた際に有効になる実験的なツール呼び出しモードを追加しました。ツールは自動的にグループ化され、モデルはツールグループを有効化して呼び出せるようになります。
 
-This behavior, including the threshold, is configurable via the setting `setting(github.copilot.chat.virtualTools.threshold)`.
+この挙動 (しきい値を含む) は `setting(github.copilot.chat.virtualTools.threshold)` で設定できます。
 
-### Terminal auto-approve improvements {#terminal-auto-approve-improvements}
+### ターミナル自動承認の改善 {#terminal-auto-approve-improvements}
 
-**Setting**: `setting(chat.tools.terminal.autoApprove)`
+**設定**: `setting(chat.tools.terminal.autoApprove)`
 
-Early terminal auto-approve settings were introduced last month. This release, the feature got many improvements. Learn more about [terminal auto-approval](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands-experimental) in our documentation.
+先月導入したターミナル自動承認の設定を、今月は大幅に改善しました。詳細はドキュメントの [ターミナル自動承認](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands-experimental) を参照してください。
 
-- We merged the `allowList` and `denyList` settings into the `setting(chat.tools.terminal.autoApprove)` setting. If you were using the old settings, you should see a warning asking you to migrate to the new setting.
-- Regular expression matchers now support flags. This allows case insensitivity, for example in PowerShell, where case often doesn't matter:
+- `allowList` と `denyList` の 2 つの設定を `setting(chat.tools.terminal.autoApprove)` に統合しました。旧設定を使用している場合は新設定への移行を促す警告が表示されます。
+- 正規表現マッチャーがフラグに対応しました。たとえば PowerShell では大文字/小文字を区別しないことが多いため、`i` フラグが有用です:
 
     ```jsonc
     "chat.tools.terminal.autoApprove": {
-      // Deny any `Remove-Item` command, regardless of case
+      // 大文字/小文字に関係なく、あらゆる `Remove-Item` コマンドを拒否
       "/^Remove-Item\\b/i": false
     }
     ```
 
-- There was some confusion around how the sub-command matching works, this is now explained in detail in the setting's description, but we also support matching against the complete command line.
+- サブコマンドのマッチング方法に関する混乱がありましたが、設定の説明に詳細を追加し、コマンドライン全体に対するマッチングもサポートしました。
 
     ```jsonc
     "chat.tools.terminal.autoApprove": {
-      // Deny any _command line_ containing a reference to what is likely a PowerShell script
+      // PowerShell スクリプトらしき参照を含むあらゆる「コマンドライン」を拒否
       "/\\.ps1\\b/i": { "approve": false, "matchCommandLine": true }
     }
     ```
 
-- The auto approve reasoning is now logged to the Terminal Output channel. We plan to [surface this in the UI soon](https://github.com/microsoft/vscode/issues/256780).
-- For now auto approve will only be allowed in either User or Remote settings. We do plan to allow their use in workspace settings again in an upcoming release.
+- 自動承認の判断根拠を Terminal の出力チャネルに記録するようになりました。将来的に [UI での表示も予定](https://github.com/microsoft/vscode/issues/256780) しています。
+- 当面は、ユーザー設定またはリモート設定でのみ自動承認を許可します。今後のリリースでワークスペース設定でも利用可能にする予定です。
 
-### Track progress with task lists (Experimental) {#track-progress-with-task-lists-experimental}
+### タスクリストで進捗を追跡 (実験的) {#track-progress-with-task-lists-experimental}
 
-**Setting**: `setting(chat.todoListTool.enabled)`
+**設定**: `setting(chat.todoListTool.enabled)`
 
-The great thing about agent mode is that you can give it a high-level task and have it implement it. As it plans the work and breaks it down into smaller tasks, it can be overwhelming to track the progress of all these individual tasks.
+エージェントモードの利点は、高レベルのタスクを与えるだけで実装まで行えることです。しかし、作業計画を立てて細かなタスクへと分割していくと、個々のタスクの進捗を追うのが大変になることがあります。
 
-This milestone, we are introducing the task/todo list feature in chat to better help you see which tasks are completed and which ones are still pending. You can view the task list at the top of the Chat view, so you always have visibility into the progress being made. As the agent progresses through its work, it updates the task list.
+そこで今月は、チャットにタスク/ToDo リスト機能を導入しました。完了済みと保留中のタスクが一目で分かります。タスクリストは常に Chat ビュー上部に表示され、進捗を把握できます。エージェントの進行に合わせてタスクリストは更新されます。
 
-Get started by giving the agent a high-level task and ask it to track its work in a todo list!
+高レベルのタスクをエージェントに与え、ToDo リストで進捗を追跡するよう依頼してみてください。
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/chat-todo-list.mp4" title="Video that shows the todo list in chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/chat-todo-list.mp4" title="チャットの ToDo リストのデモ。" autoplay loop controls muted></video>
 
-This feature is still experimental and you can enable it with the `setting(chat.todoListTool.enabled)` setting.
+この機能はまだ実験段階で、`setting(chat.todoListTool.enabled)` を有効にすると利用できます。
 
-### Improved model management experience {#improved-model-management-experience}
+### モデル管理体験の改善 {#improved-model-management-experience}
 
-This iteration, we've revamped the chat provider API, which is responsible for language model access. Users are now able to select which models appear in their model picker, creating a more personalized and focused experience.
+今イテレーションでは、言語モデルへのアクセスを担うチャットプロバイダー API を刷新しました。ユーザーはモデルピッカーに表示するモデルを選択できるようになり、よりパーソナライズされた集中しやすい体験になります。
 
-![Screenshot of the model picker showing various models from providers such as Copilot and OpenRouter](https://code.visualstudio.com/assets/updates/1_103/modelpicker.png)
+![Copilot や OpenRouter などのプロバイダーのモデルを表示するモデルピッカーのスクリーンショット](https://code.visualstudio.com/assets/updates/1_103/modelpicker.png)
 
-We plan to finalize this new API in the coming months and would appreciate any feedback. Finalization of this API will open up the extension ecosystem to implement their own model providers and further expand the bring your own key offering.
+今後数か月でこの新 API を安定化する予定です。フィードバックをお待ちしています。API の安定化により、拡張機能が独自のモデルプロバイダーを実装でき、BYOK (Bring Your Own Key) の選択肢もさらに広がります。
 
-### Azure DevOps repos remote index support {#azure-devops-repos-remote-index-support}
+### Azure DevOps リポジトリのリモートインデックス対応 {#azure-devops-repos-remote-index-support}
 
-The [`#codebase` tool](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context#_perform-a-codebase-search) now supports remote indexes for workspaces that are linked to Azure DevOps repos. This enables `#codebase` to search for relevant snippets almost instantly without any initialization. This even works for larger repos with tens of thousands of indexable files. Previously, this feature only worked with GitHub linked repos.
+[`#codebase` ツール](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context#_perform-a-codebase-search) が、Azure DevOps のリポジトリにリンクされたワークスペース向けのリモートインデックスに対応しました。初期化なしで、関連スニペットをほぼ即時に検索できます。数万ファイル規模の大規模リポジトリでも機能します。以前は GitHub にリンクされたリポジトリのみで動作していました。
 
-Remote indexes are used automatically when working in a workspace that is linked to Azure DevOps through git. Make sure you are also logged into VS Code with the Microsoft account you use to access the Azure DevOps repos.
+Git で Azure DevOps にリンクされたワークスペースでは自動的にリモートインデックスが使われます。Azure DevOps リポジトリへアクセスする Microsoft アカウントで VS Code にサインインしていることを確認してください。
 
-We're gradually rolling out support for this feature on the services side, so not every organization might be able to use it initially. Based on the success of the rollout, we hope to turn on remote indexing for Azure DevOps for as many organizations as possible.
+この機能はサービス側で段階的にロールアウト中のため、当初は組織によっては利用できない場合があります。状況が良好であれば、できるだけ多くの組織で Azure DevOps のリモートインデックスを有効化する予定です。
 
-### Improved reliability and performance of the run in terminal and task tools {#improved-reliability-and-performance-of-the-run-in-terminal-and-task-tools}
+### ターミナル実行・タスクツールの信頼性と性能改善 {#improved-reliability-and-performance-of-the-run-in-terminal-and-task-tools}
 
-We have migrated the tools for running tasks and commands within the terminal from the Copilot extension into the core [microsoft/vscode repository](https://github.com/microsoft/vscode). This gives the tools access to lower-level and richer APIs, allowing us to fix many of the terminal hanging issues. This update also comes with the benefit of more easily implementing features going forward, as we're no longer restricted to the capabilities of the extension API, especially any changes that need custom UI within the Chat view.
+ターミナル内でコマンドやタスクを実行するツールを、Copilot 拡張からコアの [microsoft/vscode リポジトリ](https://github.com/microsoft/vscode) に移管しました。これにより、低レベルでリッチな API にアクセスでき、ターミナルがハングする問題の多くを修正できました。拡張 API の制約 (特に Chat ビュー内のカスタム UI が必要な変更) から解放され、将来の機能実装もしやすくなります。
 
-### Warning about no shell integration when using chat {#warning-about-no-shell-integration-when-using-chat}
+### チャット使用時のシェル統合未有効の警告 {#warning-about-no-shell-integration-when-using-chat}
 
-While we strive to allow agent mode to run commands in terminals without shell integration, the experience will always be inferior as the terminal is essentially a black box at that point. Examples of issues that can occur without shell integration are: no exit code reporting and the inability to differentiate between a command idling and a prompt idling, resulting in output possibly not being reported to the agent.
+エージェントモードがシェル統合なしでもターミナルでコマンドを実行できるよう努めていますが、その場合ターミナルは事実上ブラックボックスになるため体験は劣化します。発生しうる問題としては、終了コードの取得不可や、コマンド待ちとプロンプト待ちの区別が付かないために出力がエージェントへ正しく報告されない、などが挙げられます。
 
-When the `run in terminal` tool is used but [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) is not detected, a message is displayed calling this out and pointing at the documentation.
+`run in terminal` ツール使用時に [シェル統合](https://code.visualstudio.com/docs/terminal/shell-integration) が検出されない場合は、これを示しドキュメントへのリンクを提示するメッセージを表示します。
 
-![Screenshot of a message in the Chat view saying "Enable shell integration to improve command detection".](https://code.visualstudio.com/assets/updates/1_103/terminal-chat-si-none.png)
+![「コマンド検出を改善するためシェル統合を有効にしてください」と表示するメッセージのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/terminal-chat-si-none.png)
 
-### Output polling for tasks and terminals {#output-polling-for-tasks-and-terminals}
+### タスクとターミナルの出力ポーリング {#output-polling-for-tasks-and-terminals}
 
-The agent now waits for tasks and background terminals to complete before proceeding by using output polling. If a process takes longer than 20 seconds, you are prompted to continue waiting or move on. The agent will monitor the process for up to two minutes, summarizing the current state or reporting if the process is still running. This improves reliability when running long or error-prone commands in chat.
+エージェントは、出力ポーリングを使ってタスクやバックグラウンドターミナルの完了を待つようになりました。プロセスが 20 秒を超える場合、引き続き待機するか、先へ進むかを確認します。最大 2 分間監視し、進行状況の要約や、まだ実行中である旨を報告します。これにより、チャットで長時間実行やエラーが起きやすいコマンドを扱う際の信頼性が向上します。
 
-### Task awareness improvement {#task-awareness-improvement}
+### タスク認識の改善 {#task-awareness-improvement}
 
-Previously, the agent could only monitor active tasks. Now, it can track and analyze the output of both active and completed tasks, including those that have failed or finished running. This enhancement enables better troubleshooting and more comprehensive insights into task execution history.
+これまではエージェントはアクティブなタスクのみ監視できましたが、失敗または完了したタスクを含む、アクティブ・完了の両方のタスク出力を追跡・分析できるようになりました。これにより、トラブルシューティングが容易になり、タスク実行履歴の把握がより包括的になります。
 
-### Agent awareness of user created terminals {#agent-awareness-of-user-created-terminals}
+### ユーザー作成ターミナルの認識 {#agent-awareness-of-user-created-terminals}
 
-The agent now maintains awareness of all user-created terminals in the workspace. This enables it to track recent commands and access terminal output, providing better context for assisting with terminals and troubleshooting.
+エージェントはワークスペース内のユーザー作成ターミナルをすべて把握するようになりました。これにより、最近のコマンドやターミナル出力を追跡でき、ターミナル支援やトラブルシューティングの文脈が向上します。
 
-### Terminal inline chat improvements {#terminal-inline-chat-improvements}
+### ターミナルのインラインチャットの改善 {#terminal-inline-chat-improvements}
 
-Terminal inline chat now better detects your active shell, even when working within subshells (for example, launching Python or Node from PowerShell or zsh). This dynamic shell detection improves the accuracy of inline chat responses by providing more relevant command suggestions for your current shell type.
+ターミナルのインラインチャットが、サブシェル (例: PowerShell や zsh から Python / Node を起動) 内で作業している場合でも、アクティブなシェルをより適切に検出するようになりました。この動的なシェル検出により、現在のシェルに合った、より関連性の高いコマンド提案が可能になります。
 
-![Screenshot of terminal inline chat showing node specific suggestions.](https://code.visualstudio.com/assets/updates/1_103/hello_node.png)
+![Node 向けの提案を示すターミナルインラインチャットのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/hello_node.png)
 
-### Improved test runner tool {#improved-test-runner-tool}
+### テストランナーツールの改善 {#improved-test-runner-tool}
 
-The test runner tool has been reworked. It now shows progress inline within chat, and numerous bugs in the tool have been fixed.
+テストランナーツールを作り直しました。チャット内に進捗をインライン表示できるようになり、多数のバグを修正しました。
 
-### Edit previous requests {#edit-previous-requests}
+### 過去の要求を編集 {#edit-previous-requests}
 
-**Setting**: `setting(chat.editRequests)`
+**設定**: `setting(chat.editRequests)`
 
-Last iteration, we enabled users to edit previous requests and rolled out a few different access points. This iteration, we've made inline edits the default behavior. Click on the request bubble to begin editing that request. You can modify attachments, change the mode and model, and resend your request with modified text.
+前イテレーションで、過去の要求を編集できる機能を有効化し、複数の導線を展開しました。今イテレーションでは、インライン編集を既定の動作にしました。要求のバブルをクリックすると編集を開始できます。添付の変更、モードやモデルの切り替え、テキストを修正して再送信が可能です。
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/chat-previous-edits.mp4" title="Video that shows editing a previous chat request inline in the Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/chat-previous-edits.mp4" title="Chat ビューで過去のチャット要求をインライン編集するデモ。" autoplay loop controls muted></video>
 
-You can control the chat editing behavior with the `setting(chat.editRequests)` setting if you prefer editing via the toolbar hovers above each request.
+ツールバーのホバーからの編集を好む場合は、`setting(chat.editRequests)` で編集方法を制御できます。
 
-### Open chat as maximized {#open-chat-as-maximized}
+### 最大化でチャットを開く {#open-chat-as-maximized}
 
-**Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
+**設定**: `setting(workbench.secondarySideBar.defaultVisibility)`
 
-We added two extra options for configuring the default visibility of the Secondary Side Bar to open it as maximized:
+セカンダリサイドバーの既定の表示状態に、最大化して開く 2 つのオプションを追加しました。
 
-* `maximizedInWorkspace`: open the Chat view as maximized when opening a new workspace
-* `maximized`: open the Chat view always as maximized, including in empty windows
+* `maximizedInWorkspace`: 新しいワークスペースを開くときに Chat ビューを最大化で開く
+* `maximized`: 空ウィンドウも含め、常に Chat ビューを最大化で開く
 
-![Screenshot that shows the Chat view maximized.](https://code.visualstudio.com/assets/updates/1_103/max-chat.png)
+![最大化された Chat ビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/max-chat.png)
 
-### Pending chat confirmation {#pending-chat-confirmation}
+### チャット実行中の終了確認 {#pending-chat-confirmation}
 
-To help prevent accidentally closing a workspace where an agent session is actively changing files or responding to your request, we now show a dialog when you try to quit VS Code or close its window when a chat response is in progress:
+エージェントセッションがファイルを変更中または要求に応答中のワークスペースを誤って閉じてしまうのを防ぐため、チャットの応答が実行中に VS Code を終了またはウィンドウを閉じようとするとダイアログを表示します。
 
-![Screenshot of confirmation to exit with running chat.](https://code.visualstudio.com/assets/updates/1_103/confirm-chat-exit.png)
+![チャット実行中に終了を確認するダイアログのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/confirm-chat-exit.png)
 
-### OS notification on user action {#os-notification-on-user-action}
+### ユーザー操作の OS 通知 {#os-notification-on-user-action}
 
-**Setting**: `setting(chat.notifyWindowOnConfirmation)`
+**設定**: `setting(chat.notifyWindowOnConfirmation)`
 
-We now leverage the OS native notification system to show a toast when user confirmation is needed within a chat session. Enable this behavior with the `setting(chat.notifyWindowOnConfirmation)`.
+チャットセッション内でユーザーの確認が必要な場合、OS のネイティブ通知でトーストを表示するようになりました。`setting(chat.notifyWindowOnConfirmation)` で有効化できます。
 
-![Screenshot of toast for confirmation of a chat agent.](https://code.visualstudio.com/assets/updates/1_103/chat-toast.png)
+![チャットエージェントの確認トーストのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/chat-toast.png)
 
-We plan to improve this experience in the future to allow for displaying more information and for allowing you to approve directly from the toast. For now, selecting the toast focuses the window where the confirmation originated from.
+将来的には、より多くの情報表示やトーストから直接承認できるよう改善する予定です。現時点では、トーストを選択すると確認が発生したウィンドウにフォーカスします。
 
-### Math support in chat (Preview) {#math-support-in-chat-preview}
+### チャットの数式サポート (プレビュー) {#math-support-in-chat-preview}
 
-**Setting**: `setting(chat.math.enabled)`
+**設定**: `setting(chat.math.enabled)`
 
-Chats now have initial support for rendering mathematical equations in responses:
+チャットの応答で数式のレンダリングを初期対応しました。
 
-![Screenshot of the Chat view, showing inline and block equations in a chat response.](https://code.visualstudio.com/assets/updates/1_103/chat-math.png)
+![チャット応答でインライン/ブロック数式を表示するスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/chat-math.png)
 
-This feature is powered by [KaTeX](https://katex.org) and supports both inline and block math equations. Inline math equations can be written by wrapping the markup in single dollar signs (`$...$`), while block math equations use two dollar signs (`$$...$$`).
+この機能は [KaTeX](https://katex.org) で動作し、インライン/ブロックの両方の数式をサポートします。インライン数式は `$...$`、ブロック数式は `$$...$$` で囲みます。
 
-Math rendering can be enabled using `setting(chat.math.enabled)`. Currently, it is off by default but we plan to enable it in a future release, after further testing.
+数式レンダリングは `setting(chat.math.enabled)` で有効化できます。現在は既定で無効ですが、今後のテストを経て有効化する予定です。
 
-### Context7 integration for project scaffolding (Experimental) {#context7-integration-for-project-scaffolding-experimental}
+### プロジェクトのスキャフォールディングへの Context7 統合 (実験的) {#context7-integration-for-project-scaffolding-experimental}
 
-**Setting**: `setting(github.copilot.chat.newWorkspace.useContext7)`
+**設定**: `setting(github.copilot.chat.newWorkspace.useContext7)`
 
-When you scaffold a new project with `#new` in chat, you can now make sure that it uses the latest documentation and APIs from **Context7**, if you have already installed the Context7 MCP server.
+チャットで `#new` によるプロジェクトのスキャフォールディングを行う際、Context7 MCP サーバーをインストール済みであれば、最新のドキュメントと API を **Context7** から利用できるようになりました。
 
 ## MCP {#mcp}
 
-### Server autostart and trust {#server-autostart-and-trust}
+### サーバーの自動起動と信頼 {#server-autostart-and-trust}
 
-**Setting**: `setting(chat.mcp.autostart:newAndOutdated)`
+**設定**: `setting(chat.mcp.autostart:newAndOutdated)`
 
-Previously, when you added or updated an MCP server configuration, VS Code would show a blue "refresh" icon in the Chat view, enabling you to manually refresh the list of tools. In the milestone, you can now configure the auto-start behavior for MCP servers, so you no longer have to manually restart the MCP server.
+これまでは MCP サーバー設定の追加や更新後、Chat ビューに青い「更新」アイコンが表示され、手動でツール一覧の更新が必要でした。今月は MCP サーバーの自動起動を設定できるようになり、手動再起動が不要になりました。
 
-Use the `setting(chat.mcp.autostart:newAndOutdated)` setting to control this behavior. You can also change this setting within the icon's tooltip and see which servers will be started:
+`setting(chat.mcp.autostart:newAndOutdated)` で挙動を制御できます。アイコンのツールチップからも設定変更でき、起動対象のサーバーを確認できます。
 
-![Screenshot showing the hover of the refresh MCP server icon, enabling you to configure the auto-start behavior.](https://code.visualstudio.com/assets/updates/1_103/mcp-refresh-tip.png)
+![自動起動の設定を行える更新アイコンのホバーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/mcp-refresh-tip.png)
 
-The first time an MCP server is started after being updated or changed, we now show a dialog asking you to trust the server. Giving trust to these servers is particularly important with autostart turned on to prevent running undesirable commands unknowingly.
+サーバーの更新や変更後、最初の起動時にサーバーの信頼を求めるダイアログを表示します。特に自動起動を有効にしている場合、望ましくないコマンドの実行を避けるためにも信頼の付与は重要です。
 
-Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) in our documentation.
+VS Code での MCP サーバーの使い方は [ドキュメント](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) を参照してください。
 
-### Client credentials flow for remote MCP servers {#client-credentials-flow-for-remote-mcp-servers}
+### リモート MCP サーバー向けクライアント資格情報フロー {#client-credentials-flow-for-remote-mcp-servers}
 
-The ideal flow for a remote MCP server that wants to support authentication is to use an auth provider that supports Dynamic Client Registration (DCR). This enables the client (VS Code) to register itself with that auth provider, so the auth flow is seamless.
+リモート MCP サーバーが認証をサポートする理想的な方法は、Dynamic Client Registration (DCR) に対応した認証プロバイダーを使うことです。これによりクライアント (VS Code) がプロバイダーに自身を登録し、シームレスな認証フローが可能になります。
 
-However, not every auth provider supports DCR, so we introduced a client-credentials flow that enables you to supply your own client ID and (optionally) client secret that will be used when taking you through the auth provider's auth flow. Here's what that looks like:
+ただし、すべての認証プロバイダーが DCR に対応しているわけではありません。そこで、クライアント ID と (任意で) クライアントシークレットを指定して認証フローを進められるクライアント資格情報フローを導入しました。流れは次のとおりです。
 
-* Step 1: VS Code detects that DCR can't be used, and asks if you want to do the client credentials flow:
+* 手順 1: VS Code が DCR を使用できないことを検出し、クライアント資格情報フローを実行するかを確認します。
 
-    ![Screenshot of a modal dialog saying that DCR is not supported but you can provide client credentials manually.](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr1.png)
+    ![DCR はサポートされないが手動でクライアント資格情報を提供できることを示すモーダルのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr1.png)
 
-    > **IMPORTANT**: At this point, you would go to the auth provider's website and manually create an application registration. There you will put in the redirect URIs mentioned in the modal dialog.
+    > **重要**: この時点で、認証プロバイダーのサイトにアクセスし、アプリケーション登録を手動で作成します。モーダルに記載のリダイレクト URI を登録します。
 
-* Step 2: From the auth provider's portal, you will get a client ID and maybe a client secret. You'll put the client ID in the input box that appears and hit `kbstyle(Enter)`:
+* 手順 2: 認証プロバイダーのポータルからクライアント ID (と必要に応じてクライアントシークレット) を取得します。入力ボックスにクライアント ID を入力して `kbstyle(Enter)` を押下します。
 
-    ![Screenshot of an input box to provide the client ID for the MCP server.](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr2.png)
+    ![MCP サーバーのクライアント ID の入力ボックス。](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr2.png)
 
-* Step 3: Then you'll put in the client secret if you have one, and hit `kbstyle(Enter)` (leave blank if you don't have one)
+* 手順 3: クライアントシークレットがある場合は続けて入力し、`kbstyle(Enter)` を押下します (ない場合は空のまま)。
 
-    ![Screenshot of an input box to provide the optional client secret for the MCP server.](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr3.png)
+    ![MCP サーバーの任意のクライアントシークレットの入力ボックス。](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr3.png)
 
-    At that point, you'll be taken through the typical auth flow to authenticate the MCP server you're working with.
+    その後、通常の認証フローに遷移し、使用中の MCP サーバーを認証します。
 
-### Remove dynamic auth provider from Account menu {#remove-dynamic-auth-provider-from-account-menu}
+### アカウントメニューの動的認証プロバイダー削除 {#remove-dynamic-auth-provider-from-account-menu}
 
-Since the addition of remote MCP authentication, there has been a command available in the Command Palette called **Authentication: Remove Dynamic Authentication Providers**, which enables you to remove client credentials (client ID and, if available, a client secret) and all account information associated with that provider.
+リモート MCP 認証の追加以降、コマンドパレットには **Authentication: Remove Dynamic Authentication Providers** コマンドがあり、クライアント資格情報 (クライアント ID と必要に応じてクライアントシークレット) と、そのプロバイダーに関連付けられたアカウント情報を削除できます。
 
-We've now exposed this command in the Account menu. You can find it inside of an MCP server account:
+このコマンドをアカウントメニューにも表示しました。MCP サーバーアカウント内にあります。
 
-![Screenshot of the Account menu showing the manage dynamic auth option in an account's submenu.](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth1.png)
+![アカウントメニュー内の MCP サーバーアカウントに表示される管理オプションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth1.png)
 
-or at the root of the menu if you don't have any MCP server accounts yet:
+MCP サーバーアカウントがまだない場合は、メニューのルートに表示されます。
 
-![Screenshot of the Account menu showing the manage dynamic auth option in the root of account menu.](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth2.png)
+![アカウントメニュールートに表示される管理オプションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth2.png)
 
-### Support for `resource_link` and structured output {#support-for-resourcelink-and-structured-output}
+### `resource_link` と構造化出力のサポート {#support-for-resourcelink-and-structured-output}
 
-VS Code now fully supports the latest MCP specification, version `2025-06-18`, with support for `resource_link`s and structured output in tool results.
+VS Code は最新の MCP 仕様 `2025-06-18` を完全サポートし、ツール結果の `resource_link` と構造化出力に対応しました。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Accessible chat elicitations {#accessible-chat-elicitations}
+### チャットの促しをアクセシブルに {#accessible-chat-elicitations}
 
-When the agent prompts for user input, such as whether to keep waiting for a process, the chat elicitation is now accessible to screen readers. You are alerted when the prompt appears, can navigate to it with the keyboard, and can review the message in the accessible view.
+エージェントがユーザー入力を促す (プロセスの待機継続など) 際、プロンプトがスクリーンリーダーで利用できるようになりました。プロンプトの出現を通知し、キーボードで移動でき、アクセシブルビューでメッセージを確認できます。
 
-### Control file opening for chat edits {#control-file-opening-for-chat-edits}
+### チャット編集時にファイルを開く挙動を制御 {#control-file-opening-for-chat-edits}
 
-A new setting, `setting(accessibility.openChatEditedFiles)`, lets you choose whether files are automatically opened as the agent edits them in chat. Enable this setting for more control over which files appear in your editor.
+新しい設定 `setting(accessibility.openChatEditedFiles)` により、エージェントがチャットでファイルを編集する際に自動でエディターへ開くかを選択できるようになりました。どのファイルをエディターに表示するかをより細かく制御できます。
 
-### View all and previous edits commands {#view-all-and-previous-edits-commands}
+### 全編集/前回編集の表示コマンド {#view-all-and-previous-edits-commands}
 
-The **View All Edits** and **View Previous Edits** commands are now available throughout the editor, making it easy to review changes made by the agent. These commands are especially helpful when `setting(accessibility.openChatEditedFiles)` is disabled, allowing you to track edits without opening each file.
+エディター全体で **View All Edits** と **View Previous Edits** コマンドが利用可能になりました。エージェントによる変更を簡単に確認できます。`setting(accessibility.openChatEditedFiles)` を無効にしている場合にも、各ファイルを開かずに編集を追跡するのに役立ちます。
 
-### Side Bar visibility announcements {#side-bar-visibility-announcements}
+### サイドバーの可視性アナウンス {#side-bar-visibility-announcements}
 
-When the Primary or Secondary Side Bar is shown or hidden, an ARIA announcement now notifies you of this change. This improves accessibility by ensuring screen reader users are aware of Side Bar visibility updates.
+プライマリ/セカンダリサイドバーの表示/非表示が変更された際、ARIA のアナウンスで通知するようになりました。これにより、スクリーンリーダー利用者もサイドバーの可視性の変化を把握できます。
 
-### Accessibility testing with Playwright {#accessibility-testing-with-playwright}
+### Playwright によるアクセシビリティテスト {#accessibility-testing-with-playwright}
 
-We have added automated accessibility tests for the editor using Playwright. These tests help us continuously validate that Visual Studio Code meets accessibility standards and best practices, ensuring a better experience for all users.
+エディターの自動アクセシビリティテストを Playwright で追加しました。Visual Studio Code がアクセシビリティ標準とベストプラクティスに継続的に準拠していることを検証し、すべてのユーザーにより良い体験を提供します。
 
-## Editor Experience {#editor-experience}
+## エディター体験 {#editor-experience}
 
-### Settings search suggestions {#settings-search-suggestions}
+### 設定検索のサジェスト {#settings-search-suggestions}
 
-The AI search results toggle in the search box of the Settings editor, indicated by a sparkle, is now available for all users. The toggle is enabled when AI search results have loaded and are available. Pressing the toggle switches between the AI and non-AI search results.
+設定エディターの検索ボックスのスパークルで示される AI 検索結果のトグルを、すべてのユーザーに展開しました。AI 検索の結果が読み込まれ利用可能になるとトグルが有効になります。トグルを押すと AI / 非 AI の検索結果を切り替えます。
 
-The AI settings search results are based on semantic similarity instead of string matching. For example, `editor.fontSize` appears as an AI settings search result when you search for "increase text size".
+AI 設定検索結果は文字列の一致ではなく、意味的な類似性に基づきます。たとえば「文字サイズを大きくする」と検索すると、`editor.fontSize` が AI 設定検索結果に表示されます。
 
-![Screenshot of AI results in the Settings editor for "increase text size" showing editor.fontSize setting.](https://code.visualstudio.com/assets/updates/1_103/settings-editor-toggle.png)
+![「increase text size」で editor.fontSize を示す設定エディターの AI 結果のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/settings-editor-toggle.png)
 
-### Editor tab context menu {#editor-tab-context-menu}
+### エディタータブのコンテキストメニュー {#editor-tab-context-menu}
 
-We cleaned up the editor tab context menu to group related options for splitting and moving into a submenu:
+エディタータブのコンテキストメニューを整理し、分割と移動に関連するオプションをサブメニューにまとめました。
 
-![Screenshot that shows the 'Split and Move' editor tab context menu.](https://code.visualstudio.com/assets/updates/1_103/editor-menu.png)
+![“Split and Move” サブメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/editor-menu.png)
 
-### AI statistics (Preview) {#ai-statistics-preview}
+### AI 統計 (プレビュー) {#ai-statistics-preview}
 
-**Setting**: `setting(editor.aiStats.enabled:true)`
+**設定**: `setting(editor.aiStats.enabled:true)`
 
-We added an experimental feature for displaying basic AI statistics. Use the `setting(editor.aiStats.enabled:true)` to enable this feature, which is disabled by default.
+基本的な AI 統計を表示する実験的機能を追加しました。既定では無効で、`setting(editor.aiStats.enabled:true)` で有効化できます。
 
-This feature shows you, per project, the percentage of characters that was inserted by AI versus inserted by typing. It also keeps track of how many inline and next edit suggestions you accepted during the current day.
+プロジェクトごとに、AI によって挿入された文字の割合と手入力の割合を表示します。加えて、その日の間に受け入れたインライン/次の編集候補の数も追跡します。
 
-![Screenshot showing the AI statistic hover information in the Status Bar.](https://code.visualstudio.com/assets/updates/1_103/ai-stats.png)
+![ステータスバーの AI 統計ホバー情報のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/ai-stats.png)
 
-## Notebooks {#notebooks}
+## ノートブック {#notebooks}
 
-### Notebook inline chat with agent tools {#notebook-inline-chat-with-agent-tools}
+### ノートブックのインラインチャットにエージェントツール {#notebook-inline-chat-with-agent-tools}
 
-**Setting**: `setting(inlineChat.notebookAgent:true)`
+**設定**: `setting(inlineChat.notebookAgent:true)`
 
-The notebook inline chat control can now use the full suite of notebook agent tools to enable additional capabilities like running cells and installing packages into the kernel.
+ノートブックのインラインチャットコントロールが、セルの実行やカーネルへのパッケージインストールなどの追加機能を可能にする、ノートブックエージェントツール一式を利用できるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/notebook-inline-agent.mp4" title="Video showing a coding agent session opening in a chat session editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/notebook-inline-agent.mp4" title="チャットセッションエディターでのコーディングエージェントセッションのデモ。" autoplay loop controls muted></video>
 
-To enable agent tools in notebooks, enable the new experimental setting `setting(inlineChat.notebookAgent:true)`. This also currently requires enabling the setting for inline chat v2 `setting(inlineChat.enableV2:true)`.
+ノートブックでエージェントツールを有効にするには、新しい実験的設定 `setting(inlineChat.notebookAgent:true)` を有効にします。現在はインラインチャット v2 の設定 `setting(inlineChat.enableV2:true)` も有効にする必要があります。
 
-### Install dependencies in Virtual Environments created with uv {#install-dependencies-in-virtual-environments-created-with-uv}
+### uv で作成した仮想環境に依存関係をインストール {#install-dependencies-in-virtual-environments-created-with-uv}
 
-We now support installing required dependencies when you run Jupyter Notebooks against a Virtual Environment created using [uv](https://docs.astral.sh/uv/pip/environments/).
+[uv](https://docs.astral.sh/uv/pip/environments/) で作成した仮想環境で Jupyter Notebook を実行する際に、必要な依存関係のインストールをサポートしました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/uv-install-ipykernel.mp4" title="Video that shows installing IPyKernel in uv Virtual Environment." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/uv-install-ipykernel.mp4" title="uv 仮想環境に IPyKernel をインストールするデモ。" autoplay loop controls muted></video>
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Git worktree support {#git-worktree-support}
+### Git worktree サポート {#git-worktree-support}
 
-**Setting**: `setting(git.detectWorktrees)`
+**設定**: `setting(git.detectWorktrees)`
 
-To address a long-standing [feature request](https://github.com/microsoft/vscode/issues/68038), this milestone we have added Git worktree support. Worktrees let you check out multiple branches at once, making it easy to test changes or work in parallel without switching contexts.
+長年の [要望](https://github.com/microsoft/vscode/issues/68038) に応え、Git worktree をサポートしました。Worktree により、複数のブランチを同時にチェックアウトでき、コンテキストを切り替えずに変更のテストや並行作業が容易になります。
 
-When opening a folder or workspace that contains a git repository, we now automatically detect worktrees and display them in the Source Control Repositories view. You can now view, create, delete, and open worktrees in a new or current window by using commands available from the Command Palette or Source Control Repositories view. You can disable this functionality by toggling the `setting(git.detectWorktrees)` setting.
+Git リポジトリを含むフォルダーやワークスペースを開くと、worktree を自動検出し、ソース管理のリポジトリビューに表示します。コマンドパレットやリポジトリビューから、worktree の表示・作成・削除・新規/現在のウィンドウでのオープンが可能です。`setting(git.detectWorktrees)` の切り替えで無効化できます。
 
-![Screenshot of create worktree command in Source Control view.](https://code.visualstudio.com/assets/updates/1_103/repository_worktree_submenu.png)
+![ソース管理ビューで worktree を作成するコマンドのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/repository_worktree_submenu.png)
 
-![Screenshot of open and delete worktree commands in the Source Control view.](https://code.visualstudio.com/assets/updates/1_103/worktree_specific_submenu.png)
+![ソース管理ビューで worktree を開く/削除するコマンドのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/worktree_specific_submenu.png)
 
-### Repositories view {#repositories-view}
+### リポジトリビュー {#repositories-view}
 
-The Source Control Repositories view displays all source control providers that were discovered in the current folder/workspace. This milestone, we have updated the rendering of the view in order to visually distinguish between repositories, submodules, and worktrees. We also show the parent-child relationship between repositories, submodules and worktrees.
+ソース管理のリポジトリビューには、現在のフォルダー/ワークスペースで検出されたすべてのソース管理プロバイダーが表示されます。今月は、リポジトリ・サブモジュール・worktree を視覚的に区別できるようレンダリングを更新し、親子関係も表示するようにしました。
 
-![Screenshot of the Source Control Repositories view showing two repositories and a worktree associated with one of the repos.](https://code.visualstudio.com/assets/updates/1_103/repositories-view.png)
+![2 つのリポジトリと、そのうち 1 つに関連する worktree を示すリポジトリビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/repositories-view.png)
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Documentation support in terminal suggest {#documentation-support-in-terminal-suggest}
+### ターミナルのサジェストでドキュメントを表示 {#documentation-support-in-terminal-suggest}
 
-Terminal suggestions powered by language servers (LSP) now include inline documentation, similar to what you see in the editor. Starting with the Python REPL, you'll get helpful descriptions and usage details for commands as you type.
+言語サーバー (LSP) によるターミナルのサジェストに、エディター同様のインラインドキュメントが表示されるようになりました。まずは Python REPL から、入力中のコマンドに関する説明や使用例が得られます。
 
-You currently need these settings to enable LSP suggestions in the terminal:
+ターミナルで LSP のサジェストを有効にするには、次の設定が必要です。
 
 * `setting(python.terminal.shellIntegration.enabled:true)`
 * `setting(python.analysis.supportAllPythonDocuments:true)`
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/lsp_documentation.mp4" title="Video showing terminal suggest completions items with LSP now show code docs." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/lsp_documentation.mp4" title="ターミナルのサジェストに LSP のドキュメントが表示されるデモ。" autoplay loop controls muted></video>
 
-### Voice dictation {#voice-dictation}
+### 音声ディクテーション {#voice-dictation}
 
-Now that natural language input is supported in terminals, including those enabled by the Gemini and Claude extensions, we have reintroduced voice dictation in the terminal. You can start or stop dictation by using the **Terminal: Start Dictation in Terminal** and **Terminal: Stop Dictation in Terminal** commands.
+ターミナルで自然言語入力がサポートされたこと (Gemini や Claude の拡張を含む) を受け、ターミナルでの音声ディクテーションを再導入しました。**Terminal: Start Dictation in Terminal** / **Terminal: Stop Dictation in Terminal** コマンドで開始/停止できます。
 
-### Improved shell integration diagnostics {#improved-shell-integration-diagnostics}
+### シェル統合の診断を改善 {#improved-shell-integration-diagnostics}
 
-[Shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) is the foundation that many features in the integrated terminal are built upon such as [sticky scroll](https://code.visualstudio.com/docs/terminal/shell-integration#_sticky-scroll), [quick fixes](https://code.visualstudio.com/docs/terminal/shell-integration#_quick-fixes) and [agent mode's](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) ability to understand what's happening inside the terminal.
+[シェル統合](https://code.visualstudio.com/docs/terminal/shell-integration) は、統合ターミナルの多くの機能 (例: [スティッキースクロール](https://code.visualstudio.com/docs/terminal/shell-integration#_sticky-scroll)、[クイック修正](https://code.visualstudio.com/docs/terminal/shell-integration#_quick-fixes)、[エージェントモード](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) によるターミナル内部の把握) の基盤です。
 
-This release features some improved diagnostics when you hover the terminal and select **Show Details**. You should now see the detected shell type and current working directory:
+今リリースでは、ターミナルをホバーして **Show Details** を選択したときの診断が改善されました。検出したシェルの種類と現在の作業ディレクトリが表示されます。
 
-![Screenshot of the detailed terminal tab hover showing the shell type like pwsh and the current working directory.](https://code.visualstudio.com/assets/updates/1_103/terminal-si-diagnostics.png)
+![pwsh などのシェル種別と現在の作業ディレクトリを示す詳細ホバーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/terminal-si-diagnostics.png)
 
-This is one of the first places to look if one of these rich features isn't working as expected.
+これらのリッチ機能が期待通りに動作しない場合、最初に確認する場所の 1 つです。
 
-## Languages {#languages}
+## 言語 {#languages}
 
 ### Python {#python}
 
-#### Shell integration support for Python 3.13 and above {#shell-integration-support-for-python-3-13-and-above}
+#### Python 3.13 以降のシェル統合サポート {#shell-integration-support-for-python-3-13-and-above}
 
-We now support shell integration for Python when using version 3.13 or later. When enabled, PyREPL is automatically disabled to ensure compatibility. You can disable shell integration if you prefer to continue using PyREPL.
+Python 3.13 以降でシェル統合をサポートしました。有効化すると互換性のため PyREPL は自動的に無効化されます。PyREPL を使い続けたい場合はシェル統合を無効にできます。
 
-![Screenshot showing the Python shell integration setting in the Settings editor.](https://code.visualstudio.com/assets/updates/1_103/python_shellIntegration.png)
+![設定エディターでの Python シェル統合設定のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/python_shellIntegration.png)
 
-#### Python Environments extension improvements {#python-environments-extension-improvements}
+#### Python Environments 拡張の改善 {#python-environments-extension-improvements}
 
-The [Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) continued to receive bug fixes and improvements as part of the controlled roll-out to stable users. To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code `settings.json` file: `"python.useEnvironmentsExtension": true`.
+[Python Environments 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) は、安定版ユーザーへの段階的ロールアウトの一環として、バグ修正と改善を継続しています。ロールアウト期間中にこの拡張を利用するには、拡張をインストールし、VS Code の `settings.json` に `"python.useEnvironmentsExtension": true` を追加してください。
 
 ### TypeScript 5.9 {#typescript-59}
 
-VS Code now includes TypeScript 5.9.2. This major update brings a few new language improvements, including [support for import defer](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer), along with tooling improvements such as [improved docs for many DOM apis](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer).
+VS Code には TypeScript 5.9.2 が同梱されます。このメジャーアップデートには、[import defer のサポート](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer) などの言語改善に加え、[多くの DOM API のドキュメント改善](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer) などのツール改善が含まれます。
 
-Check out the [TypeScript 5.9 release blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/) for more details on this update.
+詳細は [TypeScript 5.9 のリリースブログ](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/) をご覧ください。
 
-### Expandable hovers for JavaScript and TypeScript {#expandable-hovers-for-javascript-and-typescript}
+### JavaScript / TypeScript の展開可能なホバー {#expandable-hovers-for-javascript-and-typescript}
 
-When you hover over a symbol in JavaScript or TypeScript, VS Code tries to show the most useful IntelliSense type information about that symbol. Types can be very complex, so one challenge for us has been trying to find the right balance between showing enough details to be useful, while not showing so much info that it becomes overwhelming. It's hard to come up with a good one size fits all approach, and also the level of type detail you want might change depending on what you are working on.
+JavaScript / TypeScript のシンボルにホバーすると、VS Code はそのシンボルの最も有用な IntelliSense の型情報を表示しようとします。型は非常に複雑になり得るため、有用な詳細を十分に示しつつ情報過多にならないバランスは難題でした。用途によって求める詳細度も変わります。
 
-That's why this iteration, we've added new UI that gives you more control over how types are shown in hovers. When you hover over a symbol, now you can select the little `+` icon on the left side of the hover control to expand the interfaces and complex types in the hover into their components. For example, you can use this to see the properties of an interface directly in the hover:
+そこで今イテレーションでは、ホバーの表示をより細かく制御できる新しい UI を追加しました。ホバー時に左側の小さな `+` アイコンを選ぶと、インターフェイスや複合型を構成要素へ展開できます。例えばインターフェイスのプロパティをホバー内で直接確認できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_103/ts-expandable-hovers.mp4" title="Video showing expanding interface types." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_103/ts-expandable-hovers.mp4" title="インターフェイス型の展開デモ。" autoplay loop controls muted></video>
 
-Hovers can be expanded multiple times, which recursively expands types from the previous expansion. If you ever expand too much, just select the `-` icon to go back to the previous level. Also keep in mind that not every type is expandable and that we still need some limits on just how much expansion we can support. [Let us know](https://github.com/microsoft/vscode/issues/new?template=bug_report.md) if there are any cases where expandable hovers aren't working how you'd like.
+ホバーは複数回展開でき、前回の展開から再帰的に型を展開します。展開しすぎた場合は `-` アイコンで 1 段階戻せます。すべての型が展開可能というわけではなく、展開の上限もあります。期待通りに動作しないケースがあれば [お知らせください](https://github.com/microsoft/vscode/issues/new?template=bug_report.md)。
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### GitHub Pull Requests {#github-pull-requests}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
+[GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張の進捗がさらにありました。プルリクエストや課題の作成・管理・作業が可能です。
 
-Review the [changelog for the 0.116.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01160) release of the extension to learn about everything in the release.
+拡張のリリースに含まれる変更点は、[0.116.0 の変更ログ](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01160) を参照してください。
 
-#### Pull request header cleanup {#pull-request-header-cleanup}
+#### プルリクエストヘッダーの整理 {#pull-request-header-cleanup}
 
-We've simplified the button bar in the pull request description header. The copy actions are now in the right-click context menu of the PR link.
+プルリクエスト詳細のヘッダーにあるボタンバーを簡素化しました。コピー系の操作は、PR リンクの右クリックコンテキストメニューに移しました。
 
-![Screenshot of the simplified PR header when opening the PR details.](https://code.visualstudio.com/assets/updates/1_103/simplified-pr-header-buttons.png)
+![簡素化された PR ヘッダーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/simplified-pr-header-buttons.png)
 
-#### Show coding agent PRs in chat {#show-coding-agent-prs-in-chat}
+#### チャットにコーディングエージェントの PR を表示 {#show-coding-agent-prs-in-chat}
 
-**Setting**: `setting(githubPullRequests.codingAgent.uiIntegration)`
+**設定**: `setting(githubPullRequests.codingAgent.uiIntegration)`
 
-When you start a coding agent session (via `#copilotCodingAgent` or with the **Delegate to coding agent** action), the pull request is rendered as a card in the Chat view.
+`#copilotCodingAgent` や **Delegate to coding agent** アクションでコーディングエージェントセッションを開始すると、プルリクエストが Chat ビュー内のカードとして表示されます。
 
-![Screenshot of a coding agent PR card in the Chat view.](https://code.visualstudio.com/assets/updates/1_103/pr-card-in-chat.png)
+![Chat ビュー内のコーディングエージェント PR カードのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/pr-card-in-chat.png)
 
-Enable the `setting(githubPullRequests.codingAgent.uiIntegration)` setting to enable the new **Delegate to coding agent** button in the Chat view, for repositories that have the agent enabled.
+リポジトリがエージェントに対応している場合、Chat ビューに新しい **Delegate to coding agent** ボタンを表示するには、`setting(githubPullRequests.codingAgent.uiIntegration)` を有効にします。
 
-#### Chat sessions (Experimental) {#chat-sessions-experimental}
+#### チャットセッション (実験的) {#chat-sessions-experimental}
 
-##### Coding agent chats {#coding-agent-chats}
+##### コーディングエージェントのチャット {#coding-agent-chats}
 
-Building off [last iteration's Copilot coding agent integration](https://code.visualstudio.com/updates/v1_102#_github-pull-requests), you can now manage a coding agent session from a dedicated chat editor. This enables you to follow the progress of the coding agent, provide follow-up instructions, and see the agent's responses in a dedicated chat editor.
+[前イテレーションの Copilot コーディングエージェント統合](https://code.visualstudio.com/updates/v1_102#_github-pull-requests) を基に、専用のチャットエディターからコーディングエージェントセッションを管理できるようになりました。進捗の確認、追加入力の提供、応答の確認を 1 つのエディターで行えます。
 
-* Start a coding agent session from VS Code with the `#copilotCodingAgent` tool or via the [UI controls](https://code.visualstudio.com/updates/v1_102#_start-a-coding-agent-session-preview).
+* VS Code から `#copilotCodingAgent` ツールまたは [UI 操作](https://code.visualstudio.com/updates/v1_102#_start-a-coding-agent-session-preview) でコーディングエージェントセッションを開始。
 
-    <video src="https://code.visualstudio.com/assets/updates/1_103/coding-agent-start.mp4" title="Video showing a coding agent session opening in a chat session editor." autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_103/coding-agent-start.mp4" title="チャットセッションエディターでのコーディングエージェントセッションのデモ。" autoplay loop controls muted></video>
 
-* Follow the progress of coding agent in an attached chat editor.
+* 連携したチャットエディターでコーディングエージェントの進捗を追跡。
 
-    ![Screenshot showing Coding Agent progress.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-progress.png)
+    ![Coding Agent の進捗を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/coding-agent-progress.png)
 
-* Provide follow-up instructions directly from chat.
+* チャットから直接フォローアップを指示。
 
-    ![Screenshot showing providing a followup in chat to coding agent.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-follow-up.png)
+    ![チャットからフォローアップを指示するスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/coding-agent-follow-up.png)
 
-##### Chat sessions view {#chat-sessions-view}
+##### チャットセッションビュー {#chat-sessions-view}
 
-**Setting**: `setting(chat.agentSessionsViewLocation)`
+**設定**: `setting(chat.agentSessionsViewLocation)`
 
-Enable the `setting(chat.agentSessionsViewLocation)` setting to try this experimental feature.
+実験的機能を試すには `setting(chat.agentSessionsViewLocation)` を設定します。
 
-* When set to `view`, you will see a new **Chat Sessions** view is shown in the VS Code Side Bar. This view enables you to manage and interact with your local chat sessions, as well as the coding agent sessions.
+* `view` に設定すると、VS Code のサイドバーに新しい **Chat Sessions** ビューが表示されます。ローカルのチャットセッションやコーディングエージェントセッションを管理・操作できます。
 
-    ![Screenshot showing the Coding Agent Sessions view.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-sessions-view.png)
+    ![Coding Agent Sessions ビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/coding-agent-sessions-view.png)
 
-* When set to `showChatsMenu`, coding agent chat sessions are shown alongside the local chat history.
+* `showChatsMenu` に設定すると、ローカルのチャット履歴と並んでコーディングエージェントのチャットセッションが表示されます。
 
-    ![Screenshot showing the Coding Agent Sessions Quick Pick.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-sessions-quick-pick.png)
+    ![Coding Agent Sessions のクイックピックのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/coding-agent-sessions-quick-pick.png)
 
-This integration requires the latest GitHub Pull Request extension and a repository open that supports Copilot coding agent. For more information, see the new documentation on how to [use coding agent in VS Code](https://aka.ms/coding-agent-docs).
+この統合には最新の GitHub Pull Request 拡張と、Copilot コーディングエージェントに対応したリポジトリが必要です。詳細は [VS Code でコーディングエージェントを使う方法](https://aka.ms/coding-agent-docs) を参照してください。
 
-_Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
+_テーマ: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) ( [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized) でプレビュー)_
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能の作成 {#extension-authoring}
 
-### Terminal activation events {#terminal-activation-events}
+### ターミナルのアクティベーションイベント {#terminal-activation-events}
 
-Two new activation events are available for extensions:
+拡張機能向けに 2 つの新しいアクティベーションイベントを追加しました。
 
-* `onTerminal`: Triggered when any terminal is opened.
-* `onTerminalShellIntegration`: Triggered when rich shell integration is activated for a terminal.
+* `onTerminal`: いずれかのターミナルが開かれたときに発火します。
+* `onTerminalShellIntegration`: ターミナルでリッチなシェル統合が有効化されたときに発火します。
 
-You can specify a `shellType` to target specific shells. For example, `onTerminalShellIntegration:bash` activates when shell integration is enabled for a Bash terminal.
+特定のシェルを対象にするには `shellType` を指定できます。例えば、`onTerminalShellIntegration:bash` は Bash ターミナルでシェル統合が有効化されたときに発火します。
 
-## Proposed APIs {#proposed-apis}
+## 提案 API {#proposed-apis}
 
-### Render custom webviews in chat responses {#render-custom-webviews-in-chat-responses}
+### チャット応答にカスタム WebView をレンダリング {#render-custom-webviews-in-chat-responses}
 
-The Chat Output Renderer API lets extensions take chat responses beyond text and images. With it, your extension can use a [webview](https://code.visualstudio.com/api/extension-capabilities/extending-workbench) to render arbitrary HTML content in the chat output. Example use cases include custom visualizations, inline previews, and even interactive controls.
+Chat Output Renderer API により、拡張機能はチャット応答をテキストや画像の範囲を超えて拡張できます。[webview](https://code.visualstudio.com/api/extension-capabilities/extending-workbench) を使って、チャット出力に任意の HTML を描画できます。例として、カスタム可視化・インラインプレビュー・インタラクティブなコントロールなどが挙げられます。
 
-The [Chat Output Renderer extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-output-renderer-sample) shows how this API can be used to render [Mermaid diagrams](http://mermaid.js.org) in chat responses. Here's an example of this extension sample in action:
+[Chat Output Renderer の拡張サンプル](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-output-renderer-sample) では、この API を使ってチャット応答に [Mermaid 図](http://mermaid.js.org) を描画する方法を示しています。以下はサンプルの実行例です。
 
-![Screenshot showing a mermaid diagram in a chat response.](https://code.visualstudio.com/assets/updates/1_103/chat-output-1.png)
+![チャット応答に表示された Mermaid 図のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/chat-output-1.png)
 
-The neat thing is not that VS Code can render Mermaid diagrams, but that this rendering can be contributed entirely by extensions. With it, you can iterate on the custom outputs in chat:
+重要なのは VS Code が Mermaid 図をレンダリングできることではなく、このレンダリングが拡張機能だけで提供できる点です。これにより、チャット内のカスタム出力を反復的に改善できます。
 
-![Screenshot asking chat to generate a modified version of the first diagram.](https://code.visualstudio.com/assets/updates/1_103/chat-output-2.png)
+![最初の図の変更版を生成するようチャットへ依頼するスクリーンショット。](https://code.visualstudio.com/assets/updates/1_103/chat-output-2.png)
 
-Here's a quick run down of how the API works:
+API の仕組みは次のとおりです。
 
-1. Register a language model tool that can return custom data as part of its response. We use a mime type to identify this data.
-1. Register a chat output renderer for this mime type.
-1. When a language model calls the tool, invoke the chat output renderer to render it into a webview in the response.
+1. レスポンスの一部としてカスタムデータを返せる言語モデルツールを登録します。データの識別には MIME タイプを使います。
+1. その MIME タイプ用のチャット出力レンダラーを登録します。
+1. 言語モデルがツールを呼び出したら、チャット出力レンダラーで WebView に描画します。
 
-Check out the [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-output-renderer-sample) for a full end-to-end example of this API in action.
+API の一連の流れは、[拡張サンプル](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-output-renderer-sample) を参照してください。
 
-This API has the potential to be very powerful and enable some amazing new chat experiences, so give it a try and let us know what you think!
+この API は非常に強力で、新しいチャット体験を実現できる可能性があります。ぜひ試してフィードバックをお寄せください。
 
-### Chat Session Provider API {#chat-session-provider-api}
+### チャットセッションプロバイダー API {#chat-session-provider-api}
 
-The new Chat Session Provider API proposal enables extensions to integrate their own chat backend into VS Code's native chat UI. Using it, your extension can open a new chat session, populate the history for that session, and respond to new user prompts.
+新しい Chat Session Provider API の提案により、拡張機能は VS Code のネイティブチャット UI に自身のチャットバックエンドを統合できます。これを使うと、新しいチャットセッションを開き、その履歴を投入し、新しいユーザー入力に応答できます。
 
-This API is still in early stages and is likely to change. However we're already using it to power the new [GitHub coding agent session flow](#chat-sessions-experimental), which loads chats from GitHub and allows you to chat with an agent that is controlled entirely by GitHub.
+この API はまだ初期段階で変更の可能性があります。ただし、すでに新しい [GitHub コーディングエージェントセッションフロー](#chat-sessions-experimental) を駆動しており、GitHub からチャットを読み込み、GitHub が完全に制御するエージェントと会話できます。
 
-### Task execution terminal {#task-execution-terminal}
+### タスク実行ターミナル {#task-execution-terminal}
 
-Extension authors can now access the terminal associated with a running task via the new `taskExecution.terminal` property. This makes it easier to identify which terminal is linked to a specific task and interact with it programmatically.
+拡張機能の作者は、実行中のタスクに関連付けられたターミナルへ `taskExecution.terminal` プロパティでアクセスできるようになりました。これにより、特定のタスクに紐づくターミナルの特定や、プログラムからの操作が容易になります。
 
 ### SecretStorage `keys()` API {#secretstorage-keys-api}
 
-If you have ever wanted to get the list of keys that your extension has stored in `SecretStorage`, you can now do so with the new proposed `keys()` API:
+`SecretStorage` に拡張機能が保存したキーの一覧を取得したい場合、新しい提案 API `keys()` で取得できます。
 
 ```ts
 export async function activate(context: ExtensionContext) {
@@ -576,169 +576,165 @@ export async function activate(context: ExtensionContext) {
 }
 ```
 
-> **NOTE**: This change is dependent on a change to anything that provides an alternative implementation of a Secret Storage, notably <https://vscode.dev>, which has adopted the new API, and <https://github.dev>, which will adopt the new API soon. In an environment where it is not supported, this API will throw an exception.
+> **注意**: この変更は Secret Storage の代替実装を提供するプラットフォームの変更に依存します。特に <https://vscode.dev> は新 API を採用済みで、<https://github.dev> も間もなく採用予定です。未対応の環境では、この API は例外をスローします。
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### packages.microsoft.com key update {#packages-microsoft-com-key-update}
+### packages.microsoft.com のキー更新 {#packages-microsoft-com-key-update}
 
-`packages.microsoft.com` has updated their signing key and as a result, Linux users on newer distributions should stop seeing key-related warnings or errors while installing VS Code. Debian-based distributions automatically receive the new key, whereas users on other distributions may have to manually remove the old key before [importing the new key](https://code.visualstudio.com/docs/setup/linux#_install-vs-code-on-linux).
+`packages.microsoft.com` の署名キーを更新しました。これにより、新しいディストリビューションの Linux ユーザーは VS Code のインストール時にキー関連の警告やエラーが表示されなくなるはずです。Debian 系ディストリビューションは自動で新しいキーを受け取りますが、その他のディストリビューションでは旧キーの削除と [新キーの取り込み](https://code.visualstudio.com/docs/setup/linux#_install-vs-code-on-linux) が必要な場合があります。
 
-### Electron 37 update {#electron-37-update}
+### Electron 37 への更新 {#electron-37-update}
 
-In this milestone, we are promoting the Electron 37 update to users on our Stable release. This update comes with Chromium 138.0.7204.100 and Node.js 22.17.0. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+今月は Electron 37 の更新を Stable リリースのユーザーへ昇格展開します。この更新には Chromium 138.0.7204.100 と Node.js 22.17.0 が含まれます。Insiders ビルドでセルフホストし、早期のフィードバックを提供してくださった皆さまに感謝します。
 
-## Notable fixes {#notable-fixes}
+## 注目すべき修正 {#notable-fixes}
 
-* [vscode#252384](https://github.com/microsoft/vscode/issues/252384) - Agent Mode pauses when VS Code loses focus
+* [vscode#252384](https://github.com/microsoft/vscode/issues/252384) - VS Code のフォーカスが外れると Agent Mode が一時停止する
 
-## Thank you {#thank-you}
+## 謝辞 {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code のコントリビューターの皆さまに心より _**感謝**_ いたします。
 
-### Issue tracking {#issue-tracking}
+### 課題トラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+課題トラッキングへの貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull Requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@adityavc (Aditya Chittari)](https://github.com/adityavc): #134898 - trimming whitespace when deleting new line character [PR #210870](https://github.com/microsoft/vscode/pull/210870)
-* [@adrianstephens](https://github.com/adrianstephens): Add debug/watch/context to list of valid menu extension points [PR #237751](https://github.com/microsoft/vscode/pull/237751)
-* [@andy0130tw (Andy Pan)](https://github.com/andy0130tw): Support the locale argument of TypeScript language server on the web version (#256252) [PR #256256](https://github.com/microsoft/vscode/pull/256256)
-* [@Benimautner](https://github.com/Benimautner): Add inertial scrolling to scrollable elements [PR #244034](https://github.com/microsoft/vscode/pull/244034)
-* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): fix: cannot display MAKR Underlined in minimap [PR #226116](https://github.com/microsoft/vscode/pull/226116)
-* [@bytemain (Jiacheng)](https://github.com/bytemain): refactor(terminal): introduce ITerminalLaunchResult interface [PR #256284](https://github.com/microsoft/vscode/pull/256284)
-* [@c-claeys (Cristopher Claeys)](https://github.com/c-claeys): Make ServicesAccessor typing more consistent in editor commands [PR #218369](https://github.com/microsoft/vscode/pull/218369)
-* [@CookieeQuinn (Quinn)](https://github.com/CookieeQuinn): Fix issue #212484: caretRangeFromPoint was not working when invoked over text which used user-select: none. [PR #219819](https://github.com/microsoft/vscode/pull/219819)
-* [@CrazySteve0605 (Wang Chong)](https://github.com/CrazySteve0605): fix(gettingStarted): remove duplicated "can be" in hover description [PR #254412](https://github.com/microsoft/vscode/pull/254412)
-* [@dbreen (Dan Breen)](https://github.com/dbreen): Use a saner default scrollbar width for the Explorer [PR #199784](https://github.com/microsoft/vscode/pull/199784)
-* [@devlinjunker](https://github.com/devlinjunker): Expose undo/redo and canUndo/canRedo methods on model API [PR #213954](https://github.com/microsoft/vscode/pull/213954)
-* [@dibarbet (David Barbet)](https://github.com/dibarbet): Enable angle bracket colorization for C# [PR #247665](https://github.com/microsoft/vscode/pull/247665)
-* [@duncpro (Duncan)](https://github.com/duncpro): Vertical pipe characters should terminate URLs [PR #232460](https://github.com/microsoft/vscode/pull/232460)
-* [@dylanchu](https://github.com/dylanchu): TerminalTaskSystem: Fix addtion arguments for string command [PR #251201](https://github.com/microsoft/vscode/pull/251201)
-* [@estrizhok (Eugene Strizhok)](https://github.com/estrizhok): Correct capitalization of 'JetBrains' and 'ReSharper' in settings UI [PR #254472](https://github.com/microsoft/vscode/pull/254472)
-* [@firelizzard18 (Ethan Reesor)](https://github.com/firelizzard18): Context key `availableEditorIds` for diff editors [PR #250198](https://github.com/microsoft/vscode/pull/250198)
-* [@futurist (James Yang)](https://github.com/futurist): fix(terminal): getBufferReverseIterator bug after scrollback limit reached [PR #257311](https://github.com/microsoft/vscode/pull/257311)
-* [@g0t4 (Wes Higbee)](https://github.com/g0t4): Add editor option to allow selection highlighting of multiline selections and another option to control max length [PR #228982](https://github.com/microsoft/vscode/pull/228982)
-* [@gabrielcsapo (Gabriel Csapo)](https://github.com/gabrielcsapo): feat: adds (requestTime) logLevel to match tsserver options [PR #250778](https://github.com/microsoft/vscode/pull/250778)
+* [@adityavc (Aditya Chittari)](https://github.com/adityavc): #134898 - 改行削除時の空白トリミング [PR #210870](https://github.com/microsoft/vscode/pull/210870)
+* [@adrianstephens](https://github.com/adrianstephens): 有効なメニュー拡張ポイントに debug/watch/context を追加 [PR #237751](https://github.com/microsoft/vscode/pull/237751)
+* [@andy0130tw (Andy Pan)](https://github.com/andy0130tw): Web 版の TypeScript Language Server の locale 引数をサポート (#256252) [PR #256256](https://github.com/microsoft/vscode/pull/256256)
+* [@Benimautner](https://github.com/Benimautner): スクロール可能要素に慣性スクロールを追加 [PR #244034](https://github.com/microsoft/vscode/pull/244034)
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): 修正: ミニマップで MAKR Underlined を表示できない [PR #226116](https://github.com/microsoft/vscode/pull/226116)
+* [@bytemain (Jiacheng)](https://github.com/bytemain): リファクタ(terminal): ITerminalLaunchResult インターフェイスの導入 [PR #256284](https://github.com/microsoft/vscode/pull/256284)
+* [@c-claeys (Cristopher Claeys)](https://github.com/c-claeys): エディターコマンドの ServicesAccessor の型付けをより一貫化 [PR #218369](https://github.com/microsoft/vscode/pull/218369)
+* [@CookieeQuinn (Quinn)](https://github.com/CookieeQuinn): 修正 #212484: user-select: none のテキスト上で caretRangeFromPoint が動作しない [PR #219819](https://github.com/microsoft/vscode/pull/219819)
+* [@CrazySteve0605 (Wang Chong)](https://github.com/CrazySteve0605): 修正(gettingStarted): ホバー説明の重複する "can be" を削除 [PR #254412](https://github.com/microsoft/vscode/pull/254412)
+* [@dbreen (Dan Breen)](https://github.com/dbreen): エクスプローラーのより妥当なデフォルトスクロールバー幅 [PR #199784](https://github.com/microsoft/vscode/pull/199784)
+* [@devlinjunker](https://github.com/devlinjunker): モデル API に undo/redo と canUndo/canRedo を公開 [PR #213954](https://github.com/microsoft/vscode/pull/213954)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): C# の山括弧の色分けを有効化 [PR #247665](https://github.com/microsoft/vscode/pull/247665)
+* [@duncpro (Duncan)](https://github.com/duncpro): URL を区切るための縦棒 (|) のサポート [PR #232460](https://github.com/microsoft/vscode/pull/232460)
+* [@dylanchu](https://github.com/dylanchu): TerminalTaskSystem: 文字列コマンドの追加引数の修正 [PR #251201](https://github.com/microsoft/vscode/pull/251201)
+* [@estrizhok (Eugene Strizhok)](https://github.com/estrizhok): 設定 UI で ‘JetBrains’ と ‘ReSharper’ の大文字表記を修正 [PR #254472](https://github.com/microsoft/vscode/pull/254472)
+* [@firelizzard18 (Ethan Reesor)](https://github.com/firelizzard18): Diff エディター向けのコンテキストキー `availableEditorIds` [PR #250198](https://github.com/microsoft/vscode/pull/250198)
+* [@futurist (James Yang)](https://github.com/futurist): 修正(terminal): スクロールバック制限到達後の getBufferReverseIterator のバグ [PR #257311](https://github.com/microsoft/vscode/pull/257311)
+* [@g0t4 (Wes Higbee)](https://github.com/g0t4): 複数行選択のハイライト許可と最大長制御のオプション追加 [PR #228982](https://github.com/microsoft/vscode/pull/228982)
+* [@gabrielcsapo (Gabriel Csapo)](https://github.com/gabrielcsapo): 機能: tsserver オプションに合わせて (requestTime) ログレベルを追加 [PR #250778](https://github.com/microsoft/vscode/pull/250778)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
-  * Add `SecretStorage.keys()` as proposed API [PR #252804](https://github.com/microsoft/vscode/pull/252804)
-  * Fix an `@param` typo [PR #257219](https://github.com/microsoft/vscode/pull/257219)
-* [@hickford (M Hickford)](https://github.com/hickford): Add editor action 'reverse lines' [PR #242926](https://github.com/microsoft/vscode/pull/242926)
-* [@HolgerJeromin (Holger Jeromin)](https://github.com/HolgerJeromin): vscode api: Raise compatibility to webview content [PR #253635](https://github.com/microsoft/vscode/pull/253635)
-* [@iann0036 (Ian Mckay)](https://github.com/iann0036): fix: Typo in lm invokeTool description [PR #257975](https://github.com/microsoft/vscode/pull/257975)
-* [@jiahaoxiang2000 (isomo)](https://github.com/jiahaoxiang2000): Fix git.diff.stageHunk command to work with keyboard shortcuts [PR #254145](https://github.com/microsoft/vscode/pull/254145)
-* [@Jiogo18 (Jérôme Lécuyer)](https://github.com/Jiogo18): Git - l10n discard changes dialogs [PR #254366](https://github.com/microsoft/vscode/pull/254366)
+  * 提案 API として `SecretStorage.keys()` を追加 [PR #252804](https://github.com/microsoft/vscode/pull/252804)
+  * `@param` タイポを修正 [PR #257219](https://github.com/microsoft/vscode/pull/257219)
+* [@hickford (M Hickford)](https://github.com/hickford): エディター操作 ‘reverse lines’ を追加 [PR #242926](https://github.com/microsoft/vscode/pull/242926)
+* [@HolgerJeromin (Holger Jeromin)](https://github.com/HolgerJeromin): vscode API: WebView コンテンツへの互換性を引き上げ [PR #253635](https://github.com/microsoft/vscode/pull/253635)
+* [@iann0036 (Ian Mckay)](https://github.com/iann0036): 修正: lm invokeTool の説明のタイポ [PR #257975](https://github.com/microsoft/vscode/pull/257975)
+* [@jiahaoxiang2000 (isomo)](https://github.com/jiahaoxiang2000): キーボードショートカットで機能するよう `git.diff.stageHunk` コマンドを修正 [PR #254145](https://github.com/microsoft/vscode/pull/254145)
+* [@Jiogo18 (Jérôme Lécuyer)](https://github.com/Jiogo18): Git - l10n 変更破棄ダイアログ [PR #254366](https://github.com/microsoft/vscode/pull/254366)
 * [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen)
-  * [WIP] Add support for NuGet as an MCP package source (VS Code) [PR #254678](https://github.com/microsoft/vscode/pull/254678)
-  * Add experiment flag around NuGet MCP assisted config [PR #257463](https://github.com/microsoft/vscode/pull/257463)
-* [@Jose-AE](https://github.com/Jose-AE): Fix Jittery editor mouse wheel zoom when setting window.zoomLevel = 1 [PR #227916](https://github.com/microsoft/vscode/pull/227916)
-* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): fix: make chat input placeholder less cryptic [PR #255601](https://github.com/microsoft/vscode/pull/255601)
+  * [WIP] NuGet を MCP パッケージソースとしてサポート (VS Code) [PR #254678](https://github.com/microsoft/vscode/pull/254678)
+  * NuGet MCP 支援設定の実験フラグを追加 [PR #257463](https://github.com/microsoft/vscode/pull/257463)
+* [@Jose-AE](https://github.com/Jose-AE): `window.zoomLevel = 1` 設定時のエディターのホイール拡大がガタつく問題を修正 [PR #227916](https://github.com/microsoft/vscode/pull/227916)
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): 修正: チャット入力のプレースホルダーを分かりやすく [PR #255601](https://github.com/microsoft/vscode/pull/255601)
 * [@justin39 (Justin Wang)](https://github.com/justin39)
-  * Add commit_id option to ServeWebArgs for specific client version [PR #255494](https://github.com/microsoft/vscode/pull/255494)
-  * Fix --commit-id flag for code serve-web [PR #258904](https://github.com/microsoft/vscode/pull/258904)
-* [@jwangxx (James Wang)](https://github.com/jwangxx): Add the ability to clear a ChatResponseStream, passing in a reason which results in a warning being displayed [PR #257271](https://github.com/microsoft/vscode/pull/257271)
-* [@Kaidesuyoo (Kaidesuyo)](https://github.com/Kaidesuyoo): fix: Incorrect webWorkerExtensionHost startup process on vscode desktop [PR #234505](https://github.com/microsoft/vscode/pull/234505)
-* [@madskristensen (Mads Kristensen)](https://github.com/madskristensen): Updated references to schemastore.org [PR #254690](https://github.com/microsoft/vscode/pull/254690)
-* [@martijnwalraven (Martijn Walraven)](https://github.com/martijnwalraven): Fix notebook inline values when using language provider [PR #254264](https://github.com/microsoft/vscode/pull/254264)
-* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): feat: editor.minimap.autohide support scroll [PR #253868](https://github.com/microsoft/vscode/pull/253868)
-* [@neorth (Joakim Berglund)](https://github.com/neorth): CamelCase first word if not acronym [PR #229797](https://github.com/microsoft/vscode/pull/229797)
-* [@Ninglo (Ninglo)](https://github.com/Ninglo): Fix `editor.wordSegmenterLocales` configuration don't take effect in simpleWidget editors (like chat or SCM input Editor) [PR #223921](https://github.com/microsoft/vscode/pull/223921)
-* [@OfekShilon (Ofek)](https://github.com/OfekShilon): Fix #4775: Escape user code before incorporating in a regex [PR #236809](https://github.com/microsoft/vscode/pull/236809)
-* [@omar-cs (Omar Carrizales)](https://github.com/omar-cs): Issue #168531: Cursor Height [PR #211473](https://github.com/microsoft/vscode/pull/211473)
-* [@Q1CHENL (Qichen Liu 刘启辰)](https://github.com/Q1CHENL): Fix: prevent view shift when enable minimap with right-click on the scrollbar [PR #210510](https://github.com/microsoft/vscode/pull/210510)
-* [@qirong77](https://github.com/qirong77): Fix the unexpected console error that occurs when updating the shadow dom selection in monaco-editor [PR #215780](https://github.com/microsoft/vscode/pull/215780)
-* [@raffaeu (Raffaele Garofalo)](https://github.com/raffaeu): Feature/move editor menu [PR #247818](https://github.com/microsoft/vscode/pull/247818)
-* [@RedCMD (RedCMD)](https://github.com/RedCMD): Fix empty end bracket error [PR #240609](https://github.com/microsoft/vscode/pull/240609)
+  * 特定クライアントバージョン向けに ServeWebArgs へ commit_id オプションを追加 [PR #255494](https://github.com/microsoft/vscode/pull/255494)
+  * `code serve-web` の `--commit-id` フラグを修正 [PR #258904](https://github.com/microsoft/vscode/pull/258904)
+* [@jwangxx (James Wang)](https://github.com/jwangxx): 理由付きで ChatResponseStream をクリアし警告表示する機能を追加 [PR #257271](https://github.com/microsoft/vscode/pull/257271)
+* [@Kaidesuyoo (Kaidesuyo)](https://github.com/Kaidesuyoo): 修正: デスクトップ版での webWorkerExtensionHost 起動処理の不備 [PR #234505](https://github.com/microsoft/vscode/pull/234505)
+* [@madskristensen (Mads Kristensen)](https://github.com/madskristensen): schemastore.org への参照を更新 [PR #254690](https://github.com/microsoft/vscode/pull/254690)
+* [@martijnwalraven (Martijn Walraven)](https://github.com/martijnwalraven): 言語プロバイダー使用時のノートブックインライン値を修正 [PR #254264](https://github.com/microsoft/vscode/pull/254264)
+* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): 機能: スクロール対応の editor.minimap.autohide を追加 [PR #253868](https://github.com/microsoft/vscode/pull/253868)
+* [@neorth (Joakim Berglund)](https://github.com/neorth): 頭字語でない場合の CamelCase の最初の単語を大文字化 [PR #229797](https://github.com/microsoft/vscode/pull/229797)
+* [@Ninglo (Ninglo)](https://github.com/Ninglo): `editor.wordSegmenterLocales` がシンプルウィジェットエディター (chat / SCM 入力など) で有効化されない問題を修正 [PR #223921](https://github.com/microsoft/vscode/pull/223921)
+* [@OfekShilon (Ofek)](https://github.com/OfekShilon): 修正 #4775: 正規表現に組み込む前にユーザーコードをエスケープ [PR #236809](https://github.com/microsoft/vscode/pull/236809)
+* [@omar-cs (Omar Carrizales)](https://github.com/omar-cs): Issue #168531: カーソルの高さ [PR #211473](https://github.com/microsoft/vscode/pull/211473)
+* [@Q1CHENL (Qichen Liu 刘启辰)](https://github.com/Q1CHENL): 修正: スクロールバーの右クリックでミニマップ有効化時のビューのずれを防止 [PR #210510](https://github.com/microsoft/vscode/pull/210510)
+* [@qirong77](https://github.com/qirong77): monaco-editor の Shadow DOM 選択更新時に発生する予期しないコンソールエラーを修正 [PR #215780](https://github.com/microsoft/vscode/pull/215780)
+* [@raffaeu (Raffaele Garofalo)](https://github.com/raffaeu): 機能/エディターメニューの移動 [PR #247818](https://github.com/microsoft/vscode/pull/247818)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): 空の閉じ括弧エラーを修正 [PR #240609](https://github.com/microsoft/vscode/pull/240609)
 * [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
-  * Add *.tsbuildinfo to .gitignore [PR #254225](https://github.com/microsoft/vscode/pull/254225)
-  * Add RTL support based on decorations [PR #255455](https://github.com/microsoft/vscode/pull/255455)
-* [@rfon6ngy (Griffon Langyer)](https://github.com/rfon6ngy): Allow \n to trigger a softwrap [PR #231120](https://github.com/microsoft/vscode/pull/231120)
-* [@Rishi-infy47 (Saptarshi Chakraborty)](https://github.com/Rishi-infy47): fix: changed the node js version for devcontainer [PR #257400](https://github.com/microsoft/vscode/pull/257400)
-* [@sahin52 (Sahin Kasap)](https://github.com/sahin52): fix: Quick search does not retain search term [PR #234368](https://github.com/microsoft/vscode/pull/234368)
+  * `.tsbuildinfo` を .gitignore に追加 [PR #254225](https://github.com/microsoft/vscode/pull/254225)
+  * デコレーションに基づく RTL サポートを追加 [PR #255455](https://github.com/microsoft/vscode/pull/255455)
+* [@rfon6ngy (Griffon Langyer)](https://github.com/rfon6ngy): `\n` でソフトラップをトリガー可能に [PR #231120](https://github.com/microsoft/vscode/pull/231120)
+* [@Rishi-infy47 (Saptarshi Chakraborty)](https://github.com/Rishi-infy47): 修正: devcontainer の Node.js バージョンを更新 [PR #257400](https://github.com/microsoft/vscode/pull/257400)
+* [@sahin52 (Sahin Kasap)](https://github.com/sahin52): 修正: クイック検索が検索語を保持しない [PR #234368](https://github.com/microsoft/vscode/pull/234368)
 * [@Schpoone (Jason Kuo)](https://github.com/Schpoone)
-  * Use preserveFocus when focusing stack frames [PR #251964](https://github.com/microsoft/vscode/pull/251964)
-  * Fix popup message when hovering over an instruction breakpoint [PR #254925](https://github.com/microsoft/vscode/pull/254925)
+  * スタックフレームにフォーカスする際に preserveFocus を使用 [PR #251964](https://github.com/microsoft/vscode/pull/251964)
+  * 命令ブレークポイントにホバーしたときのポップアップメッセージを修正 [PR #254925](https://github.com/microsoft/vscode/pull/254925)
 * [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
-  * fix: memory leak in extension features tab [PR #256887](https://github.com/microsoft/vscode/pull/256887)
-  * fix: memory leak in editor edit context [PR #256957](https://github.com/microsoft/vscode/pull/256957)
-  * fix: set edit context to undefined in dispose [PR #256965](https://github.com/microsoft/vscode/pull/256965)
-  * fix: memory leak in ChatInputPart [PR #257082](https://github.com/microsoft/vscode/pull/257082)
-  * fix: memory leak in context key [PR #258206](https://github.com/microsoft/vscode/pull/258206)
-* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): Fix testFailure stringify [PR #258463](https://github.com/microsoft/vscode/pull/258463)
-* [@timheuer (Tim Heuer)](https://github.com/timheuer): Adds support for proper localhost loopback on RFC 6761 [PR #256617](https://github.com/microsoft/vscode/pull/256617)
+  * 修正: 拡張機能の機能タブのメモリリーク [PR #256887](https://github.com/microsoft/vscode/pull/256887)
+  * 修正: editor edit context のメモリリーク [PR #256957](https://github.com/microsoft/vscode/pull/256957)
+  * 修正: dispose で edit context を undefined に設定 [PR #256965](https://github.com/microsoft/vscode/pull/256965)
+  * 修正: ChatInputPart のメモリリーク [PR #257082](https://github.com/microsoft/vscode/pull/257082)
+  * 修正: コンテキストキーのメモリリーク [PR #258206](https://github.com/microsoft/vscode/pull/258206)
+* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): testFailure の stringify を修正 [PR #258463](https://github.com/microsoft/vscode/pull/258463)
+* [@timheuer (Tim Heuer)](https://github.com/timheuer): RFC 6761 に基づく適切な localhost ループバックのサポートを追加 [PR #256617](https://github.com/microsoft/vscode/pull/256617)
 * [@tmm1 (Aman Karmani)](https://github.com/tmm1)
-  * [engineering] add testSplit option to unit-test runner [PR #253049](https://github.com/microsoft/vscode/pull/253049)
-  * [dev] shortcut to open devtools attached to exthost [PR #253139](https://github.com/microsoft/vscode/pull/253139)
-  * [engineering] ensure typescript integration tests emit junit reports [PR #253528](https://github.com/microsoft/vscode/pull/253528)
-  * [engineering] add label to packageTask [PR #253779](https://github.com/microsoft/vscode/pull/253779)
-  * [engineering] parallelize unzip in product-build-darwin-universal.yml [PR #257775](https://github.com/microsoft/vscode/pull/257775)
-* [@ttttotem (ttttotem)](https://github.com/ttttotem): Horizontal dragging auto-scroll [PR #235174](https://github.com/microsoft/vscode/pull/235174)
-* [@turansky (Victor Turansky)](https://github.com/turansky): fix: `EvaluatableExpression` properties jsdoc [PR #257930](https://github.com/microsoft/vscode/pull/257930)
+  * [engineering] ユニットテストランナーに testSplit オプションを追加 [PR #253049](https://github.com/microsoft/vscode/pull/253049)
+  * [dev] exthost に接続した DevTools を開くショートカット [PR #253139](https://github.com/microsoft/vscode/pull/253139)
+  * [engineering] TypeScript 統合テストが JUnit レポートを出力するように [PR #253528](https://github.com/microsoft/vscode/pull/253528)
+  * [engineering] packageTask にラベルを追加 [PR #253779](https://github.com/microsoft/vscode/pull/253779)
+  * [engineering] product-build-darwin-universal.yml で unzip を並列化 [PR #257775](https://github.com/microsoft/vscode/pull/257775)
+* [@ttttotem (ttttotem)](https://github.com/ttttotem): 水平ドラッグの自動スクロール [PR #235174](https://github.com/microsoft/vscode/pull/235174)
+* [@turansky (Victor Turansky)](https://github.com/turansky): 修正: `EvaluatableExpression` プロパティの JSDoc [PR #257930](https://github.com/microsoft/vscode/pull/257930)
 * [@yamachu (Yusuke Yamada)](https://github.com/yamachu)
-  * Fix invalid settings keys [PR #254609](https://github.com/microsoft/vscode/pull/254609)
+  * 無効な設定キーを修正 [PR #254609](https://github.com/microsoft/vscode/pull/254609)
   * Revert "refactor: remove redundant actionRunner override in ChatEditorOverlayWidget" [PR #255456](https://github.com/microsoft/vscode/pull/255456)
-* [@yutotnh (yutotnh)](https://github.com/yutotnh): Fix the editor.wordSegmenterLocales description in the settings [PR #210305](https://github.com/microsoft/vscode/pull/210305)
+* [@yutotnh (yutotnh)](https://github.com/yutotnh): 設定の `editor.wordSegmenterLocales` の説明を修正 [PR #210305](https://github.com/microsoft/vscode/pull/210305)
 
-Contributions to `vscode-codicons`:
+`vscode-codicons` への貢献:
 
-* [@desean1625 (Sean Sullivan)](https://github.com/desean1625): Add link in readme to where you can easily preview and search for icons. [PR #295](https://github.com/microsoft/vscode-codicons/pull/295)
+* [@desean1625 (Sean Sullivan)](https://github.com/desean1625): アイコンを簡単にプレビュー・検索できる場所へのリンクを README に追加 [PR #295](https://github.com/microsoft/vscode-codicons/pull/295)
 
-Contributions to `vscode-copilot-chat`:
+`vscode-copilot-chat` への貢献:
 
 * [@24anisha](https://github.com/24anisha)
-  * Add microsoft internal telemetry [PR #341](https://github.com/microsoft/vscode-copilot-chat/pull/341)
-  * Internal telemetry fixes -- conversation id and message id [PR #369](https://github.com/microsoft/vscode-copilot-chat/pull/369)
-* [@danilofalcao (Danilo Falcão)](https://github.com/danilofalcao): list all openrouter models without category but tools support [PR #208](https://github.com/microsoft/vscode-copilot-chat/pull/208)
-* [@devm33 (Devraj Mehta)](https://github.com/devm33): Remove unused fields from Completion response interface [PR #123](https://github.com/microsoft/vscode-copilot-chat/pull/123)
-* [@johnmog (John Mogensen)](https://github.com/johnmog): Git LFS instructions to CONTRIBUTING.md [PR #156](https://github.com/microsoft/vscode-copilot-chat/pull/156)
-* [@jwangxx (James Wang)](https://github.com/jwangxx): When rendering the prompts, exclude turns from the history that errored due to prompt filtration [PR #399](https://github.com/microsoft/vscode-copilot-chat/pull/399)
-* [@shsuman (Shantnu Suman)](https://github.com/shsuman): Print Error literal at the start of all error messages for better parsing from the logs [PR #260](https://github.com/microsoft/vscode-copilot-chat/pull/260)
-* [@srilovesflutter (Sri)](https://github.com/srilovesflutter): corrected typo [PR #129](https://github.com/microsoft/vscode-copilot-chat/pull/129)
-* [@trycatchkamal (Kamal Raj Sekar)](https://github.com/trycatchkamal): Removed unused code from tests [PR #207](https://github.com/microsoft/vscode-copilot-chat/pull/207)
+  * Microsoft 内部テレメトリを追加 [PR #341](https://github.com/microsoft/vscode-copilot-chat/pull/341)
+  * 内部テレメトリ修正 — conversation id と message id [PR #369](https://github.com/microsoft/vscode-copilot-chat/pull/369)
+* [@danilofalcao (Danilo Falcão)](https://github.com/danilofalcao): カテゴリなしでもツール対応の OpenRouter モデルをすべて一覧 [PR #208](https://github.com/microsoft/vscode-copilot-chat/pull/208)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): Completion レスポンスインターフェイスから未使用フィールドを削除 [PR #123](https://github.com/microsoft/vscode-copilot-chat/pull/123)
+* [@johnmog (John Mogensen)](https://github.com/johnmog): CONTRIBUTING.md に Git LFS の手順を追加 [PR #156](https://github.com/microsoft/vscode-copilot-chat/pull/156)
+* [@jwangxx (James Wang)](https://github.com/jwangxx): プロンプト描画時に、プロンプトフィルタで失敗した履歴のターンを除外 [PR #399](https://github.com/microsoft/vscode-copilot-chat/pull/399)
+* [@shsuman (Shantnu Suman)](https://github.com/shsuman): ログ解析性向上のため、すべてのエラーメッセージの先頭に “Error” を付与 [PR #260](https://github.com/microsoft/vscode-copilot-chat/pull/260)
+* [@srilovesflutter (Sri)](https://github.com/srilovesflutter): タイポ修正 [PR #129](https://github.com/microsoft/vscode-copilot-chat/pull/129)
+* [@trycatchkamal (Kamal Raj Sekar)](https://github.com/trycatchkamal): テストから未使用のコードを削除 [PR #207](https://github.com/microsoft/vscode-copilot-chat/pull/207)
 * [@vritant24 (Vritant Bhardwaj)](https://github.com/vritant24)
-  * Add ability to specify models through config for simulation tests [PR #324](https://github.com/microsoft/vscode-copilot-chat/pull/324)
-  * Add azure open ai support to simulator model config [PR #346](https://github.com/microsoft/vscode-copilot-chat/pull/346)
+  * シミュレーションテスト用に設定からモデルを指定可能に [PR #324](https://github.com/microsoft/vscode-copilot-chat/pull/324)
+  * シミュレーターのモデル設定に Azure OpenAI を追加 [PR #346](https://github.com/vicrosoft/vscode-copilot-chat/pull/346)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献:
 
-* [@noritaka1166 (Noritaka Kobayashi)](https://github.com/noritaka1166): chore: fix typo in comment-out [PR #2031](https://github.com/microsoft/vscode-eslint/pull/2031)
+* [@noritaka1166 (Noritaka Kobayashi)](https://github.com/noritaka1166): chore: コメントのタイポ修正 [PR #2031](https://github.com/microsoft/vscode-eslint/pull/2031)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
 * [@pilaoda (pilaoda)](https://github.com/pilaoda)
-  * fix watch panel custom string representation. #2252 [PR #2253](https://github.com/microsoft/vscode-js-debug/pull/2253)
-  * fix toString not work in Local Variables panel until all variables defined in scope #2254 [PR #2255](https://github.com/microsoft/vscode-js-debug/pull/2255)
+  * ウォッチパネルのカスタム文字列表現を修正 #2252 [PR #2253](https://github.com/microsoft/vscode-js-debug/pull/2253)
+  * すべての変数がスコープに定義されるまで Local Variables パネルの toString が機能しない問題を修正 #2254 [PR #2255](https://github.com/microsoft/vscode-js-debug/pull/2255)
 
-Contributions to `vscode-json-languageservice`:
+`vscode-json-languageservice` への貢献:
 
-* [@fengzilong (MO)](https://github.com/fengzilong): feat: allow format range to be undefined [PR #272](https://github.com/microsoft/vscode-json-languageservice/pull/272)
+* [@fengzilong (MO)](https://github.com/fengzilong): 機能: format の範囲を undefined にできるように [PR #272](https://github.com/microsoft/vscode-json-languageservice/pull/272)
 
-Contributions to `vscode-vsce`:
+`vscode-vsce` への貢献:
 
-* [@Adjective-Object (Max)](https://github.com/Adjective-Object): add `commonjs` annotation to package.json [PR #1179](https://github.com/microsoft/vscode-vsce/pull/1179)
+* [@Adjective-Object (Max)](https://github.com/Adjective-Object): package.json に `commonjs` 注釈を追加 [PR #1179](https://github.com/microsoft/vscode-vsce/pull/1179)
 
-Contributions to `debug-adapter-protocol`:
+`debug-adapter-protocol` への貢献:
 
-* [@osiewicz (Piotr Osiewicz)](https://github.com/osiewicz): chore: Add Zed to the list of tools supporting DAP [PR #548](https://github.com/microsoft/debug-adapter-protocol/pull/548)
+* [@osiewicz (Piotr Osiewicz)](https://github.com/osiewicz): chore: DAP をサポートするツールの一覧に Zed を追加 [PR #548](https://github.com/microsoft/debug-adapter-protocol/pull/548)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@Leonidas-from-XIV (Marek Kubica)](https://github.com/Leonidas-from-XIV): ocaml-language-server does not exist anymore [PR #2165](https://github.com/microsoft/language-server-protocol/pull/2165)
-* [@osiewicz (Piotr Osiewicz)](https://github.com/osiewicz): chore: Add Zed to the list of implementors [PR #2164](https://github.com/microsoft/language-server-protocol/pull/2164)
+* [@Leonidas-from-XIV (Marek Kubica)](https://github.com/Leonidas-from-XIV): ocaml-language-server は存続していないため削除 [PR #2165](https://github.com/microsoft/language-server-protocol/pull/2165)
+* [@osiewicz (Piotr Osiewicz)](https://github.com/osiewicz): chore: 実装者の一覧に Zed を追加 [PR #2164](https://github.com/microsoft/language-server-protocol/pull/2164)
 
-Contributions to `python-environment-tools`:
+`python-environment-tools` への貢献:
 
-* [@renan-r-santos (Renan Santos)](https://github.com/renan-r-santos): Exclude Pixi environments from the Conda locator [PR #234](https://github.com/microsoft/python-environment-tools/pull/234)
+* [@renan-r-santos (Renan Santos)](https://github.com/renan-r-santos): Conda ロケーターから Pixi 環境を除外 [PR #234](https://github.com/microsoft/python-environment-tools/pull/234)
 
-
-
-<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
-<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_103.md
+++ b/docs/release-notes/v1_103.md
@@ -1,0 +1,744 @@
+---
+Order: 112
+TOCTitle: July 2025
+PageTitle: Visual Studio Code July 2025
+MetaDescription: Learn what is new in the Visual Studio Code July 2025 Release (1.103)
+MetaSocialImage: 1_103/release-highlights.png
+Date: 2025-08-07
+DownloadVersion: 1.103.0
+---
+# July 2025 (version 1.103)
+
+_Release date: August 7, 2025_
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the July 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+<table class="highlights-table">
+  <tr>
+    <th>MCP</th>
+    <th>Chat</th>
+    <th>Productivity</th>
+  </tr>
+  <tr>
+    <td>Revamped tool picker experience <a href="#tool-picker-improvements"><br>Show more</a></td>
+    <td>Use GPT-5 in VS Code <a href="#gpt-5-availability"><br>Show more</a></td>
+    <td>Check out multiple branches simultaneously with Git worktrees <a href="#git-worktree-support"><br>Show more</a></td>
+  </tr>
+  <tr>
+    <td>Enable more than 128 tools per agent request <a href="#tool-grouping-experimental"><br>Show more</a></td>
+    <td>Restore to a previous good state with chat checkpoints <a href="#chat-checkpoints"><br>Show more</a></td>
+    <td>Manage coding agent sessions in a dedicated view <a href="#chat-sessions-experimental"><br>Show more</a></td>
+  </tr>
+</table>
+
+<br>
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+
+> **Insiders: Want to try new features as soon as possible?**<br>
+> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> [Download Insiders](https://code.visualstudio.com/insiders)<br>
+
+<!-- TOC
+<div class="toc-nav-layout">
+  <nav id="toc-nav">
+    <div>In this update</div>
+    <ul>
+      <li><a href="#chat">Chat</a></li>
+      <li><a href="#mcp">MCP</a></li>
+      <li><a href="#accessibility">Accessibility</a></li>
+      <li><a href="#editor-experience">Editor Experience</a></li>
+      <li><a href="#notebooks">Notebooks</a></li>
+      <li><a href="#source-control">Source Control</a></li>
+      <li><a href="#terminal">Terminal</a></li>
+      <li><a href="#languages">Languages</a></li>
+      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
+      <li><a href="#extension-authoring">Extension Authoring</a></li>
+      <li><a href="#proposed-apis">Proposed APIs</a></li>
+      <li><a href="#engineering">Engineering</a></li>
+      <li><a href="#notable-fixes">Notable fixes</a></li>
+      <li><a href="#thank-you">Thank you</a></li>
+    </ul>
+  </nav>
+  <div class="notes-main">
+Navigation End -->
+
+## Chat
+
+### GPT 5 availability
+
+Starting today, GPT-5 is rolling out to all paid GitHub Copilot plans. GPT-5 is OpenAI's most capable model yet, bringing new advances in reasoning, coding, and chat. Learn more about the GPT-5 model availability in the [GitHub Changelog](https://github.blog/changelog/2025-08-07-openai-gpt-5-is-now-in-public-preview-for-github-copilot).
+
+Open the Chat view and choose GPT-5 from the model picker to start using it for your chat conversations in VS Code.
+
+Learn more about [using language models in VS Code](https://code.visualstudio.com/docs/copilot/language-models).
+
+### Chat checkpoints
+
+**Setting**: `setting(chat.checkpoints.enabled)`
+
+We've introduced checkpoints that enable you to restore different states of your chat conversations. You can easily revert edits and go back to certain points in your chat conversation. This can be particularly useful if multiple files were changed in a chat session.
+
+When you select a checkpoint, VS Code reverts workspace changes and the chat history to that point. After restoring a checkpoint, you can redo that action as well!
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/chat-checkpoints.mp4" title="Video that shows creating and managing chat checkpoints." autoplay loop controls muted></video>
+
+Checkpoints will be enabled by default and can be controlled with `setting(chat.checkpoints.enabled)`.
+
+### Tool picker improvements
+
+We've totally revamped the tool picker this iteration and adopted a new component called Quick Tree to display all the tools.
+
+![Screenshot showing the new tool picker using a quick tree, enabling collapsing and expanding nodes.](https://code.visualstudio.com/assets/updates/1_103/tool-picker-quick-tree.png)
+
+Notable features:
+
+* Expand or collapse
+* Configuration options moved to the title bar
+* Sticky scrolling
+* Icon rendering
+
+Let us know what you think!
+
+### Tool grouping (Experimental)
+
+**Setting**: `setting(github.copilot.chat.virtualTools.threshold)`
+
+The maximum number of tools that you can use for a single chat request is currently 128. Previously, you could quickly reach this limit by installing MCP servers with many tools, requiring you to deselect some tools in order to proceed.
+
+In this release of VS Code, we have enabled an experimental tool-calling mode for when the number of tools exceeds the maximum limit. Tools are automatically grouped and the model is given the ability to activate and call groups of tools.
+
+This behavior, including the threshold, is configurable via the setting `setting(github.copilot.chat.virtualTools.threshold)`.
+
+### Terminal auto-approve improvements
+
+**Setting**: `setting(chat.tools.terminal.autoApprove)`
+
+Early terminal auto-approve settings were introduced last month. This release, the feature got many improvements. Learn more about [terminal auto-approval](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands-experimental) in our documentation.
+
+- We merged the `allowList` and `denyList` settings into the `setting(chat.tools.terminal.autoApprove)` setting. If you were using the old settings, you should see a warning asking you to migrate to the new setting.
+- Regular expression matchers now support flags. This allows case insensitivity, for example in PowerShell, where case often doesn't matter:
+
+    ```jsonc
+    "chat.tools.terminal.autoApprove": {
+      // Deny any `Remove-Item` command, regardless of case
+      "/^Remove-Item\\b/i": false
+    }
+    ```
+
+- There was some confusion around how the sub-command matching works, this is now explained in detail in the setting's description, but we also support matching against the complete command line.
+
+    ```jsonc
+    "chat.tools.terminal.autoApprove": {
+      // Deny any _command line_ containing a reference to what is likely a PowerShell script
+      "/\\.ps1\\b/i": { "approve": false, "matchCommandLine": true }
+    }
+    ```
+
+- The auto approve reasoning is now logged to the Terminal Output channel. We plan to [surface this in the UI soon](https://github.com/microsoft/vscode/issues/256780).
+- For now auto approve will only be allowed in either User or Remote settings. We do plan to allow their use in workspace settings again in an upcoming release.
+
+### Track progress with task lists (Experimental)
+
+**Setting**: `setting(chat.todoListTool.enabled)`
+
+The great thing about agent mode is that you can give it a high-level task and have it implement it. As it plans the work and breaks it down into smaller tasks, it can be overwhelming to track the progress of all these individual tasks.
+
+This milestone, we are introducing the task/todo list feature in chat to better help you see which tasks are completed and which ones are still pending. You can view the task list at the top of the Chat view, so you always have visibility into the progress being made. As the agent progresses through its work, it updates the task list.
+
+Get started by giving the agent a high-level task and ask it to track its work in a todo list!
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/chat-todo-list.mp4" title="Video that shows the todo list in chat." autoplay loop controls muted></video>
+
+This feature is still experimental and you can enable it with the `setting(chat.todoListTool.enabled)` setting.
+
+### Improved model management experience
+
+This iteration, we've revamped the chat provider API, which is responsible for language model access. Users are now able to select which models appear in their model picker, creating a more personalized and focused experience.
+
+![Screenshot of the model picker showing various models from providers such as Copilot and OpenRouter](https://code.visualstudio.com/assets/updates/1_103/modelpicker.png)
+
+We plan to finalize this new API in the coming months and would appreciate any feedback. Finalization of this API will open up the extension ecosystem to implement their own model providers and further expand the bring your own key offering.
+
+### Azure DevOps repos remote index support
+
+The [`#codebase` tool](https://code.visualstudio.com/docs/copilot/chat/copilot-chat-context#_perform-a-codebase-search) now supports remote indexes for workspaces that are linked to Azure DevOps repos. This enables `#codebase` to search for relevant snippets almost instantly without any initialization. This even works for larger repos with tens of thousands of indexable files. Previously, this feature only worked with GitHub linked repos.
+
+Remote indexes are used automatically when working in a workspace that is linked to Azure DevOps through git. Make sure you are also logged into VS Code with the Microsoft account you use to access the Azure DevOps repos.
+
+We're gradually rolling out support for this feature on the services side, so not every organization might be able to use it initially. Based on the success of the rollout, we hope to turn on remote indexing for Azure DevOps for as many organizations as possible.
+
+### Improved reliability and performance of the run in terminal and task tools
+
+We have migrated the tools for running tasks and commands within the terminal from the Copilot extension into the core [microsoft/vscode repository](https://github.com/microsoft/vscode). This gives the tools access to lower-level and richer APIs, allowing us to fix many of the terminal hanging issues. This update also comes with the benefit of more easily implementing features going forward, as we're no longer restricted to the capabilities of the extension API, especially any changes that need custom UI within the Chat view.
+
+### Warning about no shell integration when using chat
+
+While we strive to allow agent mode to run commands in terminals without shell integration, the experience will always be inferior as the terminal is essentially a black box at that point. Examples of issues that can occur without shell integration are: no exit code reporting and the inability to differentiate between a command idling and a prompt idling, resulting in output possibly not being reported to the agent.
+
+When the `run in terminal` tool is used but [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) is not detected, a message is displayed calling this out and pointing at the documentation.
+
+![Screenshot of a message in the Chat view saying "Enable shell integration to improve command detection".](https://code.visualstudio.com/assets/updates/1_103/terminal-chat-si-none.png)
+
+### Output polling for tasks and terminals
+
+The agent now waits for tasks and background terminals to complete before proceeding by using output polling. If a process takes longer than 20 seconds, you are prompted to continue waiting or move on. The agent will monitor the process for up to two minutes, summarizing the current state or reporting if the process is still running. This improves reliability when running long or error-prone commands in chat.
+
+### Task awareness improvement
+
+Previously, the agent could only monitor active tasks. Now, it can track and analyze the output of both active and completed tasks, including those that have failed or finished running. This enhancement enables better troubleshooting and more comprehensive insights into task execution history.
+
+### Agent awareness of user created terminals
+
+The agent now maintains awareness of all user-created terminals in the workspace. This enables it to track recent commands and access terminal output, providing better context for assisting with terminals and troubleshooting.
+
+### Terminal inline chat improvements
+
+Terminal inline chat now better detects your active shell, even when working within subshells (for example, launching Python or Node from PowerShell or zsh). This dynamic shell detection improves the accuracy of inline chat responses by providing more relevant command suggestions for your current shell type.
+
+![Screenshot of terminal inline chat showing node specific suggestions.](https://code.visualstudio.com/assets/updates/1_103/hello_node.png)
+
+### Improved test runner tool
+
+The test runner tool has been reworked. It now shows progress inline within chat, and numerous bugs in the tool have been fixed.
+
+### Edit previous requests
+
+**Setting**: `setting(chat.editRequests)`
+
+Last iteration, we enabled users to edit previous requests and rolled out a few different access points. This iteration, we've made inline edits the default behavior. Click on the request bubble to begin editing that request. You can modify attachments, change the mode and model, and resend your request with modified text.
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/chat-previous-edits.mp4" title="Video that shows editing a previous chat request inline in the Chat view." autoplay loop controls muted></video>
+
+You can control the chat editing behavior with the `setting(chat.editRequests)` setting if you prefer editing via the toolbar hovers above each request.
+
+### Open chat as maximized
+
+**Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
+
+We added two extra options for configuring the default visibility of the Secondary Side Bar to open it as maximized:
+
+* `maximizedInWorkspace`: open the Chat view as maximized when opening a new workspace
+* `maximized`: open the Chat view always as maximized, including in empty windows
+
+![Screenshot that shows the Chat view maximized.](https://code.visualstudio.com/assets/updates/1_103/max-chat.png)
+
+### Pending chat confirmation
+
+To help prevent accidentally closing a workspace where an agent session is actively changing files or responding to your request, we now show a dialog when you try to quit VS Code or close its window when a chat response is in progress:
+
+![Screenshot of confirmation to exit with running chat.](https://code.visualstudio.com/assets/updates/1_103/confirm-chat-exit.png)
+
+### OS notification on user action
+
+**Setting**: `setting(chat.notifyWindowOnConfirmation)`
+
+We now leverage the OS native notification system to show a toast when user confirmation is needed within a chat session. Enable this behavior with the `setting(chat.notifyWindowOnConfirmation)`.
+
+![Screenshot of toast for confirmation of a chat agent.](https://code.visualstudio.com/assets/updates/1_103/chat-toast.png)
+
+We plan to improve this experience in the future to allow for displaying more information and for allowing you to approve directly from the toast. For now, selecting the toast focuses the window where the confirmation originated from.
+
+### Math support in chat (Preview)
+
+**Setting**: `setting(chat.math.enabled)`
+
+Chats now have initial support for rendering mathematical equations in responses:
+
+![Screenshot of the Chat view, showing inline and block equations in a chat response.](https://code.visualstudio.com/assets/updates/1_103/chat-math.png)
+
+This feature is powered by [KaTeX](https://katex.org) and supports both inline and block math equations. Inline math equations can be written by wrapping the markup in single dollar signs (`$...$`), while block math equations use two dollar signs (`$$...$$`).
+
+Math rendering can be enabled using `setting(chat.math.enabled)`. Currently, it is off by default but we plan to enable it in a future release, after further testing.
+
+### Context7 integration for project scaffolding (Experimental)
+
+**Setting**: `setting(github.copilot.chat.newWorkspace.useContext7)`
+
+When you scaffold a new project with `#new` in chat, you can now make sure that it uses the latest documentation and APIs from **Context7**, if you have already installed the Context7 MCP server.
+
+## MCP
+
+### Server autostart and trust
+
+**Setting**: `setting(chat.mcp.autostart:newAndOutdated)`
+
+Previously, when you added or updated an MCP server configuration, VS Code would show a blue "refresh" icon in the Chat view, enabling you to manually refresh the list of tools. In the milestone, you can now configure the auto-start behavior for MCP servers, so you no longer have to manually restart the MCP server.
+
+Use the `setting(chat.mcp.autostart:newAndOutdated)` setting to control this behavior. You can also change this setting within the icon's tooltip and see which servers will be started:
+
+![Screenshot showing the hover of the refresh MCP server icon, enabling you to configure the auto-start behavior.](https://code.visualstudio.com/assets/updates/1_103/mcp-refresh-tip.png)
+
+The first time an MCP server is started after being updated or changed, we now show a dialog asking you to trust the server. Giving trust to these servers is particularly important with autostart turned on to prevent running undesirable commands unknowingly.
+
+Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) in our documentation.
+
+### Client credentials flow for remote MCP servers
+
+The ideal flow for a remote MCP server that wants to support authentication is to use an auth provider that supports Dynamic Client Registration (DCR). This enables the client (VS Code) to register itself with that auth provider, so the auth flow is seamless.
+
+However, not every auth provider supports DCR, so we introduced a client-credentials flow that enables you to supply your own client ID and (optionally) client secret that will be used when taking you through the auth provider's auth flow. Here's what that looks like:
+
+* Step 1: VS Code detects that DCR can't be used, and asks if you want to do the client credentials flow:
+
+    ![Screenshot of a modal dialog saying that DCR is not supported but you can provide client credentials manually.](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr1.png)
+
+    > **IMPORTANT**: At this point, you would go to the auth provider's website and manually create an application registration. There you will put in the redirect URIs mentioned in the modal dialog.
+
+* Step 2: From the auth provider's portal, you will get a client ID and maybe a client secret. You'll put the client ID in the input box that appears and hit `kbstyle(Enter)`:
+
+    ![Screenshot of an input box to provide the client ID for the MCP server.](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr2.png)
+
+* Step 3: Then you'll put in the client secret if you have one, and hit `kbstyle(Enter)` (leave blank if you don't have one)
+
+    ![Screenshot of an input box to provide the optional client secret for the MCP server.](https://code.visualstudio.com/assets/updates/1_103/mcp-auth-no-dcr3.png)
+
+    At that point, you'll be taken through the typical auth flow to authenticate the MCP server you're working with.
+
+### Remove dynamic auth provider from Account menu
+
+Since the addition of remote MCP authentication, there has been a command available in the Command Palette called **Authentication: Remove Dynamic Authentication Providers**, which enables you to remove client credentials (client ID and, if available, a client secret) and all account information associated with that provider.
+
+We've now exposed this command in the Account menu. You can find it inside of an MCP server account:
+
+![Screenshot of the Account menu showing the manage dynamic auth option in an account's submenu.](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth1.png)
+
+or at the root of the menu if you don't have any MCP server accounts yet:
+
+![Screenshot of the Account menu showing the manage dynamic auth option in the root of account menu.](https://code.visualstudio.com/assets/updates/1_103/mcp-remove-dynamic-auth2.png)
+
+### Support for `resource_link` and structured output
+
+VS Code now fully supports the latest MCP specification, version `2025-06-18`, with support for `resource_link`s and structured output in tool results.
+
+## Accessibility
+
+### Accessible chat elicitations
+
+When the agent prompts for user input, such as whether to keep waiting for a process, the chat elicitation is now accessible to screen readers. You are alerted when the prompt appears, can navigate to it with the keyboard, and can review the message in the accessible view.
+
+### Control file opening for chat edits
+
+A new setting, `setting(accessibility.openChatEditedFiles)`, lets you choose whether files are automatically opened as the agent edits them in chat. Enable this setting for more control over which files appear in your editor.
+
+### View all and previous edits commands
+
+The **View All Edits** and **View Previous Edits** commands are now available throughout the editor, making it easy to review changes made by the agent. These commands are especially helpful when `setting(accessibility.openChatEditedFiles)` is disabled, allowing you to track edits without opening each file.
+
+### Side Bar visibility announcements
+
+When the Primary or Secondary Side Bar is shown or hidden, an ARIA announcement now notifies you of this change. This improves accessibility by ensuring screen reader users are aware of Side Bar visibility updates.
+
+### Accessibility testing with Playwright
+
+We have added automated accessibility tests for the editor using Playwright. These tests help us continuously validate that Visual Studio Code meets accessibility standards and best practices, ensuring a better experience for all users.
+
+## Editor Experience
+
+### Settings search suggestions
+
+The AI search results toggle in the search box of the Settings editor, indicated by a sparkle, is now available for all users. The toggle is enabled when AI search results have loaded and are available. Pressing the toggle switches between the AI and non-AI search results.
+
+The AI settings search results are based on semantic similarity instead of string matching. For example, `editor.fontSize` appears as an AI settings search result when you search for "increase text size".
+
+![Screenshot of AI results in the Settings editor for "increase text size" showing editor.fontSize setting.](https://code.visualstudio.com/assets/updates/1_103/settings-editor-toggle.png)
+
+### Editor tab context menu
+
+We cleaned up the editor tab context menu to group related options for splitting and moving into a submenu:
+
+![Screenshot that shows the 'Split and Move' editor tab context menu.](https://code.visualstudio.com/assets/updates/1_103/editor-menu.png)
+
+### AI statistics (Preview)
+
+**Setting**: `setting(editor.aiStats.enabled:true)`
+
+We added an experimental feature for displaying basic AI statistics. Use the `setting(editor.aiStats.enabled:true)` to enable this feature, which is disabled by default.
+
+This feature shows you, per project, the percentage of characters that was inserted by AI versus inserted by typing. It also keeps track of how many inline and next edit suggestions you accepted during the current day.
+
+![Screenshot showing the AI statistic hover information in the Status Bar.](https://code.visualstudio.com/assets/updates/1_103/ai-stats.png)
+
+## Notebooks
+
+### Notebook inline chat with agent tools
+
+**Setting**: `setting(inlineChat.notebookAgent:true)`
+
+The notebook inline chat control can now use the full suite of notebook agent tools to enable additional capabilities like running cells and installing packages into the kernel.
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/notebook-inline-agent.mp4" title="Video showing a coding agent session opening in a chat session editor." autoplay loop controls muted></video>
+
+To enable agent tools in notebooks, enable the new experimental setting `setting(inlineChat.notebookAgent:true)`. This also currently requires enabling the setting for inline chat v2 `setting(inlineChat.enableV2:true)`.
+
+### Install dependencies in Virtual Environments created with uv
+
+We now support installing required dependencies when you run Jupyter Notebooks against a Virtual Environment created using [uv](https://docs.astral.sh/uv/pip/environments/).
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/uv-install-ipykernel.mp4" title="Video that shows installing IPyKernel in uv Virtual Environment." autoplay loop controls muted></video>
+
+## Source Control
+
+### Git worktree support
+
+**Setting**: `setting(git.detectWorktrees)`
+
+To address a long-standing [feature request](https://github.com/microsoft/vscode/issues/68038), this milestone we have added Git worktree support. Worktrees let you check out multiple branches at once, making it easy to test changes or work in parallel without switching contexts.
+
+When opening a folder or workspace that contains a git repository, we now automatically detect worktrees and display them in the Source Control Repositories view. You can now view, create, delete, and open worktrees in a new or current window by using commands available from the Command Palette or Source Control Repositories view. You can disable this functionality by toggling the `setting(git.detectWorktrees)` setting.
+
+![Screenshot of create worktree command in Source Control view.](https://code.visualstudio.com/assets/updates/1_103/repository_worktree_submenu.png)
+
+![Screenshot of open and delete worktree commands in the Source Control view.](https://code.visualstudio.com/assets/updates/1_103/worktree_specific_submenu.png)
+
+### Repositories view
+
+The Source Control Repositories view displays all source control providers that were discovered in the current folder/workspace. This milestone, we have updated the rendering of the view in order to visually distinguish between repositories, submodules, and worktrees. We also show the parent-child relationship between repositories, submodules and worktrees.
+
+![Screenshot of the Source Control Repositories view showing two repositories and a worktree associated with one of the repos.](https://code.visualstudio.com/assets/updates/1_103/repositories-view.png)
+
+## Terminal
+
+### Documentation support in terminal suggest
+
+Terminal suggestions powered by language servers (LSP) now include inline documentation, similar to what you see in the editor. Starting with the Python REPL, you'll get helpful descriptions and usage details for commands as you type.
+
+You currently need these settings to enable LSP suggestions in the terminal:
+
+* `setting(python.terminal.shellIntegration.enabled:true)`
+* `setting(python.analysis.supportAllPythonDocuments:true)`
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/lsp_documentation.mp4" title="Video showing terminal suggest completions items with LSP now show code docs." autoplay loop controls muted></video>
+
+### Voice dictation
+
+Now that natural language input is supported in terminals, including those enabled by the Gemini and Claude extensions, we have reintroduced voice dictation in the terminal. You can start or stop dictation by using the **Terminal: Start Dictation in Terminal** and **Terminal: Stop Dictation in Terminal** commands.
+
+### Improved shell integration diagnostics
+
+[Shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) is the foundation that many features in the integrated terminal are built upon such as [sticky scroll](https://code.visualstudio.com/docs/terminal/shell-integration#_sticky-scroll), [quick fixes](https://code.visualstudio.com/docs/terminal/shell-integration#_quick-fixes) and [agent mode's](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode) ability to understand what's happening inside the terminal.
+
+This release features some improved diagnostics when you hover the terminal and select **Show Details**. You should now see the detected shell type and current working directory:
+
+![Screenshot of the detailed terminal tab hover showing the shell type like pwsh and the current working directory.](https://code.visualstudio.com/assets/updates/1_103/terminal-si-diagnostics.png)
+
+This is one of the first places to look if one of these rich features isn't working as expected.
+
+## Languages
+
+### Python
+
+#### Shell integration support for Python 3.13 and above
+
+We now support shell integration for Python when using version 3.13 or later. When enabled, PyREPL is automatically disabled to ensure compatibility. You can disable shell integration if you prefer to continue using PyREPL.
+
+![Screenshot showing the Python shell integration setting in the Settings editor.](https://code.visualstudio.com/assets/updates/1_103/python_shellIntegration.png)
+
+#### Python Environments extension improvements
+
+The [Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) continued to receive bug fixes and improvements as part of the controlled roll-out to stable users. To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code `settings.json` file: `"python.useEnvironmentsExtension": true`.
+
+### TypeScript 5.9
+
+VS Code now includes TypeScript 5.9.2. This major update brings a few new language improvements, including [support for import defer](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer), along with tooling improvements such as [improved docs for many DOM apis](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#support-for-import-defer).
+
+Check out the [TypeScript 5.9 release blog](https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/) for more details on this update.
+
+### Expandable hovers for JavaScript and TypeScript
+
+When you hover over a symbol in JavaScript or TypeScript, VS Code tries to show the most useful IntelliSense type information about that symbol. Types can be very complex, so one challenge for us has been trying to find the right balance between showing enough details to be useful, while not showing so much info that it becomes overwhelming. It's hard to come up with a good one size fits all approach, and also the level of type detail you want might change depending on what you are working on.
+
+That's why this iteration, we've added new UI that gives you more control over how types are shown in hovers. When you hover over a symbol, now you can select the little `+` icon on the left side of the hover control to expand the interfaces and complex types in the hover into their components. For example, you can use this to see the properties of an interface directly in the hover:
+
+<video src="https://code.visualstudio.com/assets/updates/1_103/ts-expandable-hovers.mp4" title="Video showing expanding interface types." autoplay loop controls muted></video>
+
+Hovers can be expanded multiple times, which recursively expands types from the previous expansion. If you ever expand too much, just select the `-` icon to go back to the previous level. Also keep in mind that not every type is expandable and that we still need some limits on just how much expansion we can support. [Let us know](https://github.com/microsoft/vscode/issues/new?template=bug_report.md) if there are any cases where expandable hovers aren't working how you'd like.
+
+## Contributions to extensions
+
+### GitHub Pull Requests
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues.
+
+Review the [changelog for the 0.116.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01160) release of the extension to learn about everything in the release.
+
+#### Pull request header cleanup
+
+We've simplified the button bar in the pull request description header. The copy actions are now in the right-click context menu of the PR link.
+
+![Screenshot of the simplified PR header when opening the PR details.](https://code.visualstudio.com/assets/updates/1_103/simplified-pr-header-buttons.png)
+
+#### Show coding agent PRs in chat
+
+**Setting**: `setting(githubPullRequests.codingAgent.uiIntegration)`
+
+When you start a coding agent session (via `#copilotCodingAgent` or with the **Delegate to coding agent** action), the pull request is rendered as a card in the Chat view.
+
+![Screenshot of a coding agent PR card in the Chat view.](https://code.visualstudio.com/assets/updates/1_103/pr-card-in-chat.png)
+
+Enable the `setting(githubPullRequests.codingAgent.uiIntegration)` setting to enable the new **Delegate to coding agent** button in the Chat view, for repositories that have the agent enabled.
+
+#### Chat sessions (Experimental)
+
+##### Coding agent chats
+
+Building off [last iteration's Copilot coding agent integration](https://code.visualstudio.com/updates/v1_102#_github-pull-requests), you can now manage a coding agent session from a dedicated chat editor. This enables you to follow the progress of the coding agent, provide follow-up instructions, and see the agent's responses in a dedicated chat editor.
+
+* Start a coding agent session from VS Code with the `#copilotCodingAgent` tool or via the [UI controls](https://code.visualstudio.com/updates/v1_102#_start-a-coding-agent-session-preview).
+
+    <video src="https://code.visualstudio.com/assets/updates/1_103/coding-agent-start.mp4" title="Video showing a coding agent session opening in a chat session editor." autoplay loop controls muted></video>
+
+* Follow the progress of coding agent in an attached chat editor.
+
+    ![Screenshot showing Coding Agent progress.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-progress.png)
+
+* Provide follow-up instructions directly from chat.
+
+    ![Screenshot showing providing a followup in chat to coding agent.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-follow-up.png)
+
+##### Chat sessions view
+
+**Setting**: `setting(chat.agentSessionsViewLocation)`
+
+Enable the `setting(chat.agentSessionsViewLocation)` setting to try this experimental feature.
+
+* When set to `view`, you will see a new **Chat Sessions** view is shown in the VS Code Side Bar. This view enables you to manage and interact with your local chat sessions, as well as the coding agent sessions.
+
+    ![Screenshot showing the Coding Agent Sessions view.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-sessions-view.png)
+
+* When set to `showChatsMenu`, coding agent chat sessions are shown alongside the local chat history.
+
+    ![Screenshot showing the Coding Agent Sessions Quick Pick.](https://code.visualstudio.com/assets/updates/1_103/coding-agent-sessions-quick-pick.png)
+
+This integration requires the latest GitHub Pull Request extension and a repository open that supports Copilot coding agent. For more information, see the new documentation on how to [use coding agent in VS Code](https://aka.ms/coding-agent-docs).
+
+_Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
+
+## Extension Authoring
+
+### Terminal activation events
+
+Two new activation events are available for extensions:
+
+* `onTerminal`: Triggered when any terminal is opened.
+* `onTerminalShellIntegration`: Triggered when rich shell integration is activated for a terminal.
+
+You can specify a `shellType` to target specific shells. For example, `onTerminalShellIntegration:bash` activates when shell integration is enabled for a Bash terminal.
+
+## Proposed APIs
+
+### Render custom webviews in chat responses
+
+The Chat Output Renderer API lets extensions take chat responses beyond text and images. With it, your extension can use a [webview](https://code.visualstudio.com/api/extension-capabilities/extending-workbench) to render arbitrary HTML content in the chat output. Example use cases include custom visualizations, inline previews, and even interactive controls.
+
+The [Chat Output Renderer extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-output-renderer-sample) shows how this API can be used to render [Mermaid diagrams](http://mermaid.js.org) in chat responses. Here's an example of this extension sample in action:
+
+![Screenshot showing a mermaid diagram in a chat response.](https://code.visualstudio.com/assets/updates/1_103/chat-output-1.png)
+
+The neat thing is not that VS Code can render Mermaid diagrams, but that this rendering can be contributed entirely by extensions. With it, you can iterate on the custom outputs in chat:
+
+![Screenshot asking chat to generate a modified version of the first diagram.](https://code.visualstudio.com/assets/updates/1_103/chat-output-2.png)
+
+Here's a quick run down of how the API works:
+
+1. Register a language model tool that can return custom data as part of its response. We use a mime type to identify this data.
+1. Register a chat output renderer for this mime type.
+1. When a language model calls the tool, invoke the chat output renderer to render it into a webview in the response.
+
+Check out the [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-output-renderer-sample) for a full end-to-end example of this API in action.
+
+This API has the potential to be very powerful and enable some amazing new chat experiences, so give it a try and let us know what you think!
+
+### Chat Session Provider API
+
+The new Chat Session Provider API proposal enables extensions to integrate their own chat backend into VS Code's native chat UI. Using it, your extension can open a new chat session, populate the history for that session, and respond to new user prompts.
+
+This API is still in early stages and is likely to change. However we're already using it to power the new [GitHub coding agent session flow](#chat-sessions-experimental), which loads chats from GitHub and allows you to chat with an agent that is controlled entirely by GitHub.
+
+### Task execution terminal
+
+Extension authors can now access the terminal associated with a running task via the new `taskExecution.terminal` property. This makes it easier to identify which terminal is linked to a specific task and interact with it programmatically.
+
+### SecretStorage `keys()` API
+
+If you have ever wanted to get the list of keys that your extension has stored in `SecretStorage`, you can now do so with the new proposed `keys()` API:
+
+```ts
+export async function activate(context: ExtensionContext) {
+    await context.secrets.store('mySecret', 'superSecretValue');
+    await context.secrets.store('mySecret2', 'superSecretValue2');
+    const keys = await context.secrets.keys();
+    console.log('All secret keys:', keys); // returns ['mySecret', 'mySecret2']
+}
+```
+
+> **NOTE**: This change is dependent on a change to anything that provides an alternative implementation of a Secret Storage, notably <https://vscode.dev>, which has adopted the new API, and <https://github.dev>, which will adopt the new API soon. In an environment where it is not supported, this API will throw an exception.
+
+## Engineering
+
+### packages.microsoft.com key update
+
+`packages.microsoft.com` has updated their signing key and as a result, Linux users on newer distributions should stop seeing key-related warnings or errors while installing VS Code. Debian-based distributions automatically receive the new key, whereas users on other distributions may have to manually remove the old key before [importing the new key](https://code.visualstudio.com/docs/setup/linux#_install-vs-code-on-linux).
+
+### Electron 37 update
+
+In this milestone, we are promoting the Electron 37 update to users on our Stable release. This update comes with Chromium 138.0.7204.100 and Node.js 22.17.0. We want to thank everyone who self-hosted on Insiders builds and provided early feedback.
+
+## Notable fixes
+
+* [vscode#252384](https://github.com/microsoft/vscode/issues/252384) - Agent Mode pauses when VS Code loses focus
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+
+### Pull Requests
+
+Contributions to `vscode`:
+
+* [@adityavc (Aditya Chittari)](https://github.com/adityavc): #134898 - trimming whitespace when deleting new line character [PR #210870](https://github.com/microsoft/vscode/pull/210870)
+* [@adrianstephens](https://github.com/adrianstephens): Add debug/watch/context to list of valid menu extension points [PR #237751](https://github.com/microsoft/vscode/pull/237751)
+* [@andy0130tw (Andy Pan)](https://github.com/andy0130tw): Support the locale argument of TypeScript language server on the web version (#256252) [PR #256256](https://github.com/microsoft/vscode/pull/256256)
+* [@Benimautner](https://github.com/Benimautner): Add inertial scrolling to scrollable elements [PR #244034](https://github.com/microsoft/vscode/pull/244034)
+* [@BlackHole1 (Kevin Cui)](https://github.com/BlackHole1): fix: cannot display MAKR Underlined in minimap [PR #226116](https://github.com/microsoft/vscode/pull/226116)
+* [@bytemain (Jiacheng)](https://github.com/bytemain): refactor(terminal): introduce ITerminalLaunchResult interface [PR #256284](https://github.com/microsoft/vscode/pull/256284)
+* [@c-claeys (Cristopher Claeys)](https://github.com/c-claeys): Make ServicesAccessor typing more consistent in editor commands [PR #218369](https://github.com/microsoft/vscode/pull/218369)
+* [@CookieeQuinn (Quinn)](https://github.com/CookieeQuinn): Fix issue #212484: caretRangeFromPoint was not working when invoked over text which used user-select: none. [PR #219819](https://github.com/microsoft/vscode/pull/219819)
+* [@CrazySteve0605 (Wang Chong)](https://github.com/CrazySteve0605): fix(gettingStarted): remove duplicated "can be" in hover description [PR #254412](https://github.com/microsoft/vscode/pull/254412)
+* [@dbreen (Dan Breen)](https://github.com/dbreen): Use a saner default scrollbar width for the Explorer [PR #199784](https://github.com/microsoft/vscode/pull/199784)
+* [@devlinjunker](https://github.com/devlinjunker): Expose undo/redo and canUndo/canRedo methods on model API [PR #213954](https://github.com/microsoft/vscode/pull/213954)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): Enable angle bracket colorization for C# [PR #247665](https://github.com/microsoft/vscode/pull/247665)
+* [@duncpro (Duncan)](https://github.com/duncpro): Vertical pipe characters should terminate URLs [PR #232460](https://github.com/microsoft/vscode/pull/232460)
+* [@dylanchu](https://github.com/dylanchu): TerminalTaskSystem: Fix addtion arguments for string command [PR #251201](https://github.com/microsoft/vscode/pull/251201)
+* [@estrizhok (Eugene Strizhok)](https://github.com/estrizhok): Correct capitalization of 'JetBrains' and 'ReSharper' in settings UI [PR #254472](https://github.com/microsoft/vscode/pull/254472)
+* [@firelizzard18 (Ethan Reesor)](https://github.com/firelizzard18): Context key `availableEditorIds` for diff editors [PR #250198](https://github.com/microsoft/vscode/pull/250198)
+* [@futurist (James Yang)](https://github.com/futurist): fix(terminal): getBufferReverseIterator bug after scrollback limit reached [PR #257311](https://github.com/microsoft/vscode/pull/257311)
+* [@g0t4 (Wes Higbee)](https://github.com/g0t4): Add editor option to allow selection highlighting of multiline selections and another option to control max length [PR #228982](https://github.com/microsoft/vscode/pull/228982)
+* [@gabrielcsapo (Gabriel Csapo)](https://github.com/gabrielcsapo): feat: adds (requestTime) logLevel to match tsserver options [PR #250778](https://github.com/microsoft/vscode/pull/250778)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+  * Add `SecretStorage.keys()` as proposed API [PR #252804](https://github.com/microsoft/vscode/pull/252804)
+  * Fix an `@param` typo [PR #257219](https://github.com/microsoft/vscode/pull/257219)
+* [@hickford (M Hickford)](https://github.com/hickford): Add editor action 'reverse lines' [PR #242926](https://github.com/microsoft/vscode/pull/242926)
+* [@HolgerJeromin (Holger Jeromin)](https://github.com/HolgerJeromin): vscode api: Raise compatibility to webview content [PR #253635](https://github.com/microsoft/vscode/pull/253635)
+* [@iann0036 (Ian Mckay)](https://github.com/iann0036): fix: Typo in lm invokeTool description [PR #257975](https://github.com/microsoft/vscode/pull/257975)
+* [@jiahaoxiang2000 (isomo)](https://github.com/jiahaoxiang2000): Fix git.diff.stageHunk command to work with keyboard shortcuts [PR #254145](https://github.com/microsoft/vscode/pull/254145)
+* [@Jiogo18 (Jérôme Lécuyer)](https://github.com/Jiogo18): Git - l10n discard changes dialogs [PR #254366](https://github.com/microsoft/vscode/pull/254366)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen)
+  * [WIP] Add support for NuGet as an MCP package source (VS Code) [PR #254678](https://github.com/microsoft/vscode/pull/254678)
+  * Add experiment flag around NuGet MCP assisted config [PR #257463](https://github.com/microsoft/vscode/pull/257463)
+* [@Jose-AE](https://github.com/Jose-AE): Fix Jittery editor mouse wheel zoom when setting window.zoomLevel = 1 [PR #227916](https://github.com/microsoft/vscode/pull/227916)
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): fix: make chat input placeholder less cryptic [PR #255601](https://github.com/microsoft/vscode/pull/255601)
+* [@justin39 (Justin Wang)](https://github.com/justin39)
+  * Add commit_id option to ServeWebArgs for specific client version [PR #255494](https://github.com/microsoft/vscode/pull/255494)
+  * Fix --commit-id flag for code serve-web [PR #258904](https://github.com/microsoft/vscode/pull/258904)
+* [@jwangxx (James Wang)](https://github.com/jwangxx): Add the ability to clear a ChatResponseStream, passing in a reason which results in a warning being displayed [PR #257271](https://github.com/microsoft/vscode/pull/257271)
+* [@Kaidesuyoo (Kaidesuyo)](https://github.com/Kaidesuyoo): fix: Incorrect webWorkerExtensionHost startup process on vscode desktop [PR #234505](https://github.com/microsoft/vscode/pull/234505)
+* [@madskristensen (Mads Kristensen)](https://github.com/madskristensen): Updated references to schemastore.org [PR #254690](https://github.com/microsoft/vscode/pull/254690)
+* [@martijnwalraven (Martijn Walraven)](https://github.com/martijnwalraven): Fix notebook inline values when using language provider [PR #254264](https://github.com/microsoft/vscode/pull/254264)
+* [@mortalYoung (野迂迂)](https://github.com/mortalYoung): feat: editor.minimap.autohide support scroll [PR #253868](https://github.com/microsoft/vscode/pull/253868)
+* [@neorth (Joakim Berglund)](https://github.com/neorth): CamelCase first word if not acronym [PR #229797](https://github.com/microsoft/vscode/pull/229797)
+* [@Ninglo (Ninglo)](https://github.com/Ninglo): Fix `editor.wordSegmenterLocales` configuration don't take effect in simpleWidget editors (like chat or SCM input Editor) [PR #223921](https://github.com/microsoft/vscode/pull/223921)
+* [@OfekShilon (Ofek)](https://github.com/OfekShilon): Fix #4775: Escape user code before incorporating in a regex [PR #236809](https://github.com/microsoft/vscode/pull/236809)
+* [@omar-cs (Omar Carrizales)](https://github.com/omar-cs): Issue #168531: Cursor Height [PR #211473](https://github.com/microsoft/vscode/pull/211473)
+* [@Q1CHENL (Qichen Liu 刘启辰)](https://github.com/Q1CHENL): Fix: prevent view shift when enable minimap with right-click on the scrollbar [PR #210510](https://github.com/microsoft/vscode/pull/210510)
+* [@qirong77](https://github.com/qirong77): Fix the unexpected console error that occurs when updating the shadow dom selection in monaco-editor [PR #215780](https://github.com/microsoft/vscode/pull/215780)
+* [@raffaeu (Raffaele Garofalo)](https://github.com/raffaeu): Feature/move editor menu [PR #247818](https://github.com/microsoft/vscode/pull/247818)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): Fix empty end bracket error [PR #240609](https://github.com/microsoft/vscode/pull/240609)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
+  * Add *.tsbuildinfo to .gitignore [PR #254225](https://github.com/microsoft/vscode/pull/254225)
+  * Add RTL support based on decorations [PR #255455](https://github.com/microsoft/vscode/pull/255455)
+* [@rfon6ngy (Griffon Langyer)](https://github.com/rfon6ngy): Allow \n to trigger a softwrap [PR #231120](https://github.com/microsoft/vscode/pull/231120)
+* [@Rishi-infy47 (Saptarshi Chakraborty)](https://github.com/Rishi-infy47): fix: changed the node js version for devcontainer [PR #257400](https://github.com/microsoft/vscode/pull/257400)
+* [@sahin52 (Sahin Kasap)](https://github.com/sahin52): fix: Quick search does not retain search term [PR #234368](https://github.com/microsoft/vscode/pull/234368)
+* [@Schpoone (Jason Kuo)](https://github.com/Schpoone)
+  * Use preserveFocus when focusing stack frames [PR #251964](https://github.com/microsoft/vscode/pull/251964)
+  * Fix popup message when hovering over an instruction breakpoint [PR #254925](https://github.com/microsoft/vscode/pull/254925)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
+  * fix: memory leak in extension features tab [PR #256887](https://github.com/microsoft/vscode/pull/256887)
+  * fix: memory leak in editor edit context [PR #256957](https://github.com/microsoft/vscode/pull/256957)
+  * fix: set edit context to undefined in dispose [PR #256965](https://github.com/microsoft/vscode/pull/256965)
+  * fix: memory leak in ChatInputPart [PR #257082](https://github.com/microsoft/vscode/pull/257082)
+  * fix: memory leak in context key [PR #258206](https://github.com/microsoft/vscode/pull/258206)
+* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): Fix testFailure stringify [PR #258463](https://github.com/microsoft/vscode/pull/258463)
+* [@timheuer (Tim Heuer)](https://github.com/timheuer): Adds support for proper localhost loopback on RFC 6761 [PR #256617](https://github.com/microsoft/vscode/pull/256617)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1)
+  * [engineering] add testSplit option to unit-test runner [PR #253049](https://github.com/microsoft/vscode/pull/253049)
+  * [dev] shortcut to open devtools attached to exthost [PR #253139](https://github.com/microsoft/vscode/pull/253139)
+  * [engineering] ensure typescript integration tests emit junit reports [PR #253528](https://github.com/microsoft/vscode/pull/253528)
+  * [engineering] add label to packageTask [PR #253779](https://github.com/microsoft/vscode/pull/253779)
+  * [engineering] parallelize unzip in product-build-darwin-universal.yml [PR #257775](https://github.com/microsoft/vscode/pull/257775)
+* [@ttttotem (ttttotem)](https://github.com/ttttotem): Horizontal dragging auto-scroll [PR #235174](https://github.com/microsoft/vscode/pull/235174)
+* [@turansky (Victor Turansky)](https://github.com/turansky): fix: `EvaluatableExpression` properties jsdoc [PR #257930](https://github.com/microsoft/vscode/pull/257930)
+* [@yamachu (Yusuke Yamada)](https://github.com/yamachu)
+  * Fix invalid settings keys [PR #254609](https://github.com/microsoft/vscode/pull/254609)
+  * Revert "refactor: remove redundant actionRunner override in ChatEditorOverlayWidget" [PR #255456](https://github.com/microsoft/vscode/pull/255456)
+* [@yutotnh (yutotnh)](https://github.com/yutotnh): Fix the editor.wordSegmenterLocales description in the settings [PR #210305](https://github.com/microsoft/vscode/pull/210305)
+
+Contributions to `vscode-codicons`:
+
+* [@desean1625 (Sean Sullivan)](https://github.com/desean1625): Add link in readme to where you can easily preview and search for icons. [PR #295](https://github.com/microsoft/vscode-codicons/pull/295)
+
+Contributions to `vscode-copilot-chat`:
+
+* [@24anisha](https://github.com/24anisha)
+  * Add microsoft internal telemetry [PR #341](https://github.com/microsoft/vscode-copilot-chat/pull/341)
+  * Internal telemetry fixes -- conversation id and message id [PR #369](https://github.com/microsoft/vscode-copilot-chat/pull/369)
+* [@danilofalcao (Danilo Falcão)](https://github.com/danilofalcao): list all openrouter models without category but tools support [PR #208](https://github.com/microsoft/vscode-copilot-chat/pull/208)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): Remove unused fields from Completion response interface [PR #123](https://github.com/microsoft/vscode-copilot-chat/pull/123)
+* [@johnmog (John Mogensen)](https://github.com/johnmog): Git LFS instructions to CONTRIBUTING.md [PR #156](https://github.com/microsoft/vscode-copilot-chat/pull/156)
+* [@jwangxx (James Wang)](https://github.com/jwangxx): When rendering the prompts, exclude turns from the history that errored due to prompt filtration [PR #399](https://github.com/microsoft/vscode-copilot-chat/pull/399)
+* [@shsuman (Shantnu Suman)](https://github.com/shsuman): Print Error literal at the start of all error messages for better parsing from the logs [PR #260](https://github.com/microsoft/vscode-copilot-chat/pull/260)
+* [@srilovesflutter (Sri)](https://github.com/srilovesflutter): corrected typo [PR #129](https://github.com/microsoft/vscode-copilot-chat/pull/129)
+* [@trycatchkamal (Kamal Raj Sekar)](https://github.com/trycatchkamal): Removed unused code from tests [PR #207](https://github.com/microsoft/vscode-copilot-chat/pull/207)
+* [@vritant24 (Vritant Bhardwaj)](https://github.com/vritant24)
+  * Add ability to specify models through config for simulation tests [PR #324](https://github.com/microsoft/vscode-copilot-chat/pull/324)
+  * Add azure open ai support to simulator model config [PR #346](https://github.com/microsoft/vscode-copilot-chat/pull/346)
+
+Contributions to `vscode-eslint`:
+
+* [@noritaka1166 (Noritaka Kobayashi)](https://github.com/noritaka1166): chore: fix typo in comment-out [PR #2031](https://github.com/microsoft/vscode-eslint/pull/2031)
+
+Contributions to `vscode-js-debug`:
+
+* [@pilaoda (pilaoda)](https://github.com/pilaoda)
+  * fix watch panel custom string representation. #2252 [PR #2253](https://github.com/microsoft/vscode-js-debug/pull/2253)
+  * fix toString not work in Local Variables panel until all variables defined in scope #2254 [PR #2255](https://github.com/microsoft/vscode-js-debug/pull/2255)
+
+Contributions to `vscode-json-languageservice`:
+
+* [@fengzilong (MO)](https://github.com/fengzilong): feat: allow format range to be undefined [PR #272](https://github.com/microsoft/vscode-json-languageservice/pull/272)
+
+Contributions to `vscode-vsce`:
+
+* [@Adjective-Object (Max)](https://github.com/Adjective-Object): add `commonjs` annotation to package.json [PR #1179](https://github.com/microsoft/vscode-vsce/pull/1179)
+
+Contributions to `debug-adapter-protocol`:
+
+* [@osiewicz (Piotr Osiewicz)](https://github.com/osiewicz): chore: Add Zed to the list of tools supporting DAP [PR #548](https://github.com/microsoft/debug-adapter-protocol/pull/548)
+
+Contributions to `language-server-protocol`:
+
+* [@Leonidas-from-XIV (Marek Kubica)](https://github.com/Leonidas-from-XIV): ocaml-language-server does not exist anymore [PR #2165](https://github.com/microsoft/language-server-protocol/pull/2165)
+* [@osiewicz (Piotr Osiewicz)](https://github.com/osiewicz): chore: Add Zed to the list of implementors [PR #2164](https://github.com/microsoft/language-server-protocol/pull/2164)
+
+Contributions to `python-environment-tools`:
+
+* [@renan-r-santos (Renan Santos)](https://github.com/renan-r-santos): Exclude Pixi environments from the Conda locator [PR #234](https://github.com/microsoft/python-environment-tools/pull/234)
+
+
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_103.md
     - release-notes/v1_102.md
     - release-notes/v1_101.md
     - release-notes/v1_100.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/fed8607c403b3f8a3f8f53b8032a2eb2a62b817c

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_103.md https://github.com/microsoft/vscode-docs/raw/fed8607c403b3f8a3f8f53b8032a2eb2a62b817c/release-notes/v1_103.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Edits)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edits)
   ```
   Please edit working files. Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```