### PR TITLE
Translate August 2025 (version 1.104)

### DIFF
--- a/docs/release-notes/v1_104.md
+++ b/docs/release-notes/v1_104.md
@@ -1,0 +1,837 @@
+---
+Order: 113
+TOCTitle: August 2025
+PageTitle: Visual Studio Code August 2025
+MetaDescription: Learn what is new in the Visual Studio Code August 2025 Release (1.104)
+MetaSocialImage: 1_104/release-highlights.png
+Date: 2025-09-11
+DownloadVersion: 1.104.1
+---
+# August 2025 (version 1.104)
+
+_Release date: September 11, 2025_
+
+**Update 1.104.1**: The update addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22August+2025+Recovery+1%22+).
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the August 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+<table class="highlights-table">
+  <tr>
+    <th>Model flexibility</th>
+    <th>Security</th>
+    <th>Productivity</th>
+  </tr>
+  <tr>
+    <td>Let VS Code select the best model <a href="#auto-model-selection-preview"><br>Show more</a></td>
+    <td>Confirm edits for sensitive files <a href="#confirm-edits-to-sensitive-files"><br>Show more</a></td>
+    <td>Remove distractions from chat file edits <a href="#improved-changed-files-experience"><br>Show more</a></td>
+  </tr>
+  <tr>
+    <td>Contribute models through VS Code extensions <a href="#language-model-chat-provider-api"><br>Show more</a></td>
+    <td>Let agents run terminal commands safely <a href="#terminal-auto-approve"><br>Show more</a></td>
+    <td>Use AGENTS.md to add chat context <a href="#support-for-agentsmd-files-experimental"><br>Show more</a></td>
+  </tr>
+</table>
+
+<br>
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+
+> **Insiders: Want to try new features as soon as possible?**<br>
+> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> [Download Insiders](https://code.visualstudio.com/insiders)<br>
+
+<!-- TOC
+<div class="toc-nav-layout">
+  <nav id="toc-nav">
+    <div>In this update</div>
+    <ul>
+      <li><a href="#chat">Chat</a></li>
+      <li><a href="#mcp">MCP</a></li>
+      <li><a href="#accessibility">Accessibility</a></li>
+      <li><a href="#code-editing">Code Editing</a></li>
+      <li><a href="#editor-experience">Editor Experience</a></li>
+      <li><a href="#notebooks">Notebooks</a></li>
+      <li><a href="#source-control">Source Control</a></li>
+      <li><a href="#terminal">Terminal</a></li>
+      <li><a href="#languages">Languages</a></li>
+      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
+      <li><a href="#extension-authoring">Extension Authoring</a></li>
+      <li><a href="#proposed-apis">Proposed APIs</a></li>
+      <li><a href="#engineering">Engineering</a></li>
+      <li><a href="#notable-fixes">Notable fixes</a></li>
+      <li><a href="#thank-you">Thank you</a></li>
+    </ul>
+  </nav>
+  <div class="notes-main">
+Navigation End -->
+
+## Chat
+
+### Auto model selection (Preview)
+
+This iteration, we're introducing auto model selection in chat. When you choose the **Auto** model in the model picker, VS Code automatically selects a model to ensure that you get the optimal performance and reduce rate limits.
+
+Auto model selection is currently in preview and we are rolling it out to all GitHub Copilot users in VS Code in the following weeks, starting with the individual Copilot plans.
+
+![Screenshot that shows the model picker in the Chat view, showing the Auto option.](images/1_104/model-dropdown-auto.png)
+
+Auto will choose between Claude Sonnet 4, GPT-5, GPT-5 mini, and GPT-4.1, unless your organization has disabled access to these models. When using auto model selection, VS Code uses a variable model multiplier, based on the selected model. If you are a paid user, auto will apply a 10% request discount.
+
+You can view the selected model and the model multiplier by hovering over the response in the Chat view.
+
+![Screenshot of a chat response, showing the selected model on hover.](images/1_104/auto-model-multiplier.png)
+
+Learn more about [auto model selection in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
+
+### Confirm edits to sensitive files
+
+**Setting**: `setting(chat.tools.edits.autoApprove)`
+
+In agent mode, the agent can autonomously make edits to files in your workspace. This might include accidentally or maliciously modifying or deleting important files such as configuration files, which could cause immediate negative side-effects on your machine. Learn more about [security considerations when using AI-powered development tools](https://code.visualstudio.com/docs/copilot/security).
+
+In this release, the agent now explicitly asks for user confirmation before making edits to certain files. This provides an additional layer of safety when using agent mode. With the `setting(chat.tools.edits.autoApprove)` setting, you can configure file patterns to indicate which files require confirmation.
+
+Common system folders, dotfiles, and files outside your workspace will require confirmation by default.
+
+![Screenshot showing the confirmation dialog for sensitive file edits in the Chat view.](images/1_104/chat-edit-sensitive-file.png)
+
+### Support for AGENTS.md files (Experimental)
+
+**Setting**: `setting(chat.useAgentsMdFile)`
+
+An `AGENTS.md` file lets you provide context and instructions to the agent. Starting from this release, when you have an `AGENTS.md` file in your workspace root(s), it is automatically picked up as context for chat requests. This can be useful for teams that use multiple AI agents.
+
+Support for `AGENTS.md` files is enabled by default and can be controlled with the `setting(chat.useAgentsMdFile)` setting. See <https://agents.md/> for more information about `AGENTS.md` files.
+
+Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) to your practices and team workflows.
+
+### Improved changed files experience
+
+This iteration, the changed files list has been reworked with several quality-of-life features. These changes should improve your experience when working in agent mode!
+
+* The list of changed files is now collapsed by default to give more space to the chat conversation. While collapsed, you can still see the files changed count and the lines added or removed.
+
+* When you keep or accept a suggested change, the file is removed from the files changed list.
+
+* When you stage or commit a file using the Source Control view, this automatically accepts the proposed file changes.
+
+* Changes _per file_ (lines added or removed) are now shown for each item in the list.
+
+<video src="images/1_104/changed-files-list.mp4" title="Video uncollapsing the changed files list and accepting file entries to remove them from the list." autoplay loop controls muted></video>
+
+### Use custom chat modes in prompt files
+
+Prompt files are Markdown files in which you write reusable chat prompts. To run a prompt file, type `/` followed by the prompt file name in the chat input field, or use the Play button when you have the prompt file open in the editor.
+
+You can specify which chat mode should be used for running the prompt file. Previously, you could only use built-in chat modes like `agent`, `edit`, or `ask` in your prompt files. Now, you can also reference custom chat modes in your prompt files.
+
+![Screenshot showing IntelliSense for custom chat modes in prompt files.](images/1_104/custom_modes_in_prompt_files.png)
+
+Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) with prompt files, chat modes, and custom instructions.
+
+### Configure prompt file suggestions (Experimental)
+
+**Setting**: `setting(chat.promptFilesRecommendations)`
+
+Teams often create custom prompt files to standardize AI workflows, but these prompts can be hard to discover when users need them most. You can now configure which prompt files appear as suggestions in the Chat welcome view based on contextual conditions.
+
+The new `setting(chat.promptFilesRecommendations)` setting supports both simple boolean values and when-clause expressions for context-aware suggestions.
+
+```jsonc
+{
+  "chat.promptFilesRecommendations": {
+    "plan": true,                            // Always suggest
+    "a11y-audit": "resourceExtname == .html", // Only for HTML files
+    "document": "resourceLangId == markdown", // Only for Markdown files
+    "debug": false                           // Never suggest
+  }
+}
+```
+
+This helps teams surface the right AI workflows at the right time, making custom prompts more discoverable and relevant to your workspace and file type.
+
+### Select tools in tool sets
+
+[Tool sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) are a convenient way to group related tools together and VS Code has several built-in tool sets like `edit` or `search`.
+
+The tools picker now shows which tools are part of each tool set and you can individually enable or disable each tool. You can access the tools picker via the `Configure Tools...` button in the Chat view.
+
+![Screenshot showing the tools picker with an expanded edit tool set, listing all available tools.](images/1_104/tools_in_toolsets.png)
+
+### Configure font used in chat
+
+**Settings**: `setting(chat.fontFamily)`, `setting(chat.fontSize)`
+
+VS Code lets you choose which font to use across the editor, however the Chat view lacked that configurability. We have now added two new settings for configuring the font family (`setting(chat.fontFamily)`) and font size (`setting(chat.fontSize)`) of chat messages.
+
+![Screenshot showing the Chat view with a custom font and font size.](images/1_104/chat-configure-font.png)
+
+> **Note**: content for lists currently does not yet honor these settings, but this is something that we are working on fixing in the upcoming releases.
+
+### Collaborate with coding agents (Experimental)
+
+With coding agents, you delegate tasks to AI agents to be worked on in the background. You can have multiple such agents work in parallel. We're continuing to evolve the chat sessions experience to help you collaborate more effectively with coding agents.
+
+#### Chat Sessions view
+
+**Setting**: `setting(chat.agentSessionsViewLocation)`
+
+The Chat Sessions view provides a single, unified view for managing both local and contributed chat sessions. We've significantly enhanced the Chat Sessions view where you can now perform all key operations, making it easier to iterate and finalize your coding tasks.
+
+* **Status Bar tracking**: Monitor progress across multiple coding agents directly from the Status Bar.
+* **Multi-session support**: Launch and manage multiple chat sessions from the same view.
+* **Expanded context menus**: Access more actions to interact with your coding agents efficiently.
+* **Rich descriptions**: With rich description enabled, each list entry now includes detailed context to help you quickly find relevant information.
+
+#### GitHub coding agent integration
+
+We've improved the integration of [GitHub coding agents](https://code.visualstudio.com/docs/copilot/copilot-coding-agent) with chat sessions to deliver a smoother, more intuitive experience.
+
+* **Chat editor actions**: Easily view or apply code changes, and check out pull requests directly from the chat editor.
+* **Seamless transitions**: Move from local chats to GitHub agent tasks with improved continuity.
+* **Better session rendering**: Various improvements on cards and tools rendering for better visual clarity.
+* **Performance boosts**: Faster session loading for a more responsive experience.
+
+<video src="images/1_104/chat-sessions-view.mp4" title="Video showing Chat Sessions view and integration with GitHub coding agents." autoplay loop controls muted></video>
+
+#### Delegate to coding agent
+
+We continued to expand on ways to delegate local tasks in VS Code to a Copilot coding agent:
+
+* Fix todos with coding agent:
+
+    Comments starting with `TODO` now show a Code Action to quickly initiate a coding agent session.
+
+    ![Screenshot of a code action above a TODO comment called Delegate to coding agent.](images/1_104/coding-agent-todo.png)
+
+* Delegate from chat (`setting(githubPullRequests.codingAgent.uiIntegration)`):
+
+    Additional context, including file references, are now forwarded to GitHub coding agent when you perform the **Delegate to coding agent** action in chat. This enables you to precisely plan out a task before handing it off to coding agent to complete it. A new chat editor is opened with the coding agent's progress shown in real-time.
+
+    <video src="images/1_104/delegate-to-coding-agent.mp4" title="Delegating a task from sidebar chat to coding agent" autoplay loop controls muted></video>
+
+_Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
+
+
+### Social sign in with Google
+
+The option to sign in or sign up to GitHub Copilot with a Google account is now generally available and rolling out to all users in VS Code.
+
+![Screenshot showing the sign in dialog showing the option to use a Google account.](images/1_104/google.png)
+
+You can find more information about this in the [announcement GitHub blog post](https://github.blog/changelog/2025-07-15-social-login-with-google-is-now-generally-available).
+
+### Terminal auto approve
+
+**Setting**: `setting(chat.tools.terminal.enableAutoApprove)`
+
+Automatically approving terminal commands can greatly streamline agent interactions, but it also comes with [security risks](https://code.visualstudio.com/docs/copilot/security). This release introduces several improvements to terminal auto approve to enhance both usability and security.
+
+* You can now enable or disable terminal auto approve with the `setting(chat.tools.terminal.enableAutoApprove)` setting. This setting can also be set by organizations via [device management](https://code.visualstudio.com/docs/setup/enterprise#_centrally-manage-vs-code-settings).
+
+* Before terminal auto approve is actually enabled, you need to explicitly opt in via a dropdown in the Chat view.
+
+    ![Screenshot of a terminal command in the Chat view, showing the Enable Auto Approve dropdown.](images/1_104/terminal-auto-approve-opt-in.png)
+
+* From the Chat view, you can conveniently add auto-approve rules for the command being run, or open the configuration setting:
+
+    ![Screenshot that shows the three standard options are presented for "foo --arg && bar".](images/1_104/terminal-auto-approve-ui.png)
+
+    _Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire))_
+
+    This has some basic support for commands to suggest sub-commands where they would be more appropriate, such as suggesting an `npm test` rule rather than `npm`.
+
+* To improve transparency around auto-approved commands, we show which rule was applied in the Chat view, also enabling you to configure that rule:
+
+    ![Screenshot showing the new links added under the tool call in the Chat view for adding new auto approve rules.](images/1_104/terminal-auto-approve-new-links.png)
+
+* We improved the defaults to provide safety and reduce noise. You can see the full list of rules by viewing the setting's default value by opening your `settings.json` file, then entering `chat.tools.terminal.autoApprove` and completing it via `kbstyle(Tab)`.
+
+* Non-regex rules that contain a backslash or forward slash character are now treated as a path and not only approve that exact path, but also allow either slash type and also a `./` prefix. When using PowerShell, all rules are forced to be case insensitive.
+
+* When agent mode wants to pull content from the internet using `curl`, `wget`, `Invoke-RestMethod`, or `Invoke-WebRequest`, we now show a warning, as this is a common vector for prompt injection attacks.
+
+Learn more about [terminal auto approve](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands) in our documentation.
+
+### Global auto approve
+
+Global auto approve has been [an experimental setting since v1.99](https://code.visualstudio.com/updates/v1_99#_agent-mode-tool-approvals). What we have observed is that users have been enabling this setting without thinking deeply enough about the consequences. Additionally, some users thought that enabling the `setting(chat.tools.autoApprove)` setting was a prerequisite to enabling terminal auto approve, which was never the case.
+
+To combat these misconceptions and to further protect our users, there is now a deservedly scary-looking warning the first time global auto approve attempts to be used, so the user can easily back out and disable the setting:
+
+![Screenshot of a warning dialog that appears when global auto approve is used for the first time.](images/1_104/global-auto-approve-warning.png)
+
+The setting has also been changed to the clearer `setting(chat.tools.global.autoApprove)` without any automatic migration, so all users (accidental or intentional) need to go and explicitly set it again.
+
+### Math rendering enabled by default
+
+**Setting**: `setting(chat.math.enabled)`
+
+Rendering of mathematical equations in chat responses is now generally available and enabled by default. You can disable this functionality with the `setting(chat.math.enabled)` setting.
+
+![Screenshot of the Chat view, showing inline and block equations in a chat response.](images/1_104/chat-math.png)
+
+This feature is powered by [KaTeX](https://katex.org) and supports both inline and block math equations. Inline math equations can be written by wrapping the markup in single dollar signs (`$...$`), while block math equations use two dollar signs (`$$...$$`).
+
+### Chat view default visibility
+
+**Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
+
+When you first open a workspace, the Secondary Side Bar with the Chat view is visible by default, inviting you to ask questions or start an agentic session right away. You can configure this behavior with the `setting(workbench.secondarySideBar.defaultVisibility)` setting or by using the dropdown of the Chat view itself:
+
+![Screenshot showing Chat view menu with the option to set the default Secondary Side Bar visibility.](images/1_104/auxview.png)
+
+### Improved task support
+
+* Input request detection
+
+    When you run a task or terminal command in agent mode, the agent now detects when the process requests user input, and you're prompted to respond in chat. If you type in the terminal while a prompt is present, the prompt will hide automatically. When options and descriptions are provided (such as `[Y] Yes [N] No`), these are surfaced in the confirmation prompt.
+
+    <video src="images/1_104/prompt-input-demo.mp4" title="Example of input being detected and responded to" autoplay loop controls muted></video>
+
+* Error detection for tasks with problem matchers
+
+    For tasks that use problem matchers, the agent now collects and surfaces errors based on the problem matcher results, rather than relying on the language model to evaluate output. Problems are presented in a dropdown within the chat progress message, allowing you to navigate directly to the problem location. This ensures that errors are reported only when relevant to the current task execution.
+
+* Compound task support
+
+    Agent mode now supports running compound tasks. When you run a compound task, the agent indicates progress and output for each dependent task, including any prompts for user input. This enables more complex workflows and better visibility into multi-step task execution.
+
+    In the example below, the VS Code - Build task is run. Output is assessed for each dependency task and a problem is surfaced to the user in the response and in the progress message dropdown.
+
+    <video src="images/1_104/build-task.mp4" title="Example of agent running the VS Code - Build task" autoplay loop controls muted></video>
+
+### Improved terminal support
+
+* Moved more terminal tools to core
+
+    Like [the `runInTerminal` tool last release](https://code.visualstudio.com/updates/v1_103#_improved-reliability-and-performance-of-the-run-in-terminal-and-task-tools), the `terminalSelection` and `terminalLastCommand` tools have been moved from the extension to core, which should provide general reliability improvements.
+
+* Configurable terminal tool shell integration timeout
+
+    Whenever the `runInTerminal` tool tries to create a terminal, it waits a period for shell integration to activate. If your shell is especially slow to start up, say you have a very heavy PowerShell profile, this could cause it to wait the previously fixed 5-second timeout and still end up failing in the end. This timeout is now configurable via the `setting(chat.tools.terminal.shellIntegrationTimeout)` setting.
+
+* Prevent Command Prompt usage
+
+    Since shell integration isn't really possible in Command Prompt, at least with the capabilities that Copilot needs, Copilot now opts to use Windows PowerShell instead, which should have shell integration by default. This should improve the reliability of the `runInTerminal` tool when your default shell is Command Prompt.
+
+    If, for some reason, you want Copilot to use Command Prompt, this is currently not possible. We will likely be adding the ability to customize the terminal profile used by Copilot soon, which is tracked in [#253945](https://github.com/microsoft/vscode/issues/253945).
+
+### Todo List tool
+
+The todo list tool helps agents break down complex multi-step tasks into smaller tasks and report progress to help you track individual items. We've made improvements to this tool, which is now enabled by default.
+
+Tool progress is displayed in the Todo control at the top of the Chat view, which automatically collapses as the todo list is worked through and shows only the current task in progress.
+
+### Skip tool calls
+
+When the agent requests confirmation for a tool call, you can now choose to skip the tool call and let the agent continue. You can still cancel the request or enter a new request via the chat input box.
+
+### Improvements to semantic workspace search
+
+We've upgraded the `#codebase` tool to use a new [embeddings](https://en.wikipedia.org/wiki/Embedding_(machine_learning)) model for semantic searching for code in your workspace. This new model provides better results for code searches. The new embeddings also use less storage space, requiring only 6% of our previous model's on-disk storage size for each embedding.
+
+We'll be gradually rolling out this new embeddings model over the next few weeks. Your workspace will be automatically updated to use this new embeddings model, so no action is required. VS Code Insiders is already using the new model if you want to try it out before it rolls out to you.
+
+### Hide and disable GitHub Copilot AI features
+
+**Setting**: `setting(chat.disableAIFeatures)`
+
+We are introducing a new setting `setting(chat.disableAIFeatures)` for disabling and hiding built-in AI features provided by GitHub Copilot, including chat, code completions, and next edit suggestions.
+
+The setting has the following advantages over the previous solution we had in place:
+
+* Syncs across your devices unless you disable this explicitly
+* Disables the Copilot extensions in case they are installed
+* Configure the setting per-profile or per-workspace, making it easy to disable AI features selectively
+
+The command to "Hide AI Features" was renamed to reflect this change and will now reveal this new setting in the settings editor.
+
+> **Note**: users that were hiding AI features previously will continue to see AI features hidden. You can update the setting in addition if you want to synchronize your choice across devices.
+
+## MCP
+
+### Support for server instructions
+
+VS Code now reads MCP server instructions and will include them in its base prompt.
+
+### MCP auto discovery disabled by default
+
+**Setting**: `setting(chat.mcp.discovery.enabled)`
+
+VS Code supports [automatic discovery of MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) installed in other apps like Claude Code. As MCP support has matured in VS Code, auto-discovery is now disabled by default, but you can re-enable it using the `setting(chat.mcp.discovery.enabled)` setting.
+
+### Enable MCP
+
+**Setting**: `setting(chat.mcp.access)`
+
+The `chat.mcp.enabled` setting that previously controlled whether MCP servers could run in VS Code has been migrated to a new `setting(chat.mcp.access)` setting with more descriptive options:
+
+* `all`: allow all MCP servers to run (equivalent to the previous `true` value)
+* `none`: disable MCP support entirely (equivalent to the previous `false` value)
+
+## Accessibility
+
+### Focus chat confirmation action
+
+We've added a command, **Focus Chat Confirmation** `(kb(workbench.action.chat.focusConfirmation))`, which focuses the confirmation dialog, if present, or announces to screen reader users that confirmation is not required.
+
+## Code Editing
+
+### Configurable inline suggestion delay
+
+**Setting**: `setting(editor.inlineSuggest.minShowDelay)`
+
+A new setting `setting(editor.inlineSuggest.minShowDelay)` enables you to configure how quickly inline suggestions can appear after you type. This can be useful if you find that suggestions are appearing too quickly and getting in the way of your typing.
+
+## Editor Experience
+
+### Window border color support on Windows
+
+**Setting**: `setting(window.border)`
+
+We are happy to add a new setting `setting(window.border)` on Windows that enables you to show a colored border around the VS Code window. The setting has the following options:
+
+* `default`: respect color theme settings, fallback to Windows settings
+* `system`: respect Windows settings only (window title accent color)
+* `off`: disable border colors
+* `<color>`: specific color in Hex, RGB, RGBA, HSL, HSLA format
+
+You can configure colors per workspace, making it easier to distinguish which workspace is opened in which window.
+
+![Screenshot of several VS Code windows with different border colors.](images/1_104/border.png)
+
+When you configure `setting(window.border)` as `default`, a theme is able to set the border color for active and inactive windows using the `window.activeBorder` and `window.inactiveBorder` color keys. You can further override these colors from the `setting(workbench.colorCustomizations)` setting.
+
+### Manage extension account preference
+
+We've added an **Accounts: Manage Extension Account Preferences** command to the Command Palette. When invoked, it shows a list of extensions that have access to authentication accounts and lets you change the account that those extensions use. You are even able to sign in to a new account right from the list.
+
+This builds on the [account management functionality that we added a year ago](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference).
+
+### Editor tab index
+
+**Setting**: `setting(workbench.editor.showTabIndex)`
+
+You can now render the index of an editor tab in the tab's label. This can be helpful when you have many tabs open and want to quickly navigate between them using keyboard shortcuts. Enable this functionality with the `setting(workbench.editor.showTabIndex)` setting.
+
+![Screenshot of editor tabs with numbers in front of them, indicating their index.](images/1_104/editorTabIndex.png)
+
+### Editor tab bar scrollbar visibility
+
+**Setting**: `setting(workbench.editor.titleScrollbarVisibility)`
+
+The `setting(workbench.editor.titleScrollbarVisibility)` enables you to control when the scrollbar in the editor tab bar is visible. The default value `auto` shows the scrollbar only when the tabs overflow and a tab is hovered. You can also set it to `visible` to always show the scrollbar when the tabs overflow, or `hidden` to never show it.
+
+### Issue reporter improvements
+
+When reporting issues in VS Code or extensions via the built-in issue reporter, you can now choose either **Create on GitHub** or **Preview on GitHub** via a dropdown on the report button. If the button does not populate a dropdown and only shows Create or Preview, this likely means that you are still loading extension data or need to ensure that you are signed in with a GitHub account that provides the correct scopes.
+
+![Screenshot of a dropdown showing Create on Github and Preview on Github in the issue reporter.](images/1_104/issue-reporter-dropdown.png)
+
+## Notebooks
+
+### Improved NES suggestions (Experimental)
+
+**Setting**: `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)`
+
+We are experimenting with improving the quality of next edit suggestions for notebooks. Currently, the language model has access to the contents of the active cell when generating suggestions. With the `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)` setting enabled, the language model has access to the entire notebook, enabling it to generate more accurate and higher-quality next edit suggestions.
+
+## Source Control
+
+### Preview and migrate Git worktree changes
+
+You can now preview differences between worktree files and your current workspace by right-clicking on a worktree file to open the context menu in the Source Control Changes view and selecting **Compare with Workspace**.
+
+![Screenshot of the context menu shown in the SCM view on a changed file in a worktree, with the Compare with Workspace option selected.](images/1_104/image.png)
+
+After reviewing your changes, you can use the **Migrate Worktree Changes...** command from the Command Palette (`kb(git.migrateWorktreeChanges)`) to merge all changes from a worktree into your current workspace. This makes it easy to work across multiple worktrees and selectively bring changes back into your main repository.
+
+Learn more about [Git worktrees in VS Code](https://code.visualstudio.com/docs/sourcecontrol/overview#_worktrees).
+
+## Terminal
+
+### Terminal window discoverability and polish
+
+A common request is to allow terminals to be opened in separate windows. This functionality has existed for about one and a half years, but it has not been particularly discoverable. This iteration, we added multiple entry points for this functionality:
+
+* The new command `kb(workbench.action.terminal.newInNewWindow)`.
+* The empty editor and tab well menus now have a **New Terminal** entry.
+* The new terminal dropdown has been shuffled around and now has a **New Terminal Window** entry.
+* The top-level terminal menu now has a **New Terminal Window** entry.
+
+We also polished the experience where these new terminal windows open in compact mode. If you add a new tab to the window, it automatically exits compact mode.
+
+![Screenshot of the terminal window open in compact mode, hiding tabs to make more room for terminal content.](images/1_104/terminal-window.png)
+
+### Terminal actions in terminal editors
+
+The actions that are available in the terminal view (new terminal dropdown, clear terminal, etc.) are now also available for terminals in the editor area and terminal windows.
+
+![Screenshot of different terminal actions in the editor actions menu.](images/1_104/terminal-editor-actions.png)
+
+Just like in the terminal view, you can right-click the actions area to move them out of the overflow menu.
+
+### Terminal IntelliSense improvements (Preview)
+
+Terminal IntelliSense is getting several improvements this release:
+
+* Multiple performance improvements, these disproportionately affect the experience on Windows.
+* `git` completions are now more reliable on Windows due to the removal of the `sed` dependency, which isn't available on Windows.
+* `git` completions now have familiar icons to represent commits, branches, remotes, stashes, and tags.
+    ![Screenshot of new icons showing for tags and branches on completions for "git checkout"](images/1_104/terminal-suggest.png)
+* A large number of completion specs were added: `adb`, `basename`, `bundle`, `clear`, `cut`, `date`, `dd`, `diff`, `dig`, `dirname`, `docker-compose`, `docker`, `dotnet`, `env`, `export`, `fdisk`, `fmt`, `fold`, `gh`, `go`, `htop`, `id`, `jq`, `ln`, `lsblk`, `lsof`, `mount`, `nl`, `od`, `paste`, `ping`, `pkill`, `readlink`, `rsync`, `ruby`, `ruff`, `sed`, `seq`, `shred`, `sort`, `source`, `split`, `stat`, `su`, `sudo`, `tac`, `tar`, `tee`, `time`, `tr`, `traceroute`, `tree`, `truncate`, `uniq`, `unzip`, `wc`, `where`, `whereis`, `which`, `who`, `xargs`, `xxd`, `yo`, `zip`
+
+### Terminal sticky scroll improvements
+
+We have now enabled terminal sticky scroll by default. We have made several improvements for a better experience, such as improved behavior when using a pager. Terminal sticky scroll is now compatible with the `setting(editor.tabFocusMode)` setting.
+
+## Languages
+
+### JavaScript and TypeScript
+
+After reviewing usage numbers, we decided to remove our built-in `bower.json` IntelliSense. Bower has been [deprecated since 2017](https://bower.io/blog/2017/how-to-migrate-away-from-bower/) and our built-in support had little usage and was not being actively maintained.
+
+Bower recommends that users migrate to `npm` or `yarn`. Continued support for Bower in VS Code can be provided by extensions.
+
+### Python
+
+#### Python Environments extension support for Pipenv
+
+Pipenv environments can now be discovered and selected just like in the Python extension. In addition, they appear in the **Environment Manager** view in the Python sidebar, where they are grouped and displayed alongside your other environment types.
+
+![Screenshot showing the Python sidebar with Pipenv environments expanded.](images/1_104/pipenv-supported-screenshot.png)
+
+#### Configure environment variable injection
+
+A new setting, `setting(python.useEnvFile)`, controls whether environment variables from `.env` files and the `setting(python.envFile)` setting are injected into terminals when the Python Environments extension is enabled.
+
+#### Python Environments extension improvements
+
+The [Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) continued to receive bug fixes and improvements as part of the controlled roll-out to stable users. To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code `settings.json` file: `"python.useEnvironmentsExtension": true`.
+
+#### AI-powered hover summaries with Pylance (Experimental)
+
+A new experimental AI hover summaries feature is now available for Python when using the latest pre-release version of Pylance. When you enable the `setting(python.analysis.aiHoverSummaries)` setting, you can get helpful summaries on-the-fly for symbols that do not already have documentation. This makes it easier to understand unfamiliar code and boosts productivity as you explore Python projects. AI hover summaries are currently available to GitHub Copilot Pro, Pro+, and Enterprise users.
+
+<video src="images/1_104/pylance-hover-summaries.mp4" title="Video showing AI-powered hover summaries with Pylance." autoplay loop controls muted></video>
+
+We look forward to bringing this experimental experience to the stable extension version soon.
+
+#### Run code snippet tool
+
+Instead of relying on terminal commands like `python -c "code"` or creating temporary files to be executed, the Pylance run code snippets tool enables GitHub Copilot to execute Python snippets entirely in memory. It automatically uses the correct Python interpreter configured for your workspace, and it eliminates common issues with shell escaping and quoting that sometimes arise during terminal execution.
+
+One of the standout benefits is the clean, well-formatted output it provides, with both stdout and stderr interleaved for clarity. This makes it ideal when using agent mode with GitHub Copilot to test small blocks of code, run quick scripts, validate Python expressions, or check imports, all within the context of your workspace.
+
+To try it out, make sure to use the latest pre-release version of the Pylance extension. You can then select the `pylancerunCodeSnippet` tool via the **Add context...** > **Tools** menu in the Chat view.
+
+> **Note**: As with all AI-generated code, please make sure to inspect the generated code before allowing this tool to be executed. Reviewing the logic and intent of the code ensures it aligns with your project's goals and maintains safety and correctness.
+
+<video src="images/1_104/pylance-run-code-snippet.mp4" title="Code snippet generated and executed by GitHub Copilot in the Chat panel via the pylancerunCodeSnippet tool." autoplay loop controls muted></video>
+
+#### Pylance IntelliSense enabled in all Python documents
+
+The `python.analysis.supportAllPythonDocuments` setting has been removed from the latest Pylance pre-release version, with Pylance IntelliSense now being enabled by default in all Python documents, including terminal and diff views. This means you can get rich code completions, hover and code navigation wherever you work with Python in VS Code.
+
+#### Activation hooks
+
+Python activation hooks can now run from shell integration scripts, instead of requiring the Python environment extension to modify your shell profile. This provides more reliable terminal activation when `setting(python-envs.terminal.autoActivationType)` is set to `shellStartup` and, importantly, ensures Copilot terminals are activated as expected.
+
+## Contributions to extensions
+
+### GitHub Pull Requests
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+
+* Side Bar content collapses on narrow windows
+* Pull request and issue webviews restore after reload
+* The new "TODO" code action lets you delegate directly to the Copilot coding agent
+* Submodules can be ignored with `setting(githubPullRequests.ignoreSubmodules)`
+
+Review the [changelog for the 0.118.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01180) release of the extension to learn about everything in the release.
+
+## Extension Authoring
+
+### shellIntegrationNonce for extension launched terminals
+
+`shellIntegrationNonce` can now be passed to `createTerminal` in `TerminalOptions` and `ExtensionTerminalOptions`. This enables the extension to control the nonce, which is used to verify commands [in shell integration escape sequences](https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences).
+
+### Language Model Chat Provider API
+
+This iteration, we finalized the `LanguageModelChatProviders` API. This enables extensions to contribute one or more language models, cloud-hosted or local. By installing the extension, users can select these models through the model picker in chat.
+
+There are already multiple extensions that take advantage of this API to extend chat in VS Code with additional models, including [AI Toolkit for VS Code](https://aka.ms/AIToolkit), [Cerebras Inference](https://aka.ms/vscode/cerebras), and [Hugging Face](https://aka.ms/vscode/huggingface).
+
+You can learn more about how to utilize this API in our [Language Model Chat Provider extension guide](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider) or in our [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-model-provider-sample).
+
+> **Note**: Models provided through this API are currently only available to users on [individual GitHub Copilot plans](https://docs.github.com/en/copilot/concepts/billing/individual-plans).
+
+## Proposed APIs
+
+### Authentication: Supporting `WWW-Authenticate` challenges in `getSession`
+
+A well-established pattern of HTTP is that a request to an API can return a 401 Unauthorized status code with a [WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) header, which defines _auth challenges_. These are essentially things that the API needs in order to resolve past the 401.
+
+We have introduced a proposed API, which allows for the passing down and handling of these challenges to authentication providers. First off, from the calling side you can now pass in a challenge like so:
+
+```ts
+export interface AuthenticationWWWAuthenticateRequest {
+	/**
+	 * The raw WWW-Authenticate header value that triggered this challenge.
+	 */
+	readonly wwwAuthenticate: string;
+
+	/**
+	 * Optional scopes for the session.
+	 */
+	readonly scopes?: readonly string[];
+}
+
+export namespace authentication {
+		// NOTE: The only change is the 2nd parameter, the other variations of `getSession` have the same change
+		export function getSession(providerId: string, scopeListOrRequest: ReadonlyArray<string> | AuthenticationWWWAuthenticateRequest, options?: AuthenticationGetSessionOptions): Thenable<AuthenticationSession | undefined>;
+}
+```
+
+On the authentication provider side, we have added the following two new functions to `AuthenticationProvider`:
+
+```ts
+getSessionsFromChallenges(constraint: AuthenticationConstraint, options: AuthenticationProviderSessionOptions): Thenable<readonly AuthenticationSession[]>;
+createSessionFromChallenges(constraint: AuthenticationConstraint, options: AuthenticationProviderSessionOptions): Thenable<AuthenticationSession>;
+```
+
+and an auth provider can declare support for challenges when registered via `supportsChallenges: true` in `AuthenticationProviderOptions`.
+
+#### Example: Azure MFA
+
+This work was initially done [due to an upcoming change to require MFA in Azure APIs](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) so let's also use that as an example of this API.
+
+Let's say you have an extension that creates a resource in Azure. All that's doing is calling an Azure RM API, nothing fancy...  Your extension is probably already familiar with calling `vscode.authentication.getSession` to get an authentication session, mainly an access token, that can be used to call this API. Now, when you first minted that authentication session, depending on your organization, you may or may NOT have gone through multifactor authentication (MFA). If you did, then the Azure API will be happy. If you _didn't_ go through MFA, then Azure's API will return a 401 and a `WWW-Authenticate` header.
+
+Now comes our new API in VS Code... all you have to do is take that header value, and pass it right in to `vscode.authentication.getSession`:
+
+```ts
+const newRequest = {
+  wwwAuthenticate: theRawHeaderValue,
+  scopes: scopesFromPreviousRequest
+}
+const sessionWithMFA = await vscode.authentication.getSession('microsoft', newRequest, options)
+```
+
+This will pass that header value down to the `microsoft` auth provider, and the auth provider will be responsible for minting a session in which the challenges are satisfied.
+
+#### Next steps
+
+Next iteration we will finalize the `getSession` (aka extension asking for auth) parts of this proposal so if you have any feedback on that or the shape of the `AuthenticationProvider` changes, let us know! You can [find the full proposal on GitHub here](https://github.com/microsoft/vscode/blob/a924f20c72bd8f9665894be8213ce7f5680ab528/src/vscode-dts/vscode.proposed.authenticationChallenges.d.ts).
+
+Another use case that will be lit up soon regarding `WWW-Authenticate`, is for MCP servers to issue a `WWW-Authenticate` header asking for a token with more scopes. There's [a proposal in the MCP specification for this](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/835).
+
+### View containers in the Secondary Side Bar
+
+Extensions can contribute view containers to the `activitybar` and `panel`. We have now added support for contributing to the `secondarySidebar` as well. This is currently behind the `contribSecondarySideBar` proposed API. We are hoping to finalize this API soon.
+
+
+## Engineering
+
+### Exploring Playwright and Playwright MCP in the inner development loop of VS Code
+
+Agent mode and other AI features of VS Code have become a core tool (no pun intended) for the VS Code team to build VS Code itself. We wanted to explore how we can apply these features further to make the inner development loop of VS Code even better. To that end, we have been experimenting with extending our existing smoke test [automation project](https://github.com/microsoft/vscode/tree/main/test/automation), which uses [Playwright](https://playwright.dev/), to create an MCP server that can drive a local instance of VS Code. This allows our existing agentic flows, which focused on receiving context from build/test-time artifacts (compilation, linters, tests, etc.), to now also interact with a live instance of VS Code... verifying that changes have the desired effect at runtime.
+
+The first piece of this work can be found [in the test/mcp folder](https://github.com/microsoft/vscode/tree/main/test/mcp) of the vscode repo. If you're interested in trying it out, it's very easy to get started:
+
+1. Follow the [Contribution Guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute) for getting a local version of Code OSS running
+2. Then you can use [our trivial (for now) prompt file](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) to ask a question `/playwright your question here` in Agent mode.
+
+This is still an early exploration, but we are excited about the possibilities this opens up for us to use AI further in our inner development loop. The ground work is now laid, and we will be iterating on this to make it more robust and useful for the team.
+
+This work was recently featured on the VS Code Insiders podcast, where we discussed the motivations behind this exploration and some of the technical details. You can listen to the episode of the [VS Code Insiders podcast](https://www.vscodepodcast.com/3).
+
+## Notable fixes
+
+* [vscode#151902](https://github.com/microsoft/vscode/issues/151902) - Terminal: Copy on selection + new highlight in 1.68 copies previous term on CMD+F
+* [vscode#222075](https://github.com/microsoft/vscode/issues/222075) - Terminal sticky scroll can show up for 1 frame when using page down in a pager
+* [xtermjs/xterm.js#5390](https://github.com/xtermjs/xterm.js/pull/5390) - Fix scrollbar teleport after exiting alt buffer
+
+## Thank you
+
+Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+
+### Pull Requests
+
+Contributions to `vscode`:
+
+* [@a-ariff (Ariff)](https://github.com/a-ariff): docs: fix grammar in Development Container section [PR #264162](https://github.com/microsoft/vscode/pull/264162)
+* [@alexkozy (Alexey)](https://github.com/alexkozy)
+  * fix: tiny memory leak in debugToolBar.ts [PR #259349](https://github.com/microsoft/vscode/pull/259349)
+  * fix: register WorkerTextModelSyncClient [PR #259442](https://github.com/microsoft/vscode/pull/259442)
+* [@alexvoedi (Alexander Vödisch)](https://github.com/alexvoedi): Fix linkedEditing desync [PR #242993](https://github.com/microsoft/vscode/pull/242993)
+* [@bluedog13](https://github.com/bluedog13)
+  * Fix OAuth redirect URI format to align with Microsoft's URL standards [PR #260446](https://github.com/microsoft/vscode/pull/260446)
+  * Fix OAuth2 resource parameter compliance with RFC 8707 [PR #261815](https://github.com/microsoft/vscode/pull/261815)
+* [@CGNonofr (Loïc Mangeonjean)](https://github.com/CGNonofr): Fix theme not being synchronized with external windows on firefox [PR #259839](https://github.com/microsoft/vscode/pull/259839)
+* [@Da-nie-elT](https://github.com/Da-nie-elT): Update for-in loop snippet with `Object.hasOwn()` [PR #262682](https://github.com/microsoft/vscode/pull/262682)
+* [@DoctorKrolic](https://github.com/DoctorKrolic): Add `.slnx` to `xml` language extension list [PR #259049](https://github.com/microsoft/vscode/pull/259049)
+* [@DrSergei (Druzhkov Sergei)](https://github.com/DrSergei): Fix memory reference handling in Watch window [PR #259753](https://github.com/microsoft/vscode/pull/259753)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+  * Add `Go to Test` to coverage sources quickpick [PR #259600](https://github.com/microsoft/vscode/pull/259600)
+  * Set correct active entry on test coverage toolbar's quickpick [PR #259639](https://github.com/microsoft/vscode/pull/259639)
+  * Test Results: Only offer `Go to Test` with a uri (fix #260443) [PR #260508](https://github.com/microsoft/vscode/pull/260508)
+* [@hihry (Himanshu Ravindra Iwanati)](https://github.com/hihry): fix: update capitalization for 'Restore to Last Checkpoint' hover text [PR #259572](https://github.com/microsoft/vscode/pull/259572)
+* [@j3iiifn](https://github.com/j3iiifn): Prompt file name cannot contain digits [PR #261704](https://github.com/microsoft/vscode/pull/261704)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen)
+  * Allow the canonical package name and version to be sent back from the install flow [PR #259081](https://github.com/microsoft/vscode/pull/259081)
+  * Support server.json being returned by assisted MCP install [PR #259634](https://github.com/microsoft/vscode/pull/259634)
+  * Add support for a help link when MCP assisted installation fails [PR #260215](https://github.com/microsoft/vscode/pull/260215)
+* [@kenherring (Ken Herring)](https://github.com/kenherring): terminal.copyOnSelection and terminalFindWidget - do not copy selection on focus [PR #254065](https://github.com/microsoft/vscode/pull/254065)
+* [@kplates (kplates)](https://github.com/kplates): feat: Include/ Exclude file types from file search [PR #254285](https://github.com/microsoft/vscode/pull/254285)
+* [@LeftPhalange (Ethan Bovard)](https://github.com/LeftPhalange): Add Open Active Diff Side option to Command Palette using DIFF_OPEN_SIDE command [PR #261699](https://github.com/microsoft/vscode/pull/261699)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
+  * Fix global access of MonacoEnvironment [PR #248075](https://github.com/microsoft/vscode/pull/248075)
+  * Highlight more languages in markdown code blocks [PR #263550](https://github.com/microsoft/vscode/pull/263550)
+* [@rwoll (Ross Wollman)](https://github.com/rwoll)
+  * Wait for agent loop to finish in automation [PR #262370](https://github.com/microsoft/vscode/pull/262370)
+  * support model switching in automation [PR #262420](https://github.com/microsoft/vscode/pull/262420)
+  * fix: parse commands in chat.open commands [PR #263458](https://github.com/microsoft/vscode/pull/263458)
+  * `workbench.action.chat.export` optionally accept path [PR #263507](https://github.com/microsoft/vscode/pull/263507)
+  * fix: confirm response based on promise [PR #263894](https://github.com/microsoft/vscode/pull/263894)
+  * Revert "fix: confirm response based on promise (#263894)" [PR #264047](https://github.com/microsoft/vscode/pull/264047)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
+  * fix: memory leak in pattern input widget [PR #258152](https://github.com/microsoft/vscode/pull/258152)
+  * fix: memory leak in codelens controller [PR #263136](https://github.com/microsoft/vscode/pull/263136)
+  * fix: memory leak in accessibility signal scheduler [PR #263147](https://github.com/microsoft/vscode/pull/263147)
+  * fix: memory leak in QuickDiffModel [PR #265007](https://github.com/microsoft/vscode/pull/265007)
+* [@swordjjjkkk (Truman)](https://github.com/swordjjjkkk): Display Tab Indexes in VSCode [PR #209196](https://github.com/microsoft/vscode/pull/209196)
+* [@terreng (Terren)](https://github.com/terreng): Implement new option to control title scrollbar visibility [PR #246161](https://github.com/microsoft/vscode/pull/246161)
+* [@timheuer (Tim Heuer)](https://github.com/timheuer): Add collapse all functionality to test coverage view [PR #258906](https://github.com/microsoft/vscode/pull/258906)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1)
+  * fix some typos [PR #259747](https://github.com/microsoft/vscode/pull/259747)
+  * terminalProcessManager: fix disposable leak [PR #261710](https://github.com/microsoft/vscode/pull/261710)
+  * storage: optimize sqlite insert with upsert syntax [PR #261999](https://github.com/microsoft/vscode/pull/261999)
+* [@Tritlo (Matthías Páll Gissurarson)](https://github.com/Tritlo): extHostMcp: accept Content-Type parameters for SSE/JSON handling [PR #262787](https://github.com/microsoft/vscode/pull/262787)
+* [@ttttotem (ttttotem)](https://github.com/ttttotem): Fixes "Caret jumps to column 0 when clicking between first two characters" [PR #265131](https://github.com/microsoft/vscode/pull/265131)
+* [@JBlitzar (JBlitzar)](https://github.com/JBlitzar): Use `app.dock.hide` when connecting to an existing instance [PR #259352](https://github.com/microsoft/vscode/pull/259352)
+
+Contributions to `vscode-copilot-chat`:
+
+* [@24anisha](https://github.com/24anisha): add sku data to github telemetry [PR #819](https://github.com/microsoft/vscode-copilot-chat/pull/819)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): Make logprobs field optional [PR #325](https://github.com/microsoft/vscode-copilot-chat/pull/325)
+* [@iann0036 (Ian Mckay)](https://github.com/iann0036): fix: Case sensitive adjustment for "GitHub" [PR #631](https://github.com/microsoft/vscode-copilot-chat/pull/631)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen)
+  * Use .NET SDK to search for NuGet packages, emit events, add tests for all package types [PR #546](https://github.com/microsoft/vscode-copilot-chat/pull/546)
+  * Add command executor abstraction, only run dotnet CLI tests on CI [PR #607](https://github.com/microsoft/vscode-copilot-chat/pull/607)
+  * Hash package name during MCP server installation [PR #618](https://github.com/microsoft/vscode-copilot-chat/pull/618)
+* [@jwangxx (James Wang)](https://github.com/jwangxx)
+  * Add "onExP" tag to enableRetryAfterFilteredResponse setting [PR #479](https://github.com/microsoft/vscode-copilot-chat/pull/479)
+  * Remove experimental setting for retrying after filtered response [PR #830](https://github.com/microsoft/vscode-copilot-chat/pull/830)
+* [@lipido (Daniel Glez-Peña)](https://github.com/lipido): Improve agent test coverage [PR #614](https://github.com/microsoft/vscode-copilot-chat/pull/614)
+* [@m4dc4p](https://github.com/m4dc4p): Update getErrors (GetErrors / problems) tool [PR #394](https://github.com/microsoft/vscode-copilot-chat/pull/394)
+* [@rwoll (Ross Wollman)](https://github.com/rwoll)
+  * Fix auth for Copilot Chat running in automated VSC Extension Host [PR #609](https://github.com/microsoft/vscode-copilot-chat/pull/609)
+  * allow more services in Scenario Mode [PR #653](https://github.com/microsoft/vscode-copilot-chat/pull/653)
+  * plumb `code` on `ChatErrorDetails` [PR #680](https://github.com/microsoft/vscode-copilot-chat/pull/680)
+* [@shaunm-msft (Shaun Miller)](https://github.com/shaunm-msft)
+  * Remove the message copilot_cache_control field from a context where there is no understanding of it [PR #554](https://github.com/microsoft/vscode-copilot-chat/pull/554)
+  * port PR 665 to simulator [PR #694](https://github.com/microsoft/vscode-copilot-chat/pull/694)
+* [@sridharavinash (Avinash Sridhar)](https://github.com/sridharavinash): Add mode to conversation model messages [PR #517](https://github.com/microsoft/vscode-copilot-chat/pull/517)
+* [@yemohyleyemohyle](https://github.com/yemohyleyemohyle): Add message length events to MSFT internal telemetry  [PR #473](https://github.com/microsoft/vscode-copilot-chat/pull/473)
+* [@zhichli (Zhichao Li)](https://github.com/zhichli)
+  * Feature: add JSON export of chat prompt logs in chat debug view [PR #672](https://github.com/microsoft/vscode-copilot-chat/pull/672)
+  * Add tool and other metadata to chat debug json export  [PR #789](https://github.com/microsoft/vscode-copilot-chat/pull/789)
+  * Remove tool calls from `request` type JSON logs exported from chat debug [PR #794](https://github.com/microsoft/vscode-copilot-chat/pull/794)
+
+Contributions to `vscode-eslint`:
+
+* [@AmarMuric04 (AmarMuric)](https://github.com/AmarMuric04)
+  * docs: Update ESLint installation and configuration instructions [PR #2062](https://github.com/microsoft/vscode-eslint/pull/2062)
+  * docs: Remove duplicate text in README.md [PR #2066](https://github.com/microsoft/vscode-eslint/pull/2066)
+* [@davidtaylorhq (David Taylor)](https://github.com/davidtaylorhq): Add probe support for Ember's glimmer-ts/glimmer-js format [PR #2069](https://github.com/microsoft/vscode-eslint/pull/2069)
+
+Contributions to `vscode-extension-samples`:
+
+* [@Sepush (Artea)](https://github.com/Sepush): refactor(lsp-embedded-request-forwarding): clean useless code [PR #1196](https://github.com/microsoft/vscode-extension-samples/pull/1196)
+
+Contributions to `vscode-js-debug`:
+
+* [@LittleLittleCloud (Xiaoyun Zhang)](https://github.com/LittleLittleCloud): fix: handle localhost hostname in constructInspectorWSUri function [PR #2260](https://github.com/microsoft/vscode-js-debug/pull/2260)
+
+Contributions to `vscode-jupyter`:
+
+* [@hunterhogan (Hunter Hogan)](https://github.com/hunterhogan): Typos in package.nls.json [PR #16890](https://github.com/microsoft/vscode-jupyter/pull/16890)
+* [@krassowski (Michał Krassowski)](https://github.com/krassowski): Add support for custom CDN URLs [PR #16885](https://github.com/microsoft/vscode-jupyter/pull/16885)
+
+Contributions to `vscode-languageserver-node`:
+
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Add capability information to `textDocument/colorPresentation` [PR #1660](https://github.com/microsoft/vscode-languageserver-node/pull/1660)
+
+Contributions to `vscode-markdown-languageservice`:
+
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Update @vscode/l10n to version 0.0.18 [PR #199](https://github.com/microsoft/vscode-markdown-languageservice/pull/199)
+
+Contributions to `vscode-markdown-tm-grammar`:
+
+* [@c-schuhmann (Christian Schuhmann)](https://github.com/c-schuhmann): Add support for SAP ABAP syntax [PR #176](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/176)
+* [@esmasth (Siddharth Sharma)](https://github.com/esmasth): Add support for YANG code fence [PR #169](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/169)
+* [@Morikko (Eric Masseran)](https://github.com/Morikko): Add restructuredtext support in markdown code block [PR #178](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/178)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
+  * Add support for jsonl code blocks [PR #181](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/181)
+  * Add support for ignore code blocks [PR #182](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/182)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@krassowski (Michał Krassowski)](https://github.com/krassowski): Fix typo "will be replace" → "will be replaced" [PR #7540](https://github.com/microsoft/vscode-pull-request-github/pull/7540)
+
+Contributions to `vscode-python-environments`:
+
+* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): fix: enhance conda executable retrieval with path existence checks [PR #677](https://github.com/microsoft/vscode-python-environments/pull/677)
+* [@sjsikora (Sam Sikora)](https://github.com/sjsikora): bug fix: Stricter pip list Package Parsing [PR #698](https://github.com/microsoft/vscode-python-environments/pull/698)
+
+Contributions to `vscode-vsce`:
+
+* [@tgrospic (Tomislav Grospić)](https://github.com/tgrospic): Avoid Node.js DEP0190 warning by using string form for prepublish command [PR #1188](https://github.com/microsoft/vscode-vsce/pull/1188)
+
+Contributions to `debug-adapter-protocol`:
+
+* [@jborean93 (Jordan Borean)](https://github.com/jborean93): Add Ansible implementation [PR #552](https://github.com/microsoft/debug-adapter-protocol/pull/552)
+
+Contributions to `language-server-protocol`:
+
+* [@aartaka (Artyom Bologov)](https://github.com/aartaka): Add cl-lsp (Common Lisp) to implementations list [PR #2179](https://github.com/microsoft/language-server-protocol/pull/2179)
+* [@anakin4747 (Anakin Childerhose)](https://github.com/anakin4747): Add kconfig-language-server [PR #2177](https://github.com/microsoft/language-server-protocol/pull/2177)
+* [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721): add ty [PR #2175](https://github.com/microsoft/language-server-protocol/pull/2175)
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Add capability information to `textDocument/colorPresentation` [PR #2173](https://github.com/microsoft/language-server-protocol/pull/2173)
+* [@notpeter (Peter Tripp)](https://github.com/notpeter)
+  * Fix broken anchor links in changelog [PR #2171](https://github.com/microsoft/language-server-protocol/pull/2171)
+  * Markdown whitespace formatting improvements  [PR #2172](https://github.com/microsoft/language-server-protocol/pull/2172)
+* [@ribru17 (Riley Bruins)](https://github.com/ribru17): Fix 3.18 metamodel version [PR #2180](https://github.com/microsoft/language-server-protocol/pull/2180)
+* [@skewb1k](https://github.com/skewb1k): correct grammar and consistency in lazy property descriptions [PR #2170](https://github.com/microsoft/language-server-protocol/pull/2170)
+
+Contributions to `node-jsonc-parser`:
+
+* [@operagxsasha](https://github.com/operagxsasha): docs: edited the link to the badge tests [PR #98](https://github.com/microsoft/node-jsonc-parser/pull/98)
+* [@pimterry (Tim Perry)](https://github.com/pimterry): Add startLine & startCharacter to parser errors [PR #102](https://github.com/microsoft/node-jsonc-parser/pull/102)
+
+Contributions to `python-environment-tools`:
+
+* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): Fix conda env trace message [PR #241](https://github.com/microsoft/python-environment-tools/pull/241)
+
+We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+
+>If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_104.md
+++ b/docs/release-notes/v1_104.md
@@ -78,13 +78,13 @@ This iteration, we're introducing auto model selection in chat. When you choose 
 
 Auto model selection is currently in preview and we are rolling it out to all GitHub Copilot users in VS Code in the following weeks, starting with the individual Copilot plans.
 
-![Screenshot that shows the model picker in the Chat view, showing the Auto option.](images/1_104/model-dropdown-auto.png)
+![Screenshot that shows the model picker in the Chat view, showing the Auto option.](https://code.visualstudio.com/assets/updates/1_104/model-dropdown-auto.png)
 
 Auto will choose between Claude Sonnet 4, GPT-5, GPT-5 mini, and GPT-4.1, unless your organization has disabled access to these models. When using auto model selection, VS Code uses a variable model multiplier, based on the selected model. If you are a paid user, auto will apply a 10% request discount.
 
 You can view the selected model and the model multiplier by hovering over the response in the Chat view.
 
-![Screenshot of a chat response, showing the selected model on hover.](images/1_104/auto-model-multiplier.png)
+![Screenshot of a chat response, showing the selected model on hover.](https://code.visualstudio.com/assets/updates/1_104/auto-model-multiplier.png)
 
 Learn more about [auto model selection in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
 
@@ -98,7 +98,7 @@ In this release, the agent now explicitly asks for user confirmation before maki
 
 Common system folders, dotfiles, and files outside your workspace will require confirmation by default.
 
-![Screenshot showing the confirmation dialog for sensitive file edits in the Chat view.](images/1_104/chat-edit-sensitive-file.png)
+![Screenshot showing the confirmation dialog for sensitive file edits in the Chat view.](https://code.visualstudio.com/assets/updates/1_104/chat-edit-sensitive-file.png)
 
 ### Support for AGENTS.md files (Experimental)
 
@@ -122,7 +122,7 @@ This iteration, the changed files list has been reworked with several quality-of
 
 * Changes _per file_ (lines added or removed) are now shown for each item in the list.
 
-<video src="images/1_104/changed-files-list.mp4" title="Video uncollapsing the changed files list and accepting file entries to remove them from the list." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/changed-files-list.mp4" title="Video uncollapsing the changed files list and accepting file entries to remove them from the list." autoplay loop controls muted></video>
 
 ### Use custom chat modes in prompt files
 
@@ -130,7 +130,7 @@ Prompt files are Markdown files in which you write reusable chat prompts. To run
 
 You can specify which chat mode should be used for running the prompt file. Previously, you could only use built-in chat modes like `agent`, `edit`, or `ask` in your prompt files. Now, you can also reference custom chat modes in your prompt files.
 
-![Screenshot showing IntelliSense for custom chat modes in prompt files.](images/1_104/custom_modes_in_prompt_files.png)
+![Screenshot showing IntelliSense for custom chat modes in prompt files.](https://code.visualstudio.com/assets/updates/1_104/custom_modes_in_prompt_files.png)
 
 Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) with prompt files, chat modes, and custom instructions.
 
@@ -161,7 +161,7 @@ This helps teams surface the right AI workflows at the right time, making custom
 
 The tools picker now shows which tools are part of each tool set and you can individually enable or disable each tool. You can access the tools picker via the `Configure Tools...` button in the Chat view.
 
-![Screenshot showing the tools picker with an expanded edit tool set, listing all available tools.](images/1_104/tools_in_toolsets.png)
+![Screenshot showing the tools picker with an expanded edit tool set, listing all available tools.](https://code.visualstudio.com/assets/updates/1_104/tools_in_toolsets.png)
 
 ### Configure font used in chat
 
@@ -169,7 +169,7 @@ The tools picker now shows which tools are part of each tool set and you can ind
 
 VS Code lets you choose which font to use across the editor, however the Chat view lacked that configurability. We have now added two new settings for configuring the font family (`setting(chat.fontFamily)`) and font size (`setting(chat.fontSize)`) of chat messages.
 
-![Screenshot showing the Chat view with a custom font and font size.](images/1_104/chat-configure-font.png)
+![Screenshot showing the Chat view with a custom font and font size.](https://code.visualstudio.com/assets/updates/1_104/chat-configure-font.png)
 
 > **Note**: content for lists currently does not yet honor these settings, but this is something that we are working on fixing in the upcoming releases.
 
@@ -197,7 +197,7 @@ We've improved the integration of [GitHub coding agents](https://code.visualstud
 * **Better session rendering**: Various improvements on cards and tools rendering for better visual clarity.
 * **Performance boosts**: Faster session loading for a more responsive experience.
 
-<video src="images/1_104/chat-sessions-view.mp4" title="Video showing Chat Sessions view and integration with GitHub coding agents." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/chat-sessions-view.mp4" title="Video showing Chat Sessions view and integration with GitHub coding agents." autoplay loop controls muted></video>
 
 #### Delegate to coding agent
 
@@ -207,13 +207,13 @@ We continued to expand on ways to delegate local tasks in VS Code to a Copilot c
 
     Comments starting with `TODO` now show a Code Action to quickly initiate a coding agent session.
 
-    ![Screenshot of a code action above a TODO comment called Delegate to coding agent.](images/1_104/coding-agent-todo.png)
+    ![Screenshot of a code action above a TODO comment called Delegate to coding agent.](https://code.visualstudio.com/assets/updates/1_104/coding-agent-todo.png)
 
 * Delegate from chat (`setting(githubPullRequests.codingAgent.uiIntegration)`):
 
     Additional context, including file references, are now forwarded to GitHub coding agent when you perform the **Delegate to coding agent** action in chat. This enables you to precisely plan out a task before handing it off to coding agent to complete it. A new chat editor is opened with the coding agent's progress shown in real-time.
 
-    <video src="images/1_104/delegate-to-coding-agent.mp4" title="Delegating a task from sidebar chat to coding agent" autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_104/delegate-to-coding-agent.mp4" title="Delegating a task from sidebar chat to coding agent" autoplay loop controls muted></video>
 
 _Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
 
@@ -222,7 +222,7 @@ _Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=jo
 
 The option to sign in or sign up to GitHub Copilot with a Google account is now generally available and rolling out to all users in VS Code.
 
-![Screenshot showing the sign in dialog showing the option to use a Google account.](images/1_104/google.png)
+![Screenshot showing the sign in dialog showing the option to use a Google account.](https://code.visualstudio.com/assets/updates/1_104/google.png)
 
 You can find more information about this in the [announcement GitHub blog post](https://github.blog/changelog/2025-07-15-social-login-with-google-is-now-generally-available).
 
@@ -236,11 +236,11 @@ Automatically approving terminal commands can greatly streamline agent interacti
 
 * Before terminal auto approve is actually enabled, you need to explicitly opt in via a dropdown in the Chat view.
 
-    ![Screenshot of a terminal command in the Chat view, showing the Enable Auto Approve dropdown.](images/1_104/terminal-auto-approve-opt-in.png)
+    ![Screenshot of a terminal command in the Chat view, showing the Enable Auto Approve dropdown.](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-opt-in.png)
 
 * From the Chat view, you can conveniently add auto-approve rules for the command being run, or open the configuration setting:
 
-    ![Screenshot that shows the three standard options are presented for "foo --arg && bar".](images/1_104/terminal-auto-approve-ui.png)
+    ![Screenshot that shows the three standard options are presented for "foo --arg && bar".](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-ui.png)
 
     _Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire))_
 
@@ -248,7 +248,7 @@ Automatically approving terminal commands can greatly streamline agent interacti
 
 * To improve transparency around auto-approved commands, we show which rule was applied in the Chat view, also enabling you to configure that rule:
 
-    ![Screenshot showing the new links added under the tool call in the Chat view for adding new auto approve rules.](images/1_104/terminal-auto-approve-new-links.png)
+    ![Screenshot showing the new links added under the tool call in the Chat view for adding new auto approve rules.](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-new-links.png)
 
 * We improved the defaults to provide safety and reduce noise. You can see the full list of rules by viewing the setting's default value by opening your `settings.json` file, then entering `chat.tools.terminal.autoApprove` and completing it via `kbstyle(Tab)`.
 
@@ -264,7 +264,7 @@ Global auto approve has been [an experimental setting since v1.99](https://code.
 
 To combat these misconceptions and to further protect our users, there is now a deservedly scary-looking warning the first time global auto approve attempts to be used, so the user can easily back out and disable the setting:
 
-![Screenshot of a warning dialog that appears when global auto approve is used for the first time.](images/1_104/global-auto-approve-warning.png)
+![Screenshot of a warning dialog that appears when global auto approve is used for the first time.](https://code.visualstudio.com/assets/updates/1_104/global-auto-approve-warning.png)
 
 The setting has also been changed to the clearer `setting(chat.tools.global.autoApprove)` without any automatic migration, so all users (accidental or intentional) need to go and explicitly set it again.
 
@@ -274,7 +274,7 @@ The setting has also been changed to the clearer `setting(chat.tools.global.auto
 
 Rendering of mathematical equations in chat responses is now generally available and enabled by default. You can disable this functionality with the `setting(chat.math.enabled)` setting.
 
-![Screenshot of the Chat view, showing inline and block equations in a chat response.](images/1_104/chat-math.png)
+![Screenshot of the Chat view, showing inline and block equations in a chat response.](https://code.visualstudio.com/assets/updates/1_104/chat-math.png)
 
 This feature is powered by [KaTeX](https://katex.org) and supports both inline and block math equations. Inline math equations can be written by wrapping the markup in single dollar signs (`$...$`), while block math equations use two dollar signs (`$$...$$`).
 
@@ -284,7 +284,7 @@ This feature is powered by [KaTeX](https://katex.org) and supports both inline a
 
 When you first open a workspace, the Secondary Side Bar with the Chat view is visible by default, inviting you to ask questions or start an agentic session right away. You can configure this behavior with the `setting(workbench.secondarySideBar.defaultVisibility)` setting or by using the dropdown of the Chat view itself:
 
-![Screenshot showing Chat view menu with the option to set the default Secondary Side Bar visibility.](images/1_104/auxview.png)
+![Screenshot showing Chat view menu with the option to set the default Secondary Side Bar visibility.](https://code.visualstudio.com/assets/updates/1_104/auxview.png)
 
 ### Improved task support
 
@@ -292,7 +292,7 @@ When you first open a workspace, the Secondary Side Bar with the Chat view is vi
 
     When you run a task or terminal command in agent mode, the agent now detects when the process requests user input, and you're prompted to respond in chat. If you type in the terminal while a prompt is present, the prompt will hide automatically. When options and descriptions are provided (such as `[Y] Yes [N] No`), these are surfaced in the confirmation prompt.
 
-    <video src="images/1_104/prompt-input-demo.mp4" title="Example of input being detected and responded to" autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_104/prompt-input-demo.mp4" title="Example of input being detected and responded to" autoplay loop controls muted></video>
 
 * Error detection for tasks with problem matchers
 
@@ -304,7 +304,7 @@ When you first open a workspace, the Secondary Side Bar with the Chat view is vi
 
     In the example below, the VS Code - Build task is run. Output is assessed for each dependency task and a problem is surfaced to the user in the response and in the progress message dropdown.
 
-    <video src="images/1_104/build-task.mp4" title="Example of agent running the VS Code - Build task" autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_104/build-task.mp4" title="Example of agent running the VS Code - Build task" autoplay loop controls muted></video>
 
 ### Improved terminal support
 
@@ -404,7 +404,7 @@ We are happy to add a new setting `setting(window.border)` on Windows that enabl
 
 You can configure colors per workspace, making it easier to distinguish which workspace is opened in which window.
 
-![Screenshot of several VS Code windows with different border colors.](images/1_104/border.png)
+![Screenshot of several VS Code windows with different border colors.](https://code.visualstudio.com/assets/updates/1_104/border.png)
 
 When you configure `setting(window.border)` as `default`, a theme is able to set the border color for active and inactive windows using the `window.activeBorder` and `window.inactiveBorder` color keys. You can further override these colors from the `setting(workbench.colorCustomizations)` setting.
 
@@ -420,7 +420,7 @@ This builds on the [account management functionality that we added a year ago](h
 
 You can now render the index of an editor tab in the tab's label. This can be helpful when you have many tabs open and want to quickly navigate between them using keyboard shortcuts. Enable this functionality with the `setting(workbench.editor.showTabIndex)` setting.
 
-![Screenshot of editor tabs with numbers in front of them, indicating their index.](images/1_104/editorTabIndex.png)
+![Screenshot of editor tabs with numbers in front of them, indicating their index.](https://code.visualstudio.com/assets/updates/1_104/editorTabIndex.png)
 
 ### Editor tab bar scrollbar visibility
 
@@ -432,7 +432,7 @@ The `setting(workbench.editor.titleScrollbarVisibility)` enables you to control 
 
 When reporting issues in VS Code or extensions via the built-in issue reporter, you can now choose either **Create on GitHub** or **Preview on GitHub** via a dropdown on the report button. If the button does not populate a dropdown and only shows Create or Preview, this likely means that you are still loading extension data or need to ensure that you are signed in with a GitHub account that provides the correct scopes.
 
-![Screenshot of a dropdown showing Create on Github and Preview on Github in the issue reporter.](images/1_104/issue-reporter-dropdown.png)
+![Screenshot of a dropdown showing Create on Github and Preview on Github in the issue reporter.](https://code.visualstudio.com/assets/updates/1_104/issue-reporter-dropdown.png)
 
 ## Notebooks
 
@@ -448,7 +448,7 @@ We are experimenting with improving the quality of next edit suggestions for not
 
 You can now preview differences between worktree files and your current workspace by right-clicking on a worktree file to open the context menu in the Source Control Changes view and selecting **Compare with Workspace**.
 
-![Screenshot of the context menu shown in the SCM view on a changed file in a worktree, with the Compare with Workspace option selected.](images/1_104/image.png)
+![Screenshot of the context menu shown in the SCM view on a changed file in a worktree, with the Compare with Workspace option selected.](https://code.visualstudio.com/assets/updates/1_104/image.png)
 
 After reviewing your changes, you can use the **Migrate Worktree Changes...** command from the Command Palette (`kb(git.migrateWorktreeChanges)`) to merge all changes from a worktree into your current workspace. This makes it easy to work across multiple worktrees and selectively bring changes back into your main repository.
 
@@ -467,13 +467,13 @@ A common request is to allow terminals to be opened in separate windows. This fu
 
 We also polished the experience where these new terminal windows open in compact mode. If you add a new tab to the window, it automatically exits compact mode.
 
-![Screenshot of the terminal window open in compact mode, hiding tabs to make more room for terminal content.](images/1_104/terminal-window.png)
+![Screenshot of the terminal window open in compact mode, hiding tabs to make more room for terminal content.](https://code.visualstudio.com/assets/updates/1_104/terminal-window.png)
 
 ### Terminal actions in terminal editors
 
 The actions that are available in the terminal view (new terminal dropdown, clear terminal, etc.) are now also available for terminals in the editor area and terminal windows.
 
-![Screenshot of different terminal actions in the editor actions menu.](images/1_104/terminal-editor-actions.png)
+![Screenshot of different terminal actions in the editor actions menu.](https://code.visualstudio.com/assets/updates/1_104/terminal-editor-actions.png)
 
 Just like in the terminal view, you can right-click the actions area to move them out of the overflow menu.
 
@@ -484,7 +484,7 @@ Terminal IntelliSense is getting several improvements this release:
 * Multiple performance improvements, these disproportionately affect the experience on Windows.
 * `git` completions are now more reliable on Windows due to the removal of the `sed` dependency, which isn't available on Windows.
 * `git` completions now have familiar icons to represent commits, branches, remotes, stashes, and tags.
-    ![Screenshot of new icons showing for tags and branches on completions for "git checkout"](images/1_104/terminal-suggest.png)
+    ![Screenshot of new icons showing for tags and branches on completions for "git checkout"](https://code.visualstudio.com/assets/updates/1_104/terminal-suggest.png)
 * A large number of completion specs were added: `adb`, `basename`, `bundle`, `clear`, `cut`, `date`, `dd`, `diff`, `dig`, `dirname`, `docker-compose`, `docker`, `dotnet`, `env`, `export`, `fdisk`, `fmt`, `fold`, `gh`, `go`, `htop`, `id`, `jq`, `ln`, `lsblk`, `lsof`, `mount`, `nl`, `od`, `paste`, `ping`, `pkill`, `readlink`, `rsync`, `ruby`, `ruff`, `sed`, `seq`, `shred`, `sort`, `source`, `split`, `stat`, `su`, `sudo`, `tac`, `tar`, `tee`, `time`, `tr`, `traceroute`, `tree`, `truncate`, `uniq`, `unzip`, `wc`, `where`, `whereis`, `which`, `who`, `xargs`, `xxd`, `yo`, `zip`
 
 ### Terminal sticky scroll improvements
@@ -505,7 +505,7 @@ Bower recommends that users migrate to `npm` or `yarn`. Continued support for Bo
 
 Pipenv environments can now be discovered and selected just like in the Python extension. In addition, they appear in the **Environment Manager** view in the Python sidebar, where they are grouped and displayed alongside your other environment types.
 
-![Screenshot showing the Python sidebar with Pipenv environments expanded.](images/1_104/pipenv-supported-screenshot.png)
+![Screenshot showing the Python sidebar with Pipenv environments expanded.](https://code.visualstudio.com/assets/updates/1_104/pipenv-supported-screenshot.png)
 
 #### Configure environment variable injection
 
@@ -519,7 +519,7 @@ The [Python Environments Extension](https://marketplace.visualstudio.com/items?
 
 A new experimental AI hover summaries feature is now available for Python when using the latest pre-release version of Pylance. When you enable the `setting(python.analysis.aiHoverSummaries)` setting, you can get helpful summaries on-the-fly for symbols that do not already have documentation. This makes it easier to understand unfamiliar code and boosts productivity as you explore Python projects. AI hover summaries are currently available to GitHub Copilot Pro, Pro+, and Enterprise users.
 
-<video src="images/1_104/pylance-hover-summaries.mp4" title="Video showing AI-powered hover summaries with Pylance." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/pylance-hover-summaries.mp4" title="Video showing AI-powered hover summaries with Pylance." autoplay loop controls muted></video>
 
 We look forward to bringing this experimental experience to the stable extension version soon.
 
@@ -533,7 +533,7 @@ To try it out, make sure to use the latest pre-release version of the Pylance ex
 
 > **Note**: As with all AI-generated code, please make sure to inspect the generated code before allowing this tool to be executed. Reviewing the logic and intent of the code ensures it aligns with your project's goals and maintains safety and correctness.
 
-<video src="images/1_104/pylance-run-code-snippet.mp4" title="Code snippet generated and executed by GitHub Copilot in the Chat panel via the pylancerunCodeSnippet tool." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/pylance-run-code-snippet.mp4" title="Code snippet generated and executed by GitHub Copilot in the Chat panel via the pylancerunCodeSnippet tool." autoplay loop controls muted></video>
 
 #### Pylance IntelliSense enabled in all Python documents
 

--- a/docs/release-notes/v1_104.md
+++ b/docs/release-notes/v1_104.md
@@ -1,620 +1,620 @@
 ---
 Order: 113
-TOCTitle: August 2025
-PageTitle: Visual Studio Code August 2025
-MetaDescription: Learn what is new in the Visual Studio Code August 2025 Release (1.104)
+TOCTitle: 2025 年 8 月
+PageTitle: Visual Studio Code 2025 年 8 月
+MetaDescription: Visual Studio Code 2025 年 8 月リリース (1.104) の新機能について学びます。
 MetaSocialImage: 1_104/release-highlights.png
 Date: 2025-09-11
 DownloadVersion: 1.104.1
 ---
-# August 2025 (version 1.104) {#august-2025-version-1104}
+# 2025 年 8 月 (バージョン 1.104) {#august-2025-version-1104}
 
-_Release date: September 11, 2025_
+_リリース日: 2025 年 9 月 11 日_
 
-**Update 1.104.1**: The update addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22August+2025+Recovery+1%22+).
+**更新 1.104.1**: この更新では、これらの [問題](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22August+2025+Recovery+1%22+) に対処しています。
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the August 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code の 2025 年 8 月のリリースへようこそ。このバージョンには多くの更新があり、皆様に気に入っていただけることを願っています。主なハイライトは次のとおりです:
 
 <table class="highlights-table">
   <tr>
-    <th>Model flexibility</th>
-    <th>Security</th>
-    <th>Productivity</th>
+    <th>モデルの柔軟性</th>
+    <th>セキュリティ</th>
+    <th>生産性</th>
   </tr>
   <tr>
-    <td>Let VS Code select the best model <a href="#auto-model-selection-preview"><br>Show more</a></td>
-    <td>Confirm edits for sensitive files <a href="#confirm-edits-to-sensitive-files"><br>Show more</a></td>
-    <td>Remove distractions from chat file edits <a href="#improved-changed-files-experience"><br>Show more</a></td>
+    <td>VS Code に最適なモデルを選択させる <a href="#auto-model-selection-preview"><br>詳細</a></td>
+    <td>機密ファイルの編集を確認する <a href="#confirm-edits-to-sensitive-files"><br>詳細</a></td>
+    <td>チャットファイルの編集から注意散漫になる要素を削除 <a href="#improved-changed-files-experience"><br>詳細</a></td>
   </tr>
   <tr>
-    <td>Contribute models through VS Code extensions <a href="#language-model-chat-provider-api"><br>Show more</a></td>
-    <td>Let agents run terminal commands safely <a href="#terminal-auto-approve"><br>Show more</a></td>
-    <td>Use AGENTS.md to add chat context <a href="#support-for-agentsmd-files-experimental"><br>Show more</a></td>
+    <td>VS Code 拡張機能を通じてモデルをコントリビュートする <a href="#language-model-chat-provider-api"><br>詳細</a></td>
+    <td>エージェントにターミナルコマンドを安全に実行させる <a href="#terminal-auto-approve"><br>詳細</a></td>
+    <td>AGENTS.md を使用してチャットコンテキストを追加する <a href="#support-for-agentsmd-files-experimental"><br>詳細</a></td>
   </tr>
 </table>
 
 <br>
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+>これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。<br>
 
-> **Insiders: Want to try new features as soon as possible?**<br>
-> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> **Insiders: 新機能をいち早く試したいですか？**<br>
+> 夜間の Insiders ビルドをダウンロードして、利用可能になった最新の更新をすぐに試すことができます。<br>
 > [Download Insiders](https://code.visualstudio.com/insiders)<br>
 
 <!-- TOC
 <div class="toc-nav-layout">
   <nav id="toc-nav">
-    <div>In this update</div>
+    <div>このアップデートの内容</div>
     <ul>
-      <li><a href="#chat">Chat</a></li>
+      <li><a href="#chat">チャット</a></li>
       <li><a href="#mcp">MCP</a></li>
-      <li><a href="#accessibility">Accessibility</a></li>
-      <li><a href="#code-editing">Code Editing</a></li>
-      <li><a href="#editor-experience">Editor Experience</a></li>
+      <li><a href="#accessibility">アクセシビリティ</a></li>
+      <li><a href="#code-editing">コード編集</a></li>
+      <li><a href="#editor-experience">エディター体験</a></li>
       <li><a href="#notebooks">Notebooks</a></li>
-      <li><a href="#source-control">Source Control</a></li>
-      <li><a href="#terminal">Terminal</a></li>
-      <li><a href="#languages">Languages</a></li>
-      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
-      <li><a href="#extension-authoring">Extension Authoring</a></li>
-      <li><a href="#proposed-apis">Proposed APIs</a></li>
-      <li><a href="#engineering">Engineering</a></li>
-      <li><a href="#notable-fixes">Notable fixes</a></li>
-      <li><a href="#thank-you">Thank you</a></li>
+      <li><a href="#source-control">ソース管理</a></li>
+      <li><a href="#terminal">ターミナル</a></li>
+      <li><a href="#languages">言語</a></li>
+      <li><a href="#contributions-to-extensions">拡張機能への貢献</a></li>
+      <li><a href="#extension-authoring">拡張機能のオーサリング</a></li>
+      <li><a href="#proposed-apis">Proposed API</a></li>
+      <li><a href="#engineering">エンジニアリング</a></li>
+      <li><a href="#notable-fixes">注目すべき修正</a></li>
+      <li><a href="#thank-you">謝辞</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Auto model selection (Preview) {#auto-model-selection-preview}
+### 自動モデル選択 (プレビュー) {#auto-model-selection-preview}
 
-This iteration, we're introducing auto model selection in chat. When you choose the **Auto** model in the model picker, VS Code automatically selects a model to ensure that you get the optimal performance and reduce rate limits.
+このイテレーションでは、チャットに自動モデル選択を導入します。モデルピッカーで **Auto** モデルを選択すると、VS Code は自動的にモデルを選択し、最適なパフォーマンスを確保し、レート制限を削減します。
 
-Auto model selection is currently in preview and we are rolling it out to all GitHub Copilot users in VS Code in the following weeks, starting with the individual Copilot plans.
+自動モデル選択は現在プレビュー段階であり、今後数週間で VS Code のすべての GitHub Copilot ユーザーに展開される予定です。まずは個人の Copilot プランから開始します。
 
-![Screenshot that shows the model picker in the Chat view, showing the Auto option.](https://code.visualstudio.com/assets/updates/1_104/model-dropdown-auto.png)
+![チャットビューのモデルピッカーに Auto オプションが表示されているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/model-dropdown-auto.png)
 
-Auto will choose between Claude Sonnet 4, GPT-5, GPT-5 mini, and GPT-4.1, unless your organization has disabled access to these models. When using auto model selection, VS Code uses a variable model multiplier, based on the selected model. If you are a paid user, auto will apply a 10% request discount.
+Auto は、組織がこれらのモデルへのアクセスを無効にしていない限り、Claude Sonnet 4、GPT-5、GPT-5 mini、および GPT-4.1 の中から選択します。自動モデル選択を使用する場合、VS Code は選択されたモデルに基づいて可変のモデル乗数を使用します。有料ユーザーの場合、auto は 10% のリクエスト割引を適用します。
 
-You can view the selected model and the model multiplier by hovering over the response in the Chat view.
+選択されたモデルとモデル乗数は、チャットビューの応答にカーソルを合わせることで確認できます。
 
-![Screenshot of a chat response, showing the selected model on hover.](https://code.visualstudio.com/assets/updates/1_104/auto-model-multiplier.png)
+![チャットの応答のスクリーンショット。ホバー時に選択されたモデルが表示されています。](https://code.visualstudio.com/assets/updates/1_104/auto-model-multiplier.png)
 
-Learn more about [auto model selection in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
+VS Code での [自動モデル選択](https://code.visualstudio.com/docs/copilot/customization/language-models) について詳しく学びましょう。
 
-### Confirm edits to sensitive files {#confirm-edits-to-sensitive-files}
+### 機密ファイルの編集を確認する {#confirm-edits-to-sensitive-files}
 
-**Setting**: `setting(chat.tools.edits.autoApprove)`
+**設定**: `setting(chat.tools.edits.autoApprove)`
 
-In agent mode, the agent can autonomously make edits to files in your workspace. This might include accidentally or maliciously modifying or deleting important files such as configuration files, which could cause immediate negative side-effects on your machine. Learn more about [security considerations when using AI-powered development tools](https://code.visualstudio.com/docs/copilot/security).
+エージェントモードでは、エージェントはワークスペース内のファイルを自律的に編集できます。これには、構成ファイルなどの重要なファイルを誤ってまたは悪意を持って変更または削除することが含まれる可能性があり、マシンに即座に悪影響を及ぼす可能性があります。AI を活用した開発ツールを使用する際の [セキュリティに関する考慮事項](https://code.visualstudio.com/docs/copilot/security) について詳しく学びましょう。
 
-In this release, the agent now explicitly asks for user confirmation before making edits to certain files. This provides an additional layer of safety when using agent mode. With the `setting(chat.tools.edits.autoApprove)` setting, you can configure file patterns to indicate which files require confirmation.
+このリリースでは、エージェントは特定のファイルを編集する前に、ユーザーに明示的に確認を求めるようになりました。これにより、エージェントモードを使用する際の安全性がさらに向上します。`setting(chat.tools.edits.autoApprove)` 設定を使用すると、確認が必要なファイルを示すファイルパターンを構成できます。
 
-Common system folders, dotfiles, and files outside your workspace will require confirmation by default.
+一般的なシステムフォルダー、ドットファイル、およびワークスペース外のファイルは、デフォルトで確認が必要になります。
 
-![Screenshot showing the confirmation dialog for sensitive file edits in the Chat view.](https://code.visualstudio.com/assets/updates/1_104/chat-edit-sensitive-file.png)
+![チャットビューで機密ファイルの編集に関する確認ダイアログが表示されているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/chat-edit-sensitive-file.png)
 
-### Support for AGENTS.md files (Experimental) {#support-for-agentsmd-files-experimental}
+### AGENTS.md ファイルのサポート (実験的) {#support-for-agentsmd-files-experimental}
 
-**Setting**: `setting(chat.useAgentsMdFile)`
+**設定**: `setting(chat.useAgentsMdFile)`
 
-An `AGENTS.md` file lets you provide context and instructions to the agent. Starting from this release, when you have an `AGENTS.md` file in your workspace root(s), it is automatically picked up as context for chat requests. This can be useful for teams that use multiple AI agents.
+`AGENTS.md` ファイルを使用すると、エージェントにコンテキストと指示を提供できます。このリリースから、ワークスペースのルートに `AGENTS.md` ファイルがあると、チャットリクエストのコンテキストとして自動的に取得されます。これは、複数の AI エージェントを使用するチームに役立ちます。
 
-Support for `AGENTS.md` files is enabled by default and can be controlled with the `setting(chat.useAgentsMdFile)` setting. See <https://agents.md/> for more information about `AGENTS.md` files.
+`AGENTS.md` ファイルのサポートはデフォルトで有効になっており、`setting(chat.useAgentsMdFile)` 設定で制御できます。`AGENTS.md` ファイルの詳細については、<https://agents.md/> を参照してください。
 
-Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) to your practices and team workflows.
+あなたのプラクティスやチームのワークフローに合わせて [VS Code でチャットをカスタマイズする](https://code.visualstudio.com/docs/copilot/customization/overview) 方法について詳しく学びましょう。
 
-### Improved changed files experience {#improved-changed-files-experience}
+### 変更されたファイルの体験向上 {#improved-changed-files-experience}
 
-This iteration, the changed files list has been reworked with several quality-of-life features. These changes should improve your experience when working in agent mode!
+このイテレーションでは、変更されたファイルのリストがいくつかの QoL (Quality-of-Life) 機能で再設計されました。これらの変更により、エージェントモードでの作業体験が向上するはずです！
 
-* The list of changed files is now collapsed by default to give more space to the chat conversation. While collapsed, you can still see the files changed count and the lines added or removed.
+* 変更されたファイルのリストは、チャットの会話により多くのスペースを確保するために、デフォルトで折りたたまれるようになりました。折りたたまれている間も、変更されたファイルの数と追加または削除された行数を確認できます。
 
-* When you keep or accept a suggested change, the file is removed from the files changed list.
+* 提案された変更を保持または受け入れると、ファイルは変更されたファイルのリストから削除されます。
 
-* When you stage or commit a file using the Source Control view, this automatically accepts the proposed file changes.
+* ソース管理ビューを使用してファイルをステージングまたはコミットすると、提案されたファイルの変更が自動的に受け入れられます。
 
-* Changes _per file_ (lines added or removed) are now shown for each item in the list.
+* リストの各項目に、_ファイルごと_ の変更 (追加または削除された行) が表示されるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_104/changed-files-list.mp4" title="Video uncollapsing the changed files list and accepting file entries to remove them from the list." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/changed-files-list.mp4" title="変更されたファイルのリストを展開し、ファイルエントリを受け入れてリストから削除するビデオ。" autoplay loop controls muted></video>
 
-### Use custom chat modes in prompt files {#use-custom-chat-modes-in-prompt-files}
+### プロンプトファイルでカスタムチャットモードを使用する {#use-custom-chat-modes-in-prompt-files}
 
-Prompt files are Markdown files in which you write reusable chat prompts. To run a prompt file, type `/` followed by the prompt file name in the chat input field, or use the Play button when you have the prompt file open in the editor.
+プロンプトファイルは、再利用可能なチャットプロンプトを記述する Markdown ファイルです。プロンプトファイルを実行するには、チャット入力フィールドに `/` に続けてプロンプトファイル名を入力するか、エディターでプロンプトファイルを開いているときに再生ボタンを使用します。
 
-You can specify which chat mode should be used for running the prompt file. Previously, you could only use built-in chat modes like `agent`, `edit`, or `ask` in your prompt files. Now, you can also reference custom chat modes in your prompt files.
+プロンプトファイルの実行に使用するチャットモードを指定できます。以前は、プロンプトファイルで `agent`、`edit`、`ask` などの組み込みチャットモードしか使用できませんでした。プロンプトファイルでカスタムチャットモードを参照することもできるようになりました。
 
-![Screenshot showing IntelliSense for custom chat modes in prompt files.](https://code.visualstudio.com/assets/updates/1_104/custom_modes_in_prompt_files.png)
+![プロンプトファイル内のカスタムチャットモードに対する IntelliSense を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/custom_modes_in_prompt_files.png)
 
-Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) with prompt files, chat modes, and custom instructions.
+プロンプトファイル、チャットモード、カスタム指示を使用して [VS Code でチャットをカスタマイズする](https://code.visualstudio.com/docs/copilot/customization/overview) 方法について詳しく学びましょう。
 
-### Configure prompt file suggestions (Experimental) {#configure-prompt-file-suggestions-experimental}
+### プロンプトファイルの提案を構成する (実験的) {#configure-prompt-file-suggestions-experimental}
 
-**Setting**: `setting(chat.promptFilesRecommendations)`
+**設定**: `setting(chat.promptFilesRecommendations)`
 
-Teams often create custom prompt files to standardize AI workflows, but these prompts can be hard to discover when users need them most. You can now configure which prompt files appear as suggestions in the Chat welcome view based on contextual conditions.
+チームは AI ワークフローを標準化するためにカスタムプロンプトファイルを作成することがよくありますが、これらのプロンプトはユーザーが最も必要とするときに見つけにくいことがあります。 अब, आप प्रासंगिक शर्तों के आधार पर चैट वेलकम व्यू में सुझाव के रूप में कौन सी प्रॉम्प्ट फाइलें दिखाई देती हैं, इसे कॉन्फ़िगर कर सकते हैं。
 
-The new `setting(chat.promptFilesRecommendations)` setting supports both simple boolean values and when-clause expressions for context-aware suggestions.
+新しい `setting(chat.promptFilesRecommendations)` 設定は、コンテキストに応じた提案のために、単純なブール値と when 句の両方の式をサポートします。
 
 ```jsonc
 {
   "chat.promptFilesRecommendations": {
-    "plan": true,                            // Always suggest
-    "a11y-audit": "resourceExtname == .html", // Only for HTML files
-    "document": "resourceLangId == markdown", // Only for Markdown files
-    "debug": false                           // Never suggest
+    "plan": true,                            // 常に提案する
+    "a11y-audit": "resourceExtname == .html", // HTML ファイルの場合のみ
+    "document": "resourceLangId == markdown", // Markdown ファイルの場合のみ
+    "debug": false                           // 提案しない
   }
 }
 ```
 
-This helps teams surface the right AI workflows at the right time, making custom prompts more discoverable and relevant to your workspace and file type.
+これにより、チームは適切なタイミングで適切な AI ワークフローを提示でき、カスタムプロンプトがワークスペースやファイルタイプに対してより見つけやすく、関連性の高いものになります。
 
-### Select tools in tool sets {#select-tools-in-tool-sets}
+### ツールセットでツールを選択する {#select-tools-in-tool-sets}
 
-[Tool sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) are a convenient way to group related tools together and VS Code has several built-in tool sets like `edit` or `search`.
+[ツールセット](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) は、関連するツールをグループ化する便利な方法であり、VS Code には `edit` や `search` などのいくつかの組み込みツールセットがあります。
 
-The tools picker now shows which tools are part of each tool set and you can individually enable or disable each tool. You can access the tools picker via the `Configure Tools...` button in the Chat view.
+ツールピッカーには、各ツールセットにどのツールが含まれているかが表示され、各ツールを個別に有効または無効にできます。ツールピッカーには、チャットビューの `Configure Tools...` ボタンからアクセスできます。
 
-![Screenshot showing the tools picker with an expanded edit tool set, listing all available tools.](https://code.visualstudio.com/assets/updates/1_104/tools_in_toolsets.png)
+![ツールピッカーのスクリーンショット。展開された編集ツールセットに、利用可能なすべてのツールがリストされています。](https://code.visualstudio.com/assets/updates/1_104/tools_in_toolsets.png)
 
-### Configure font used in chat {#configure-font-used-in-chat}
+### チャットで使用されるフォントを構成する {#configure-font-used-in-chat}
 
-**Settings**: `setting(chat.fontFamily)`, `setting(chat.fontSize)`
+**設定**: `setting(chat.fontFamily)`、`setting(chat.fontSize)`
 
-VS Code lets you choose which font to use across the editor, however the Chat view lacked that configurability. We have now added two new settings for configuring the font family (`setting(chat.fontFamily)`) and font size (`setting(chat.fontSize)`) of chat messages.
+VS Code では、エディター全体で使用するフォントを選択できますが、チャットビューにはその構成可能性がありませんでした。今回、チャットメッセージのフォントファミリー (`setting(chat.fontFamily)`) とフォントサイズ (`setting(chat.fontSize)`) を構成するための 2 つの新しい設定を追加しました。
 
-![Screenshot showing the Chat view with a custom font and font size.](https://code.visualstudio.com/assets/updates/1_104/chat-configure-font.png)
+![カスタムフォントとフォントサイズで表示されたチャットビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/chat-configure-font.png)
 
-> **Note**: content for lists currently does not yet honor these settings, but this is something that we are working on fixing in the upcoming releases.
+> **注意**: 現在、リストのコンテンツはこれらの設定を尊重しませんが、これは今後のリリースで修正に取り組んでいるものです。
 
-### Collaborate with coding agents (Experimental) {#collaborate-with-coding-agents-experimental}
+### コーディングエージェントとの共同作業 (実験的) {#collaborate-with-coding-agents-experimental}
 
-With coding agents, you delegate tasks to AI agents to be worked on in the background. You can have multiple such agents work in parallel. We're continuing to evolve the chat sessions experience to help you collaborate more effectively with coding agents.
+コーディングエージェントを使用すると、タスクを AI エージェントに委任してバックグラウンドで作業させることができます。複数のそのようなエージェントを並行して作業させることができます。コーディングエージェントとより効果的に共同作業できるように、チャットセッションの体験を進化させ続けています。
 
-#### Chat Sessions view {#chat-sessions-view}
+#### チャットセッションビュー {#chat-sessions-view}
 
-**Setting**: `setting(chat.agentSessionsViewLocation)`
+**設定**: `setting(chat.agentSessionsViewLocation)`
 
-The Chat Sessions view provides a single, unified view for managing both local and contributed chat sessions. We've significantly enhanced the Chat Sessions view where you can now perform all key operations, making it easier to iterate and finalize your coding tasks.
+チャットセッションビューは、ローカルおよびコントリビュートされたチャットセッションの両方を管理するための単一の統一されたビューを提供します。チャットセッションビューを大幅に強化し、すべての主要な操作を実行できるようになり、コーディングタスクの反復と最終決定が容易になりました。
 
-* **Status Bar tracking**: Monitor progress across multiple coding agents directly from the Status Bar.
-* **Multi-session support**: Launch and manage multiple chat sessions from the same view.
-* **Expanded context menus**: Access more actions to interact with your coding agents efficiently.
-* **Rich descriptions**: With rich description enabled, each list entry now includes detailed context to help you quickly find relevant information.
+* **ステータスバーの追跡**: ステータスバーから直接、複数のコーディングエージェントの進捗を監視します。
+* **マルチセッションのサポート**: 同じビューから複数のチャットセッションを起動および管理します。
+* **拡張されたコンテキストメニュー**: コーディングエージェントと効率的に対話するためのより多くのアクションにアクセスします。
+* **リッチな説明**: リッチな説明を有効にすると、各リストエントリに関連情報をすばやく見つけるのに役立つ詳細なコンテキストが含まれるようになりました。
 
-#### GitHub coding agent integration {#github-coding-agent-integration}
+#### GitHub コーディングエージェントの統合 {#github-coding-agent-integration}
 
-We've improved the integration of [GitHub coding agents](https://code.visualstudio.com/docs/copilot/copilot-coding-agent) with chat sessions to deliver a smoother, more intuitive experience.
+よりスムーズで直感的な体験を提供するために、[GitHub コーディングエージェント](https://code.visualstudio.com/docs/copilot/copilot-coding-agent) とチャットセッションの統合を改善しました。
 
-* **Chat editor actions**: Easily view or apply code changes, and check out pull requests directly from the chat editor.
-* **Seamless transitions**: Move from local chats to GitHub agent tasks with improved continuity.
-* **Better session rendering**: Various improvements on cards and tools rendering for better visual clarity.
-* **Performance boosts**: Faster session loading for a more responsive experience.
+* **チャットエディターのアクション**: チャットエディターから直接、コードの変更を簡単に表示または適用し、プルリクエストをチェックアウトします。
+* **シームレスな移行**: 継続性が向上し、ローカルチャットから GitHub エージェントタスクに移行します。
+* **より良いセッションレンダリング**: 視覚的な明瞭さを向上させるためのカードとツールのレンダリングに関するさまざまな改善。
+* **パフォーマンスの向上**: より応答性の高い体験のための高速なセッション読み込み。
 
-<video src="https://code.visualstudio.com/assets/updates/1_104/chat-sessions-view.mp4" title="Video showing Chat Sessions view and integration with GitHub coding agents." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/chat-sessions-view.mp4" title="チャットセッションビューと GitHub コーディングエージェントとの統合を示すビデオ。" autoplay loop controls muted></video>
 
-#### Delegate to coding agent {#delegate-to-coding-agent}
+#### コーディングエージェントへの委任 {#delegate-to-coding-agent}
 
-We continued to expand on ways to delegate local tasks in VS Code to a Copilot coding agent:
+VS Code のローカルタスクを Copilot コーディングエージェントに委任する方法を引き続き拡張しました:
 
-* Fix todos with coding agent:
+* コーディングエージェントで TODO を修正:
 
-    Comments starting with `TODO` now show a Code Action to quickly initiate a coding agent session.
+    `TODO` で始まるコメントに、コーディングエージェントセッションをすばやく開始するためのコードアクションが表示されるようになりました。
 
-    ![Screenshot of a code action above a TODO comment called Delegate to coding agent.](https://code.visualstudio.com/assets/updates/1_104/coding-agent-todo.png)
+    ![TODO コメントの上にある「Delegate to coding agent」というコードアクションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/coding-agent-todo.png)
 
-* Delegate from chat (`setting(githubPullRequests.codingAgent.uiIntegration)`):
+* チャットからの委任 (`setting(githubPullRequests.codingAgent.uiIntegration)`):
 
-    Additional context, including file references, are now forwarded to GitHub coding agent when you perform the **Delegate to coding agent** action in chat. This enables you to precisely plan out a task before handing it off to coding agent to complete it. A new chat editor is opened with the coding agent's progress shown in real-time.
+    チャットで **Delegate to coding agent** アクションを実行すると、ファイル参照を含む追加のコンテキストが GitHub コーディングエージェントに転送されるようになりました。これにより、タスクをコーディングエージェントに渡す前に正確に計画できます。新しいチャットエディターが開き、コーディングエージェントの進捗がリアルタイムで表示されます。
 
-    <video src="https://code.visualstudio.com/assets/updates/1_104/delegate-to-coding-agent.mp4" title="Delegating a task from sidebar chat to coding agent" autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_104/delegate-to-coding-agent.mp4" title="サイドバーチャットからコーディングエージェントへのタスクの委任" autoplay loop controls muted></video>
 
-_Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
+_テーマ: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) ([vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized) でプレビュー)_
 
 
-### Social sign in with Google {#social-sign-in-with-google}
+### Google でのソーシャルサインイン {#social-sign-in-with-google}
 
-The option to sign in or sign up to GitHub Copilot with a Google account is now generally available and rolling out to all users in VS Code.
+Google アカウントで GitHub Copilot にサインインまたはサインアップするオプションが一般提供され、VS Code のすべてのユーザーに展開されています。
 
-![Screenshot showing the sign in dialog showing the option to use a Google account.](https://code.visualstudio.com/assets/updates/1_104/google.png)
+![Google アカウントを使用するオプションが表示されているサインインダイアログのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/google.png)
 
-You can find more information about this in the [announcement GitHub blog post](https://github.blog/changelog/2025-07-15-social-login-with-google-is-now-generally-available).
+詳細については、[GitHub ブログの発表記事](https://github.blog/changelog/2025-07-15-social-login-with-google-is-now-generally-available) を参照してください。
 
-### Terminal auto approve {#terminal-auto-approve}
+### ターミナルの自動承認 {#terminal-auto-approve}
 
-**Setting**: `setting(chat.tools.terminal.enableAutoApprove)`
+**設定**: `setting(chat.tools.terminal.enableAutoApprove)`
 
-Automatically approving terminal commands can greatly streamline agent interactions, but it also comes with [security risks](https://code.visualstudio.com/docs/copilot/security). This release introduces several improvements to terminal auto approve to enhance both usability and security.
+ターミナルコマンドの自動承認は、エージェントとの対話を大幅に効率化できますが、[セキュリティリスク](https://code.visualstudio.com/docs/copilot/security) も伴います。このリリースでは、使いやすさとセキュリティの両方を向上させるために、ターミナルの自動承認にいくつかの改善を導入しています。
 
-* You can now enable or disable terminal auto approve with the `setting(chat.tools.terminal.enableAutoApprove)` setting. This setting can also be set by organizations via [device management](https://code.visualstudio.com/docs/setup/enterprise#_centrally-manage-vs-code-settings).
+* `setting(chat.tools.terminal.enableAutoApprove)` 設定でターミナルの自動承認を有効または無効にできるようになりました。この設定は、[デバイス管理](https://code.visualstudio.com/docs/setup/enterprise#_centrally-manage-vs-code-settings) を介して組織が設定することもできます。
 
-* Before terminal auto approve is actually enabled, you need to explicitly opt in via a dropdown in the Chat view.
+* ターミナルの自動承認が実際に有効になる前に、チャットビューのドロップダウンから明示的にオプトインする必要があります。
 
-    ![Screenshot of a terminal command in the Chat view, showing the Enable Auto Approve dropdown.](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-opt-in.png)
+    ![チャットビューのターミナルコマンドのスクリーンショット。「Enable Auto Approve」ドロップダウンが表示されています。](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-opt-in.png)
 
-* From the Chat view, you can conveniently add auto-approve rules for the command being run, or open the configuration setting:
+* チャットビューから、実行中のコマンドの自動承認ルールを簡単に追加したり、構成設定を開いたりできます:
 
-    ![Screenshot that shows the three standard options are presented for "foo --arg && bar".](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-ui.png)
+    ![「foo --arg && bar」に対して 3 つの標準オプションが表示されているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-ui.png)
 
-    _Theme: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) (preview on [vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire))_
+    _テーマ: [Sapphire](https://marketplace.visualstudio.com/items?itemName=Tyriar.theme-sapphire) ([vscode.dev](https://vscode.dev/editor/theme/Tyriar.theme-sapphire) でプレビュー)_
 
-    This has some basic support for commands to suggest sub-commands where they would be more appropriate, such as suggesting an `npm test` rule rather than `npm`.
+    これには、`npm` ではなく `npm test` ルールを提案するなど、より適切なサブコマンドを提案するための基本的なサポートが含まれています。
 
-* To improve transparency around auto-approved commands, we show which rule was applied in the Chat view, also enabling you to configure that rule:
+* 自動承認されたコマンドの透明性を向上させるために、チャットビューにどのルールが適用されたかを表示し、そのルールを構成できるようにしました:
 
-    ![Screenshot showing the new links added under the tool call in the Chat view for adding new auto approve rules.](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-new-links.png)
+    ![新しい自動承認ルールを追加するためのチャットビューのツールコールの下に追加された新しいリンクを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/terminal-auto-approve-new-links.png)
 
-* We improved the defaults to provide safety and reduce noise. You can see the full list of rules by viewing the setting's default value by opening your `settings.json` file, then entering `chat.tools.terminal.autoApprove` and completing it via `kbstyle(Tab)`.
+* 安全性を高め、ノイズを減らすためにデフォルトを改善しました。`settings.json` ファイルを開き、`chat.tools.terminal.autoApprove` を入力して `kbstyle(Tab)` で補完することで、設定のデフォルト値を確認してルールの完全なリストを表示できます。
 
-* Non-regex rules that contain a backslash or forward slash character are now treated as a path and not only approve that exact path, but also allow either slash type and also a `./` prefix. When using PowerShell, all rules are forced to be case insensitive.
+* バックスラッシュまたはフォワードスラッシュ文字を含む非正規表現ルールは、パスとして扱われるようになり、その正確なパスだけでなく、どちらのスラッシュタイプや `./` プレフィックスも許可します。PowerShell を使用する場合、すべてのルールは大文字と小文字を区別しないように強制されます。
 
-* When agent mode wants to pull content from the internet using `curl`, `wget`, `Invoke-RestMethod`, or `Invoke-WebRequest`, we now show a warning, as this is a common vector for prompt injection attacks.
+* エージェントモードが `curl`、`wget`、`Invoke-RestMethod`、または `Invoke-WebRequest` を使用してインターネットからコンテンツを取得しようとすると、警告が表示されるようになりました。これは、プロンプトインジェクション攻撃の一般的なベクトルであるためです。
 
-Learn more about [terminal auto approve](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands) in our documentation.
+ドキュメントで [ターミナルの自動承認](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands) について詳しく学びましょう。
 
-### Global auto approve {#global-auto-approve}
+### グローバル自動承認 {#global-auto-approve}
 
-Global auto approve has been [an experimental setting since v1.99](https://code.visualstudio.com/updates/v1_99#_agent-mode-tool-approvals). What we have observed is that users have been enabling this setting without thinking deeply enough about the consequences. Additionally, some users thought that enabling the `setting(chat.tools.autoApprove)` setting was a prerequisite to enabling terminal auto approve, which was never the case.
+グローバル自動承認は [v1.99 以降、実験的な設定](https://code.visualstudio.com/updates/v1_99#_agent-mode-tool-approvals) でした。私たちが観察したところによると、ユーザーは結果を深く考えずにこの設定を有効にしていました。さらに、一部のユーザーは `setting(chat.tools.autoApprove)` 設定を有効にすることがターミナルの自動承認を有効にするための前提条件であると考えていましたが、それは決して事実ではありませんでした。
 
-To combat these misconceptions and to further protect our users, there is now a deservedly scary-looking warning the first time global auto approve attempts to be used, so the user can easily back out and disable the setting:
+これらの誤解に対処し、ユーザーをさらに保護するために、グローバル自動承認が初めて使用されようとするときに、当然のことながら恐ろしい見た目の警告が表示されるようになりました。これにより、ユーザーは簡単に元に戻して設定を無効にできます:
 
-![Screenshot of a warning dialog that appears when global auto approve is used for the first time.](https://code.visualstudio.com/assets/updates/1_104/global-auto-approve-warning.png)
+![グローバル自動承認が初めて使用されたときに表示される警告ダイアログのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/global-auto-approve-warning.png)
 
-The setting has also been changed to the clearer `setting(chat.tools.global.autoApprove)` without any automatic migration, so all users (accidental or intentional) need to go and explicitly set it again.
+設定も、自動移行なしでより明確な `setting(chat.tools.global.autoApprove)` に変更されました。そのため、すべてのユーザー (偶発的または意図的) は、再度明示的に設定する必要があります。
 
-### Math rendering enabled by default {#math-rendering-enabled-by-default}
+### 数式レンダリングがデフォルトで有効に {#math-rendering-enabled-by-default}
 
-**Setting**: `setting(chat.math.enabled)`
+**設定**: `setting(chat.math.enabled)`
 
-Rendering of mathematical equations in chat responses is now generally available and enabled by default. You can disable this functionality with the `setting(chat.math.enabled)` setting.
+チャット応答での数式のレンダリングが一般提供され、デフォルトで有効になりました。この機能は `setting(chat.math.enabled)` 設定で無効にできます。
 
-![Screenshot of the Chat view, showing inline and block equations in a chat response.](https://code.visualstudio.com/assets/updates/1_104/chat-math.png)
+![チャットビューのスクリーンショット。チャット応答にインラインおよびブロック数式が表示されています。](https://code.visualstudio.com/assets/updates/1_104/chat-math.png)
 
-This feature is powered by [KaTeX](https://katex.org) and supports both inline and block math equations. Inline math equations can be written by wrapping the markup in single dollar signs (`$...$`), while block math equations use two dollar signs (`$$...$$`).
+この機能は [KaTeX](https://katex.org) を利用しており、インラインおよびブロックの両方の数式をサポートしています。インライン数式は、マークアップを単一のドル記号 (`$...$`) で囲むことで記述でき、ブロック数式は 2 つのドル記号 (`$$...$$`) を使用します。
 
-### Chat view default visibility {#chat-view-default-visibility}
+### チャットビューのデフォルトの可視性 {#chat-view-default-visibility}
 
-**Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
+**設定**: `setting(workbench.secondarySideBar.defaultVisibility)`
 
-When you first open a workspace, the Secondary Side Bar with the Chat view is visible by default, inviting you to ask questions or start an agentic session right away. You can configure this behavior with the `setting(workbench.secondarySideBar.defaultVisibility)` setting or by using the dropdown of the Chat view itself:
+ワークスペースを初めて開くと、チャットビューのあるセカンダリサイドバーがデフォルトで表示され、すぐに質問したり、エージェントセッションを開始したりできます。この動作は `setting(workbench.secondarySideBar.defaultVisibility)` 設定を使用するか、チャットビュー自体のドロップダウンを使用して構成できます:
 
-![Screenshot showing Chat view menu with the option to set the default Secondary Side Bar visibility.](https://code.visualstudio.com/assets/updates/1_104/auxview.png)
+![セカンダリサイドバーのデフォルトの可視性を設定するオプションがあるチャットビューメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/auxview.png)
 
-### Improved task support {#improved-task-support}
+### タスクサポートの改善 {#improved-task-support}
 
-* Input request detection
+* 入力リクエストの検出
 
-    When you run a task or terminal command in agent mode, the agent now detects when the process requests user input, and you're prompted to respond in chat. If you type in the terminal while a prompt is present, the prompt will hide automatically. When options and descriptions are provided (such as `[Y] Yes [N] No`), these are surfaced in the confirmation prompt.
+    エージェントモードでタスクまたはターミナルコマンドを実行すると、エージェントはプロセスがユーザー入力を要求したことを検出し、チャットで応答するように促されます。プロンプトが表示されている間にターミナルに入力すると、プロンプトは自動的に非表示になります。オプションと説明が提供されている場合 (例: `[Y] Yes [N] No`)、これらは確認プロンプトに表示されます。
 
-    <video src="https://code.visualstudio.com/assets/updates/1_104/prompt-input-demo.mp4" title="Example of input being detected and responded to" autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_104/prompt-input-demo.mp4" title="入力が検出され、応答される例" autoplay loop controls muted></video>
 
-* Error detection for tasks with problem matchers
+* 問題マッチャーを使用したタスクのエラー検出
 
-    For tasks that use problem matchers, the agent now collects and surfaces errors based on the problem matcher results, rather than relying on the language model to evaluate output. Problems are presented in a dropdown within the chat progress message, allowing you to navigate directly to the problem location. This ensures that errors are reported only when relevant to the current task execution.
+    問題マッチャーを使用するタスクの場合、エージェントは言語モデルに出力を評価させるのではなく、問題マッチャーの結果に基づいてエラーを収集して表示するようになりました。問題はチャットの進捗メッセージ内のドロップダウンに表示され、問題の場所に直接移動できます。これにより、現在のタスク実行に関連する場合にのみエラーが報告されるようになります。
 
-* Compound task support
+* 複合タスクのサポート
 
-    Agent mode now supports running compound tasks. When you run a compound task, the agent indicates progress and output for each dependent task, including any prompts for user input. This enables more complex workflows and better visibility into multi-step task execution.
+    エージェントモードは、複合タスクの実行をサポートするようになりました。複合タスクを実行すると、エージェントはユーザー入力のプロンプトを含む、各依存タスクの進捗と出力を示します。これにより、より複雑なワークフローと、複数ステップのタスク実行の可視性が向上します。
 
-    In the example below, the VS Code - Build task is run. Output is assessed for each dependency task and a problem is surfaced to the user in the response and in the progress message dropdown.
+    以下の例では、VS Code - Build タスクが実行されます。各依存タスクの出力が評価され、応答と進捗メッセージのドロップダウンでユーザーに問題が提示されます。
 
-    <video src="https://code.visualstudio.com/assets/updates/1_104/build-task.mp4" title="Example of agent running the VS Code - Build task" autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_104/build-task.mp4" title="エージェントが VS Code - Build タスクを実行する例" autoplay loop controls muted></video>
 
-### Improved terminal support {#improved-terminal-support}
+### ターミナルサポートの改善 {#improved-terminal-support}
 
-* Moved more terminal tools to core
+* より多くのターミナルツールをコアに移動
 
-    Like [the `runInTerminal` tool last release](https://code.visualstudio.com/updates/v1_103#_improved-reliability-and-performance-of-the-run-in-terminal-and-task-tools), the `terminalSelection` and `terminalLastCommand` tools have been moved from the extension to core, which should provide general reliability improvements.
+    [前回のリリースでの `runInTerminal` ツール](https://code.visualstudio.com/updates/v1_103#_improved-reliability-and-performance-of-the-run-in-terminal-and-task-tools) と同様に、`terminalSelection` と `terminalLastCommand` ツールが拡張機能からコアに移動され、全体的な信頼性が向上するはずです。
 
-* Configurable terminal tool shell integration timeout
+* 構成可能なターミナルツールのシェル統合タイムアウト
 
-    Whenever the `runInTerminal` tool tries to create a terminal, it waits a period for shell integration to activate. If your shell is especially slow to start up, say you have a very heavy PowerShell profile, this could cause it to wait the previously fixed 5-second timeout and still end up failing in the end. This timeout is now configurable via the `setting(chat.tools.terminal.shellIntegrationTimeout)` setting.
+    `runInTerminal` ツールがターミナルを作成しようとすると、シェル統合がアクティブになるまで一定期間待機します。非常に重い PowerShell プロファイルがあるなど、シェルの起動が特に遅い場合、以前は固定されていた 5 秒のタイムアウトを待っても、最終的に失敗する可能性がありました。このタイムアウトは、`setting(chat.tools.terminal.shellIntegrationTimeout)` 設定で構成できるようになりました。
 
-* Prevent Command Prompt usage
+* コマンドプロンプトの使用を防止
 
-    Since shell integration isn't really possible in Command Prompt, at least with the capabilities that Copilot needs, Copilot now opts to use Windows PowerShell instead, which should have shell integration by default. This should improve the reliability of the `runInTerminal` tool when your default shell is Command Prompt.
+    コマンドプロンプトでは、少なくとも Copilot が必要とする機能ではシェル統合が実際には不可能であるため、Copilot は代わりに Windows PowerShell を使用することを選択するようになりました。これにより、デフォルトでシェル統合が有効になるはずです。これにより、デフォルトのシェルがコマンドプロンプトの場合に `runInTerminal` ツールの信頼性が向上するはずです。
 
-    If, for some reason, you want Copilot to use Command Prompt, this is currently not possible. We will likely be adding the ability to customize the terminal profile used by Copilot soon, which is tracked in [#253945](https://github.com/microsoft/vscode/issues/253945).
+    何らかの理由で Copilot にコマンドプロンプトを使用させたい場合、現在は不可能です。近いうちに、Copilot が使用するターミナルプロファイルをカスタマイズする機能を追加する予定です。これは [#253945](https://github.com/microsoft/vscode/issues/253945) で追跡されています。
 
-### Todo List tool {#todo-list-tool}
+### Todo リストツール {#todo-list-tool}
 
-The todo list tool helps agents break down complex multi-step tasks into smaller tasks and report progress to help you track individual items. We've made improvements to this tool, which is now enabled by default.
+Todo リストツールは、エージェントが複雑な複数ステップのタスクをより小さなタスクに分解し、進捗を報告して個々の項目を追跡するのに役立ちます。このツールに改善を加え、デフォルトで有効になりました。
 
-Tool progress is displayed in the Todo control at the top of the Chat view, which automatically collapses as the todo list is worked through and shows only the current task in progress.
+ツールの進捗は、チャットビューの上部にある Todo コントロールに表示されます。これは、Todo リストが処理されるにつれて自動的に折りたたまれ、進行中の現在のタスクのみが表示されます。
 
-### Skip tool calls {#skip-tool-calls}
+### ツール呼び出しをスキップする {#skip-tool-calls}
 
-When the agent requests confirmation for a tool call, you can now choose to skip the tool call and let the agent continue. You can still cancel the request or enter a new request via the chat input box.
+エージェントがツール呼び出しの確認を要求したときに、ツール呼び出しをスキップしてエージェントを続行させることを選択できるようになりました。チャット入力ボックスを介してリクエストをキャンセルしたり、新しいリクエストを入力したりすることもできます。
 
-### Improvements to semantic workspace search {#improvements-to-semantic-workspace-search}
+### セマンティックワークスペース検索の改善 {#improvements-to-semantic-workspace-search}
 
-We've upgraded the `#codebase` tool to use a new [embeddings](https://en.wikipedia.org/wiki/Embedding_(machine_learning)) model for semantic searching for code in your workspace. This new model provides better results for code searches. The new embeddings also use less storage space, requiring only 6% of our previous model's on-disk storage size for each embedding.
+`#codebase` ツールをアップグレードし、ワークスペース内のコードをセマンティック検索するための新しい [埋め込み](https://en.wikipedia.org/wiki/Embedding_(machine_learning)) モデルを使用するようにしました。この新しいモデルは、コード検索でより良い結果を提供します。新しい埋め込みはストレージスペースも少なく、各埋め込みで以前のモデルのディスク上のストレージサイズの 6% しか必要としません。
 
-We'll be gradually rolling out this new embeddings model over the next few weeks. Your workspace will be automatically updated to use this new embeddings model, so no action is required. VS Code Insiders is already using the new model if you want to try it out before it rolls out to you.
+今後数週間で、この新しい埋め込みモデルを段階的に展開していきます。ワークスペースは自動的にこの新しい埋め込みモデルを使用するように更新されるため、アクションは必要ありません。VS Code Insiders はすでに新しいモデルを使用しているため、展開される前に試すことができます。
 
-### Hide and disable GitHub Copilot AI features {#hide-and-disable-github-copilot-ai-features}
+### GitHub Copilot AI 機能を非表示および無効にする {#hide-and-disable-github-copilot-ai-features}
 
-**Setting**: `setting(chat.disableAIFeatures)`
+**設定**: `setting(chat.disableAIFeatures)`
 
-We are introducing a new setting `setting(chat.disableAIFeatures)` for disabling and hiding built-in AI features provided by GitHub Copilot, including chat, code completions, and next edit suggestions.
+チャット、コード補完、次の編集候補など、GitHub Copilot が提供する組み込みの AI 機能を無効にして非表示にするための新しい設定 `setting(chat.disableAIFeatures)` を導入します。
 
-The setting has the following advantages over the previous solution we had in place:
+この設定には、以前のソリューションに比べて次の利点があります:
 
-* Syncs across your devices unless you disable this explicitly
-* Disables the Copilot extensions in case they are installed
-* Configure the setting per-profile or per-workspace, making it easy to disable AI features selectively
+* 明示的に無効にしない限り、デバイス間で同期されます
+* インストールされている場合、Copilot 拡張機能を無効にします
+* プロファイルごとまたはワークスペースごとに設定を構成できるため、AI 機能を簡単に選択的に無効にできます
 
-The command to "Hide AI Features" was renamed to reflect this change and will now reveal this new setting in the settings editor.
+「Hide AI Features」コマンドは、この変更を反映するように名前が変更され、設定エディターでこの新しい設定が表示されるようになります。
 
-> **Note**: users that were hiding AI features previously will continue to see AI features hidden. You can update the setting in addition if you want to synchronize your choice across devices.
+> **注意**: 以前に AI 機能を非表示にしていたユーザーは、引き続き AI 機能が非表示になります。選択をデバイス間で同期したい場合は、追加で設定を更新できます。
 
 ## MCP {#mcp}
 
-### Support for server instructions {#support-for-server-instructions}
+### サーバー指示のサポート {#support-for-server-instructions}
 
-VS Code now reads MCP server instructions and will include them in its base prompt.
+VS Code は MCP サーバーの指示を読み取り、ベースプロンプトに含めるようになりました。
 
-### MCP auto discovery disabled by default {#mcp-auto-discovery-disabled-by-default}
+### MCP 自動検出がデフォルトで無効に {#mcp-auto-discovery-disabled-by-default}
 
-**Setting**: `setting(chat.mcp.discovery.enabled)`
+**設定**: `setting(chat.mcp.discovery.enabled)`
 
-VS Code supports [automatic discovery of MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) installed in other apps like Claude Code. As MCP support has matured in VS Code, auto-discovery is now disabled by default, but you can re-enable it using the `setting(chat.mcp.discovery.enabled)` setting.
+VS Code は、Claude Code などの他のアプリにインストールされている [MCP サーバーの自動検出](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) をサポートしています。VS Code での MCP サポートが成熟したため、自動検出はデフォルトで無効になりましたが、`setting(chat.mcp.discovery.enabled)` 設定を使用して再度有効にできます。
 
-### Enable MCP {#enable-mcp}
+### MCP を有効にする {#enable-mcp}
 
-**Setting**: `setting(chat.mcp.access)`
+**設定**: `setting(chat.mcp.access)`
 
-The `chat.mcp.enabled` setting that previously controlled whether MCP servers could run in VS Code has been migrated to a new `setting(chat.mcp.access)` setting with more descriptive options:
+以前に VS Code で MCP サーバーを実行できるかどうかを制御していた `chat.mcp.enabled` 設定は、より説明的なオプションを持つ新しい `setting(chat.mcp.access)` 設定に移行されました:
 
-* `all`: allow all MCP servers to run (equivalent to the previous `true` value)
-* `none`: disable MCP support entirely (equivalent to the previous `false` value)
+* `all`: すべての MCP サーバーの実行を許可します (以前の `true` 値に相当)
+* `none`: MCP サポートを完全に無効にします (以前の `false` 値に相当)
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Focus chat confirmation action {#focus-chat-confirmation-action}
+### チャット確認アクションにフォーカスする {#focus-chat-confirmation-action}
 
-We've added a command, **Focus Chat Confirmation** `(kb(workbench.action.chat.focusConfirmation))`, which focuses the confirmation dialog, if present, or announces to screen reader users that confirmation is not required.
+コマンド **Focus Chat Confirmation** `(kb(workbench.action.chat.focusConfirmation))` を追加しました。これは、確認ダイアログが存在する場合はそれにフォーカスし、存在しない場合はスクリーンリーダーユーザーに確認が不要であることをアナウンスします。
 
-## Code Editing {#code-editing}
+## コード編集 {#code-editing}
 
-### Configurable inline suggestion delay {#configurable-inline-suggestion-delay}
+### 構成可能なインライン提案の遅延 {#configurable-inline-suggestion-delay}
 
-**Setting**: `setting(editor.inlineSuggest.minShowDelay)`
+**設定**: `setting(editor.inlineSuggest.minShowDelay)`
 
-A new setting `setting(editor.inlineSuggest.minShowDelay)` enables you to configure how quickly inline suggestions can appear after you type. This can be useful if you find that suggestions are appearing too quickly and getting in the way of your typing.
+新しい設定 `setting(editor.inlineSuggest.minShowDelay)` を使用すると、入力後にインライン提案がどれだけ早く表示されるかを構成できます。これは、提案が早すぎて入力の邪魔になると感じる場合に便利です。
 
-## Editor Experience {#editor-experience}
+## エディター体験 {#editor-experience}
 
-### Window border color support on Windows {#window-border-color-support-on-windows}
+### Windows でのウィンドウ境界線の色のサポート {#window-border-color-support-on-windows}
 
-**Setting**: `setting(window.border)`
+**設定**: `setting(window.border)`
 
-We are happy to add a new setting `setting(window.border)` on Windows that enables you to show a colored border around the VS Code window. The setting has the following options:
+Windows で VS Code ウィンドウの周りに色付きの境界線を表示できる新しい設定 `setting(window.border)` を追加できることを嬉しく思います。この設定には次のオプションがあります:
 
-* `default`: respect color theme settings, fallback to Windows settings
-* `system`: respect Windows settings only (window title accent color)
-* `off`: disable border colors
-* `<color>`: specific color in Hex, RGB, RGBA, HSL, HSLA format
+* `default`: カラーテーマの設定を尊重し、Windows の設定にフォールバックします
+* `system`: Windows の設定のみを尊重します (ウィンドウタイトルのアクセントカラー)
+* `off`: 境界線の色を無効にします
+* `<color>`: Hex、RGB、RGBA、HSL、HSLA 形式の特定の色
 
-You can configure colors per workspace, making it easier to distinguish which workspace is opened in which window.
+ワークスペースごとに色を構成できるため、どのウィンドウでどのワークスペースが開かれているかを簡単に区別できます。
 
-![Screenshot of several VS Code windows with different border colors.](https://code.visualstudio.com/assets/updates/1_104/border.png)
+![異なる境界線色の複数の VS Code ウィンドウのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/border.png)
 
-When you configure `setting(window.border)` as `default`, a theme is able to set the border color for active and inactive windows using the `window.activeBorder` and `window.inactiveBorder` color keys. You can further override these colors from the `setting(workbench.colorCustomizations)` setting.
+`setting(window.border)` を `default` として構成すると、テーマは `window.activeBorder` と `window.inactiveBorder` のカラーキーを使用して、アクティブおよび非アクティブなウィンドウの境界線の色を設定できます。これらの色は、`setting(workbench.colorCustomizations)` 設定からさらに上書きできます。
 
-### Manage extension account preference {#manage-extension-account-preference}
+### 拡張機能のアカウント設定を管理する {#manage-extension-account-preference}
 
-We've added an **Accounts: Manage Extension Account Preferences** command to the Command Palette. When invoked, it shows a list of extensions that have access to authentication accounts and lets you change the account that those extensions use. You are even able to sign in to a new account right from the list.
+コマンドパレットに **Accounts: Manage Extension Account Preferences** コマンドを追加しました。呼び出されると、認証アカウントにアクセスできる拡張機能のリストが表示され、それらの拡張機能が使用するアカウントを変更できます。リストから直接新しいアカウントにサインインすることもできます。
 
-This builds on the [account management functionality that we added a year ago](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference).
+これは、[1 年前に追加したアカウント管理機能](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference) に基づいています。
 
-### Editor tab index {#editor-tab-index}
+### エディタータブのインデックス {#editor-tab-index}
 
-**Setting**: `setting(workbench.editor.showTabIndex)`
+**設定**: `setting(workbench.editor.showTabIndex)`
 
-You can now render the index of an editor tab in the tab's label. This can be helpful when you have many tabs open and want to quickly navigate between them using keyboard shortcuts. Enable this functionality with the `setting(workbench.editor.showTabIndex)` setting.
+エディタータブのラベルにタブのインデックスをレンダリングできるようになりました。これは、多くのタブを開いていて、キーボードショートカットを使用してそれらの間をすばやく移動したい場合に便利です。この機能は `setting(workbench.editor.showTabIndex)` 設定で有効にします。
 
-![Screenshot of editor tabs with numbers in front of them, indicating their index.](https://code.visualstudio.com/assets/updates/1_104/editorTabIndex.png)
+![インデックスを示す数字が前に付いたエディタータブのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/editorTabIndex.png)
 
-### Editor tab bar scrollbar visibility {#editor-tab-bar-scrollbar-visibility}
+### エディタータブバーのスクロールバーの可視性 {#editor-tab-bar-scrollbar-visibility}
 
-**Setting**: `setting(workbench.editor.titleScrollbarVisibility)`
+**設定**: `setting(workbench.editor.titleScrollbarVisibility)`
 
-The `setting(workbench.editor.titleScrollbarVisibility)` enables you to control when the scrollbar in the editor tab bar is visible. The default value `auto` shows the scrollbar only when the tabs overflow and a tab is hovered. You can also set it to `visible` to always show the scrollbar when the tabs overflow, or `hidden` to never show it.
+`setting(workbench.editor.titleScrollbarVisibility)` を使用すると、エディタータブバーのスクロールバーがいつ表示されるかを制御できます。デフォルト値の `auto` は、タブがオーバーフローし、タブがホバーされたときにのみスクロールバーを表示します。また、タブがオーバーフローしたときに常にスクロールバーを表示するには `visible` に、表示しないようにするには `hidden` に設定することもできます。
 
-### Issue reporter improvements {#issue-reporter-improvements}
+### 問題報告者の改善 {#issue-reporter-improvements}
 
-When reporting issues in VS Code or extensions via the built-in issue reporter, you can now choose either **Create on GitHub** or **Preview on GitHub** via a dropdown on the report button. If the button does not populate a dropdown and only shows Create or Preview, this likely means that you are still loading extension data or need to ensure that you are signed in with a GitHub account that provides the correct scopes.
+組み込みの問題報告者を介して VS Code または拡張機能の問題を報告する際に、レポートボタンのドロップダウンから **Create on GitHub** または **Preview on GitHub** のいずれかを選択できるようになりました。ボタンがドロップダウンを表示せず、Create または Preview のみを表示する場合、これは拡張機能データをまだ読み込んでいるか、正しいスコープを提供する GitHub アカウントでサインインしていることを確認する必要があることを意味している可能性があります。
 
-![Screenshot of a dropdown showing Create on Github and Preview on Github in the issue reporter.](https://code.visualstudio.com/assets/updates/1_104/issue-reporter-dropdown.png)
+![問題報告者で Create on Github と Preview on Github を表示するドロップダウンのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/issue-reporter-dropdown.png)
 
 ## Notebooks {#notebooks}
 
-### Improved NES suggestions (Experimental) {#improved-nes-suggestions-experimental}
+### NES 提案の改善 (実験的) {#improved-nes-suggestions-experimental}
 
-**Setting**: `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)`
+**設定**: `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)`
 
-We are experimenting with improving the quality of next edit suggestions for notebooks. Currently, the language model has access to the contents of the active cell when generating suggestions. With the `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)` setting enabled, the language model has access to the entire notebook, enabling it to generate more accurate and higher-quality next edit suggestions.
+ノートブックの次の編集提案の品質を向上させる実験を行っています。現在、言語モデルは提案を生成する際にアクティブなセルの内容にアクセスできます。`setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)` 設定を有効にすると、言語モデルはノートブック全体にアクセスできるようになり、より正確で高品質な次の編集提案を生成できます。
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Preview and migrate Git worktree changes {#preview-and-migrate-git-worktree-changes}
+### Git worktree の変更をプレビューして移行する {#preview-and-migrate-git-worktree-changes}
 
-You can now preview differences between worktree files and your current workspace by right-clicking on a worktree file to open the context menu in the Source Control Changes view and selecting **Compare with Workspace**.
+ソース管理の変更ビューで worktree ファイルを右クリックしてコンテキストメニューを開き、**Compare with Workspace** を選択することで、worktree ファイルと現在のワークスペースとの違いをプレビューできるようになりました。
 
-![Screenshot of the context menu shown in the SCM view on a changed file in a worktree, with the Compare with Workspace option selected.](https://code.visualstudio.com/assets/updates/1_104/image.png)
+![SCM ビューで worktree 内の変更されたファイルに表示されたコンテキストメニューのスクリーンショット。「Compare with Workspace」オプションが選択されています。](https://code.visualstudio.com/assets/updates/1_104/image.png)
 
-After reviewing your changes, you can use the **Migrate Worktree Changes...** command from the Command Palette (`kb(git.migrateWorktreeChanges)`) to merge all changes from a worktree into your current workspace. This makes it easy to work across multiple worktrees and selectively bring changes back into your main repository.
+変更を確認した後、コマンドパレットから **Migrate Worktree Changes...** コマンド (`kb(git.migrateWorktreeChanges)`) を使用して、worktree からのすべての変更を現在のワークスペースにマージできます。これにより、複数の worktree 間で作業し、選択的に変更をメインリポジトリに戻すことが容易になります。
 
-Learn more about [Git worktrees in VS Code](https://code.visualstudio.com/docs/sourcecontrol/overview#_worktrees).
+VS Code での [Git worktrees](https://code.visualstudio.com/docs/sourcecontrol/overview#_worktrees) について詳しく学びましょう。
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Terminal window discoverability and polish {#terminal-window-discoverability-and-polish}
+### ターミナルウィンドウの発見可能性と洗練 {#terminal-window-discoverability-and-polish}
 
-A common request is to allow terminals to be opened in separate windows. This functionality has existed for about one and a half years, but it has not been particularly discoverable. This iteration, we added multiple entry points for this functionality:
+ターミナルを別のウィンドウで開けるようにしてほしいという要望がよくあります。この機能は約 1 年半前から存在していましたが、特に発見しやすくはありませんでした。このイテレーションでは、この機能のための複数のエントリポイントを追加しました:
 
-* The new command `kb(workbench.action.terminal.newInNewWindow)`.
-* The empty editor and tab well menus now have a **New Terminal** entry.
-* The new terminal dropdown has been shuffled around and now has a **New Terminal Window** entry.
-* The top-level terminal menu now has a **New Terminal Window** entry.
+* 新しいコマンド `kb(workbench.action.terminal.newInNewWindow)`。
+* 空のエディターとタブウェルのメニューに **New Terminal** エントリが追加されました。
+* 新しいターミナルのドロップダウンが再編成され、**New Terminal Window** エントリが追加されました。
+* トップレベルのターミナルメニューに **New Terminal Window** エントリが追加されました。
 
-We also polished the experience where these new terminal windows open in compact mode. If you add a new tab to the window, it automatically exits compact mode.
+また、これらの新しいターミナルウィンドウがコンパクトモードで開くエクスペリエンスも洗練しました。ウィンドウに新しいタブを追加すると、自動的にコンパクトモードが終了します。
 
-![Screenshot of the terminal window open in compact mode, hiding tabs to make more room for terminal content.](https://code.visualstudio.com/assets/updates/1_104/terminal-window.png)
+![コンパクトモードで開かれたターミナルウィンドウのスクリーンショット。ターミナルのコンテンツにより多くのスペースを確保するためにタブが非表示になっています。](https://code.visualstudio.com/assets/updates/1_104/terminal-window.png)
 
-### Terminal actions in terminal editors {#terminal-actions-in-terminal-editors}
+### ターミナルエディターでのターミナルアクション {#terminal-actions-in-terminal-editors}
 
-The actions that are available in the terminal view (new terminal dropdown, clear terminal, etc.) are now also available for terminals in the editor area and terminal windows.
+ターミナルビューで利用可能なアクション (新しいターミナルのドロップダウン、ターミナルのクリアなど) は、エディターエリアとターミナルウィンドウのターミナルでも利用できるようになりました。
 
-![Screenshot of different terminal actions in the editor actions menu.](https://code.visualstudio.com/assets/updates/1_104/terminal-editor-actions.png)
+![エディターアクションメニューのさまざまなターミナルアクションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/terminal-editor-actions.png)
 
-Just like in the terminal view, you can right-click the actions area to move them out of the overflow menu.
+ターミナルビューと同様に、アクションエリアを右クリックしてオーバーフローメニューから移動させることができます。
 
-### Terminal IntelliSense improvements (Preview) {#terminal-intellisense-improvements-preview}
+### ターミナル IntelliSense の改善 (プレビュー) {#terminal-intellisense-improvements-preview}
 
-Terminal IntelliSense is getting several improvements this release:
+このリリースでは、ターミナル IntelliSense にいくつかの改善が加えられています:
 
-* Multiple performance improvements, these disproportionately affect the experience on Windows.
-* `git` completions are now more reliable on Windows due to the removal of the `sed` dependency, which isn't available on Windows.
-* `git` completions now have familiar icons to represent commits, branches, remotes, stashes, and tags.
-    ![Screenshot of new icons showing for tags and branches on completions for "git checkout"](https://code.visualstudio.com/assets/updates/1_104/terminal-suggest.png)
-* A large number of completion specs were added: `adb`, `basename`, `bundle`, `clear`, `cut`, `date`, `dd`, `diff`, `dig`, `dirname`, `docker-compose`, `docker`, `dotnet`, `env`, `export`, `fdisk`, `fmt`, `fold`, `gh`, `go`, `htop`, `id`, `jq`, `ln`, `lsblk`, `lsof`, `mount`, `nl`, `od`, `paste`, `ping`, `pkill`, `readlink`, `rsync`, `ruby`, `ruff`, `sed`, `seq`, `shred`, `sort`, `source`, `split`, `stat`, `su`, `sudo`, `tac`, `tar`, `tee`, `time`, `tr`, `traceroute`, `tree`, `truncate`, `uniq`, `unzip`, `wc`, `where`, `whereis`, `which`, `who`, `xargs`, `xxd`, `yo`, `zip`
+* 複数のパフォーマンス改善。これらは Windows でのエクスペリエンスに特に大きな影響を与えます。
+* Windows で利用できない `sed` 依存関係が削除されたため、`git` 補完が Windows でより信頼性が高くなりました。
+* `git` 補完には、コミット、ブランチ、リモート、スタッシュ、タグを表すおなじみのアイコンが表示されるようになりました。
+    ![「git checkout」の補完でタグとブランチに新しいアイコンが表示されているスクリーンショット](https://code.visualstudio.com/assets/updates/1_104/terminal-suggest.png)
+* 多数の補完仕様が追加されました: `adb`, `basename`, `bundle`, `clear`, `cut`, `date`, `dd`, `diff`, `dig`, `dirname`, `docker-compose`, `docker`, `dotnet`, `env`, `export`, `fdisk`, `fmt`, `fold`, `gh`, `go`, `htop`, `id`, `jq`, `ln`, `lsblk`, `lsof`, `mount`, `nl`, `od`, `paste`, `ping`, `pkill`, `readlink`, `rsync`, `ruby`, `ruff`, `sed`, `seq`, `shred`, `sort`, `source`, `split`, `stat`, `su`, `sudo`, `tac`, `tar`, `tee`, `time`, `tr`, `traceroute`, `tree`, `truncate`, `uniq`, `unzip`, `wc`, `where`, `whereis`, `which`, `who`, `xargs`, `xxd`, `yo`, `zip`
 
-### Terminal sticky scroll improvements {#terminal-sticky-scroll-improvements}
+### ターミナルのスティッキースクロールの改善 {#terminal-sticky-scroll-improvements}
 
-We have now enabled terminal sticky scroll by default. We have made several improvements for a better experience, such as improved behavior when using a pager. Terminal sticky scroll is now compatible with the `setting(editor.tabFocusMode)` setting.
+ターミナルのスティッキースクロールをデフォルトで有効にしました。ページャーを使用する際の動作の改善など、より良いエクスペリエンスのためにいくつかの改善を行いました。ターミナルのスティッキースクロールは、`setting(editor.tabFocusMode)` 設定と互換性があります。
 
-## Languages {#languages}
+## 言語 {#languages}
 
-### JavaScript and TypeScript {#javascript-and-typescript}
+### JavaScript と TypeScript {#javascript-and-typescript}
 
-After reviewing usage numbers, we decided to remove our built-in `bower.json` IntelliSense. Bower has been [deprecated since 2017](https://bower.io/blog/2017/how-to-migrate-away-from-bower/) and our built-in support had little usage and was not being actively maintained.
+使用状況の数値をレビューした結果、組み込みの `bower.json` IntelliSense を削除することにしました。Bower は [2017 年から非推奨](https://bower.io/blog/2017/how-to-migrate-away-from-bower/) であり、私たちの組み込みサポートはほとんど使用されておらず、積極的にメンテナンスされていませんでした。
 
-Bower recommends that users migrate to `npm` or `yarn`. Continued support for Bower in VS Code can be provided by extensions.
+Bower は、ユーザーが `npm` または `yarn` に移行することを推奨しています。VS Code での Bower の継続的なサポートは、拡張機能によって提供できます。
 
 ### Python {#python}
 
-#### Python Environments extension support for Pipenv {#python-environments-extension-support-for-pipenv}
+#### Python Environments 拡張機能の Pipenv サポート {#python-environments-extension-support-for-pipenv}
 
-Pipenv environments can now be discovered and selected just like in the Python extension. In addition, they appear in the **Environment Manager** view in the Python sidebar, where they are grouped and displayed alongside your other environment types.
+Pipenv 環境が Python 拡張機能と同様に検出および選択できるようになりました。さらに、Python サイドバーの **Environment Manager** ビューに表示され、他の環境タイプと一緒にグループ化されて表示されます。
 
-![Screenshot showing the Python sidebar with Pipenv environments expanded.](https://code.visualstudio.com/assets/updates/1_104/pipenv-supported-screenshot.png)
+![Pipenv 環境が展開された Python サイドバーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_104/pipenv-supported-screenshot.png)
 
-#### Configure environment variable injection {#configure-environment-variable-injection}
+#### 環境変数のインジェクションを構成する {#configure-environment-variable-injection}
 
-A new setting, `setting(python.useEnvFile)`, controls whether environment variables from `.env` files and the `setting(python.envFile)` setting are injected into terminals when the Python Environments extension is enabled.
+新しい設定 `setting(python.useEnvFile)` は、Python Environments 拡張機能が有効になっている場合に、`.env` ファイルと `setting(python.envFile)` 設定からの環境変数がターミナルにインジェクトされるかどうかを制御します。
 
-#### Python Environments extension improvements {#python-environments-extension-improvements}
+#### Python Environments 拡張機能の改善 {#python-environments-extension-improvements}
 
-The [Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) continued to receive bug fixes and improvements as part of the controlled roll-out to stable users. To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code `settings.json` file: `"python.useEnvironmentsExtension": true`.
+[Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) は、安定版ユーザーへの制御されたロールアウトの一環として、バグ修正と改善を受け続けました。ロールアウト中に Python Environments 拡張機能を使用するには、拡張機能がインストールされていることを確認し、VS Code の `settings.json` ファイルに以下を追加してください: `"python.useEnvironmentsExtension": true`。
 
-#### AI-powered hover summaries with Pylance (Experimental) {#aipowered-hover-summaries-with-pylance-experimental}
+#### Pylance による AI を活用したホバー要約 (実験的) {#aipowered-hover-summaries-with-pylance-experimental}
 
-A new experimental AI hover summaries feature is now available for Python when using the latest pre-release version of Pylance. When you enable the `setting(python.analysis.aiHoverSummaries)` setting, you can get helpful summaries on-the-fly for symbols that do not already have documentation. This makes it easier to understand unfamiliar code and boosts productivity as you explore Python projects. AI hover summaries are currently available to GitHub Copilot Pro, Pro+, and Enterprise users.
+Pylance の最新のプレリリースバージョンを使用している場合、Python で新しい実験的な AI ホバー要約機能が利用可能になりました。`setting(python.analysis.aiHoverSummaries)` 設定を有効にすると、ドキュメントがまだないシンボルに対して、その場で役立つ要約を取得できます。これにより、なじみのないコードを理解しやすくなり、Python プロジェクトを探索する際の生産性が向上します。AI ホバー要約は現在、GitHub Copilot Pro、Pro+、および Enterprise ユーザーが利用できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_104/pylance-hover-summaries.mp4" title="Video showing AI-powered hover summaries with Pylance." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/pylance-hover-summaries.mp4" title="Pylance による AI を活用したホバー要約を示すビデオ。" autoplay loop controls muted></video>
 
-We look forward to bringing this experimental experience to the stable extension version soon.
+この実験的な体験を、近いうちに安定版の拡張機能バージョンに導入できることを楽しみにしています。
 
-#### Run code snippet tool {#run-code-snippet-tool}
+#### コードスニペット実行ツール {#run-code-snippet-tool}
 
-Instead of relying on terminal commands like `python -c "code"` or creating temporary files to be executed, the Pylance run code snippets tool enables GitHub Copilot to execute Python snippets entirely in memory. It automatically uses the correct Python interpreter configured for your workspace, and it eliminates common issues with shell escaping and quoting that sometimes arise during terminal execution.
+`python -c "code"` のようなターミナルコマンドに頼ったり、実行するための一時ファイルを作成したりする代わりに、Pylance のコードスニペット実行ツールを使用すると、GitHub Copilot は Python スニペットを完全にメモリ内で実行できます。ワークスペースに構成された正しい Python インタープリターを自動的に使用し、ターミナル実行中に時々発生するシェルエスケープやクォーティングに関する一般的な問題を排除します。
 
-One of the standout benefits is the clean, well-formatted output it provides, with both stdout and stderr interleaved for clarity. This makes it ideal when using agent mode with GitHub Copilot to test small blocks of code, run quick scripts, validate Python expressions, or check imports, all within the context of your workspace.
+際立った利点の 1 つは、stdout と stderr の両方が明確さのためにインターリーブされた、クリーンで適切にフォーマットされた出力を提供することです。これにより、GitHub Copilot でエージェントモードを使用して、ワークスペースのコンテキスト内で小さなコードブロックをテストしたり、クイックスクリプトを実行したり、Python 式を検証したり、インポートをチェックしたりするのに最適です。
 
-To try it out, make sure to use the latest pre-release version of the Pylance extension. You can then select the `pylancerunCodeSnippet` tool via the **Add context...** > **Tools** menu in the Chat view.
+試すには、Pylance 拡張機能の最新のプレリリースバージョンを使用してください。その後、チャットビューの **Add context...** > **Tools** メニューから `pylancerunCodeSnippet` ツールを選択できます。
 
-> **Note**: As with all AI-generated code, please make sure to inspect the generated code before allowing this tool to be executed. Reviewing the logic and intent of the code ensures it aligns with your project's goals and maintains safety and correctness.
+> **注意**: すべての AI 生成コードと同様に、このツールを実行させる前に、生成されたコードを検査してください。コードのロジックと意図を確認することで、プロジェクトの目標に沿っており、安全性と正確性が維持されていることを確認できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_104/pylance-run-code-snippet.mp4" title="Code snippet generated and executed by GitHub Copilot in the Chat panel via the pylancerunCodeSnippet tool." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_104/pylance-run-code-snippet.mp4" title="pylancerunCodeSnippet ツールを介してチャットパネルで GitHub Copilot によって生成および実行されたコードスニペット。" autoplay loop controls muted></video>
 
-#### Pylance IntelliSense enabled in all Python documents {#pylance-intellisense-enabled-in-all-python-documents}
+#### すべての Python ドキュメントで Pylance IntelliSense が有効に {#pylance-intellisense-enabled-in-all-python-documents}
 
-The `python.analysis.supportAllPythonDocuments` setting has been removed from the latest Pylance pre-release version, with Pylance IntelliSense now being enabled by default in all Python documents, including terminal and diff views. This means you can get rich code completions, hover and code navigation wherever you work with Python in VS Code.
+`python.analysis.supportAllPythonDocuments` 設定は最新の Pylance プレリリースバージョンから削除され、Pylance IntelliSense はターミナルや diff ビューを含むすべての Python ドキュメントでデフォルトで有効になりました。これは、VS Code で Python を扱う場所ならどこでも、リッチなコード補完、ホバー、コードナビゲーションを利用できることを意味します。
 
-#### Activation hooks {#activation-hooks}
+#### アクティベーションフック {#activation-hooks}
 
-Python activation hooks can now run from shell integration scripts, instead of requiring the Python environment extension to modify your shell profile. This provides more reliable terminal activation when `setting(python-envs.terminal.autoActivationType)` is set to `shellStartup` and, importantly, ensures Copilot terminals are activated as expected.
+Python アクティベーションフックは、シェルプロファイルを変更するために Python 環境拡張機能を必要とせず、シェル統合スクリプトから実行できるようになりました。これにより、`setting(python-envs.terminal.autoActivationType)` が `shellStartup` に設定されている場合に、より信頼性の高いターミナルアクティベーションが提供され、重要なことに、Copilot ターミナルが期待どおりにアクティベートされることが保証されます。
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### GitHub Pull Requests {#github-pull-requests}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+プルリクエストやイシューの作業、作成、管理を可能にする [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能でさらなる進展がありました。新機能は次のとおりです:
 
-* Side Bar content collapses on narrow windows
-* Pull request and issue webviews restore after reload
-* The new "TODO" code action lets you delegate directly to the Copilot coding agent
-* Submodules can be ignored with `setting(githubPullRequests.ignoreSubmodules)`
+* 狭いウィンドウでサイドバーのコンテンツが折りたたまれる
+* リロード後にプルリクエストとイシューの webview が復元される
+* 新しい "TODO" コードアクションにより、Copilot コーディングエージェントに直接委任できる
+* `setting(githubPullRequests.ignoreSubmodules)` でサブモジュールを無視できる
 
-Review the [changelog for the 0.118.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01180) release of the extension to learn about everything in the release.
+拡張機能の [0.118.0 リリースの変更履歴](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01180) を確認して、リリースのすべてについて学びましょう。
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能のオーサリング {#extension-authoring}
 
-### shellIntegrationNonce for extension launched terminals {#shellintegrationnonce-for-extension-launched-terminals}
+### 拡張機能が起動したターミナルの shellIntegrationNonce {#shellintegrationnonce-for-extension-launched-terminals}
 
-`shellIntegrationNonce` can now be passed to `createTerminal` in `TerminalOptions` and `ExtensionTerminalOptions`. This enables the extension to control the nonce, which is used to verify commands [in shell integration escape sequences](https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences).
+`shellIntegrationNonce` を `TerminalOptions` と `ExtensionTerminalOptions` の `createTerminal` に渡せるようになりました。これにより、拡張機能は [シェル統合エスケープシーケンス](https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences) でコマンドを検証するために使用される nonce を制御できます。
 
 ### Language Model Chat Provider API {#language-model-chat-provider-api}
 
-This iteration, we finalized the `LanguageModelChatProviders` API. This enables extensions to contribute one or more language models, cloud-hosted or local. By installing the extension, users can select these models through the model picker in chat.
+このイテレーションで、`LanguageModelChatProviders` API を最終決定しました。これにより、拡張機能はクラウドホストまたはローカルの 1 つ以上の言語モデルをコントリビュートできます。拡張機能をインストールすることで、ユーザーはチャットのモデルピッカーを通じてこれらのモデルを選択できます。
 
-There are already multiple extensions that take advantage of this API to extend chat in VS Code with additional models, including [AI Toolkit for VS Code](https://aka.ms/AIToolkit), [Cerebras Inference](https://aka.ms/vscode/cerebras), and [Hugging Face](https://aka.ms/vscode/huggingface).
+すでに、[AI Toolkit for VS Code](https://aka.ms/AIToolkit)、[Cerebras Inference](https://aka.ms/vscode/cerebras)、[Hugging Face](https://aka.ms/vscode/huggingface) など、この API を利用して VS Code のチャットを追加モデルで拡張する複数の拡張機能があります。
 
-You can learn more about how to utilize this API in our [Language Model Chat Provider extension guide](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider) or in our [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-model-provider-sample).
+この API の利用方法については、[Language Model Chat Provider 拡張機能ガイド](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider) または [拡張機能サンプル](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-model-provider-sample) で詳しく学ぶことができます。
 
-> **Note**: Models provided through this API are currently only available to users on [individual GitHub Copilot plans](https://docs.github.com/en/copilot/concepts/billing/individual-plans).
+> **注意**: この API を通じて提供されるモデルは、現在 [個人の GitHub Copilot プラン](https://docs.github.com/en/copilot/concepts/billing/individual-plans) のユーザーのみが利用できます。
 
-## Proposed APIs {#proposed-apis}
+## Proposed API {#proposed-apis}
 
-### Authentication: Supporting `WWW-Authenticate` challenges in `getSession` {#authentication-supporting-www-authenticate-challenges-in-getsession}
+### 認証: `getSession` での `WWW-Authenticate` チャレンジのサポート {#authentication-supporting-www-authenticate-challenges-in-getsession}
 
-A well-established pattern of HTTP is that a request to an API can return a 401 Unauthorized status code with a [WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) header, which defines _auth challenges_. These are essentially things that the API needs in order to resolve past the 401.
+HTTP の確立されたパターンとして、API へのリクエストが 401 Unauthorized ステータスコードと [WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) ヘッダーを返すことがあります。これは _auth challenges_ を定義します。これらは本質的に、API が 401 を解決するために必要なものです。
 
-We have introduced a proposed API, which allows for the passing down and handling of these challenges to authentication providers. First off, from the calling side you can now pass in a challenge like so:
+これらのチャレンジを認証プロバイダーに渡して処理できるようにする Proposed API を導入しました。まず、呼び出し側から次のようにチャレンジを渡すことができます:
 
 ```ts
 export interface AuthenticationWWWAuthenticateRequest {
 	/**
-	 * The raw WWW-Authenticate header value that triggered this challenge.
+	 * このチャレンジをトリガーした生の WWW-Authenticate ヘッダー値。
 	 */
 	readonly wwwAuthenticate: string;
 
 	/**
-	 * Optional scopes for the session.
+	 * セッションのオプションのスコープ。
 	 */
 	readonly scopes?: readonly string[];
 }
 
 export namespace authentication {
-		// NOTE: The only change is the 2nd parameter, the other variations of `getSession` have the same change
+		// 注: 唯一の変更は 2 番目のパラメーターです。`getSession` の他のバリエーションも同じ変更があります
 		export function getSession(providerId: string, scopeListOrRequest: ReadonlyArray<string> | AuthenticationWWWAuthenticateRequest, options?: AuthenticationGetSessionOptions): Thenable<AuthenticationSession | undefined>;
 }
 ```
 
-On the authentication provider side, we have added the following two new functions to `AuthenticationProvider`:
+認証プロバイダー側では、`AuthenticationProvider` に次の 2 つの新しい関数を追加しました:
 
 ```ts
 getSessionsFromChallenges(constraint: AuthenticationConstraint, options: AuthenticationProviderSessionOptions): Thenable<readonly AuthenticationSession[]>;
 createSessionFromChallenges(constraint: AuthenticationConstraint, options: AuthenticationProviderSessionOptions): Thenable<AuthenticationSession>;
 ```
 
-and an auth provider can declare support for challenges when registered via `supportsChallenges: true` in `AuthenticationProviderOptions`.
+そして、認証プロバイダーは `AuthenticationProviderOptions` の `supportsChallenges: true` を介して登録されるときに、チャレンジのサポートを宣言できます。
 
-#### Example: Azure MFA {#example-azure-mfa}
+#### 例: Azure MFA {#example-azure-mfa}
 
-This work was initially done [due to an upcoming change to require MFA in Azure APIs](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) so let's also use that as an example of this API.
+この作業は、当初 [Azure API で MFA を要求する今後の変更](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) のために行われたため、この API の例としてもそれを使用しましょう。
 
-Let's say you have an extension that creates a resource in Azure. All that's doing is calling an Azure RM API, nothing fancy...  Your extension is probably already familiar with calling `vscode.authentication.getSession` to get an authentication session, mainly an access token, that can be used to call this API. Now, when you first minted that authentication session, depending on your organization, you may or may NOT have gone through multifactor authentication (MFA). If you did, then the Azure API will be happy. If you _didn't_ go through MFA, then Azure's API will return a 401 and a `WWW-Authenticate` header.
+Azure でリソースを作成する拡張機能があるとします。それは Azure RM API を呼び出すだけで、特別なことは何もありません... あなたの拡張機能は、この API を呼び出すために使用できる認証セッション (主にアクセストークン) を取得するために `vscode.authentication.getSession` を呼び出すことにはすでにおなじみでしょう。さて、その認証セッションを最初に作成したとき、組織によっては、多要素認証 (MFA) を経由したかどうかが異なります。経由した場合、Azure API は満足します。MFA を経由しなかった場合、Azure の API は 401 と `WWW-Authenticate` ヘッダーを返します。
 
-Now comes our new API in VS Code... all you have to do is take that header value, and pass it right in to `vscode.authentication.getSession`:
+ここで VS Code の新しい API が登場します... あなたがしなければならないのは、そのヘッダー値を取得し、それを `vscode.authentication.getSession` に直接渡すことだけです:
 
 ```ts
 const newRequest = {
@@ -624,214 +624,214 @@ const newRequest = {
 const sessionWithMFA = await vscode.authentication.getSession('microsoft', newRequest, options)
 ```
 
-This will pass that header value down to the `microsoft` auth provider, and the auth provider will be responsible for minting a session in which the challenges are satisfied.
+これにより、そのヘッダー値が `microsoft` 認証プロバイダーに渡され、認証プロバイダーはチャレンジが満たされたセッションを作成する責任を負います。
 
-#### Next steps {#next-steps}
+#### 次のステップ {#next-steps}
 
-Next iteration we will finalize the `getSession` (aka extension asking for auth) parts of this proposal so if you have any feedback on that or the shape of the `AuthenticationProvider` changes, let us know! You can [find the full proposal on GitHub here](https://github.com/microsoft/vscode/blob/a924f20c72bd8f9665894be8213ce7f5680ab528/src/vscode-dts/vscode.proposed.authenticationChallenges.d.ts).
+次のイテレーションでは、この提案の `getSession` (別名、認証を要求する拡張機能) の部分を最終決定する予定ですので、それに関するフィードバックや `AuthenticationProvider` の変更の形状について何かあれば、お知らせください！[完全な提案は GitHub でこちら](https://github.com/microsoft/vscode/blob/a924f20c72bd8f9665894be8213ce7f5680ab528/src/vscode-dts/vscode.proposed.authenticationChallenges.d.ts) で見つけることができます。
 
-Another use case that will be lit up soon regarding `WWW-Authenticate`, is for MCP servers to issue a `WWW-Authenticate` header asking for a token with more scopes. There's [a proposal in the MCP specification for this](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/835).
+`WWW-Authenticate` に関して近いうちに実現されるもう 1 つのユースケースは、MCP サーバーがより多くのスコープを持つトークンを要求する `WWW-Authenticate` ヘッダーを発行することです。これについては [MCP 仕様に提案があります](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/835)。
 
-### View containers in the Secondary Side Bar {#view-containers-in-the-secondary-side-bar}
+### セカンダリサイドバーのビューコンテナー {#view-containers-in-the-secondary-side-bar}
 
-Extensions can contribute view containers to the `activitybar` and `panel`. We have now added support for contributing to the `secondarySidebar` as well. This is currently behind the `contribSecondarySideBar` proposed API. We are hoping to finalize this API soon.
+拡張機能は、`activitybar` と `panel` にビューコンテナーをコントリビュートできます。今回、`secondarySidebar` へのコントリビュートのサポートも追加しました。これは現在、`contribSecondarySideBar` Proposed API の背後にあります。この API を近いうちに最終決定したいと考えています。
 
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### Exploring Playwright and Playwright MCP in the inner development loop of VS Code {#exploring-playwright-and-playwright-mcp-in-the-inner-development-loop-of-vs-code}
+### VS Code の内部開発ループにおける Playwright と Playwright MCP の探求 {#exploring-playwright-and-playwright-mcp-in-the-inner-development-loop-of-vs-code}
 
-Agent mode and other AI features of VS Code have become a core tool (no pun intended) for the VS Code team to build VS Code itself. We wanted to explore how we can apply these features further to make the inner development loop of VS Code even better. To that end, we have been experimenting with extending our existing smoke test [automation project](https://github.com/microsoft/vscode/tree/main/test/automation), which uses [Playwright](https://playwright.dev/), to create an MCP server that can drive a local instance of VS Code. This allows our existing agentic flows, which focused on receiving context from build/test-time artifacts (compilation, linters, tests, etc.), to now also interact with a live instance of VS Code... verifying that changes have the desired effect at runtime.
+エージェントモードやその他の VS Code の AI 機能は、VS Code チームが VS Code 自体を構築するためのコアツール (しゃれではありません) になりました。私たちは、これらの機能をさらに適用して、VS Code の内部開発ループをさらに改善する方法を探求したいと考えました。そのために、[Playwright](https://playwright.dev/) を使用する既存の smoke test [自動化プロジェクト](https://github.com/microsoft/vscode/tree/main/test/automation) を拡張して、ローカルの VS Code インスタンスを駆動できる MCP サーバーを作成する実験を行っています。これにより、ビルド/テスト時のアーティファクト (コンパイル、リンター、テストなど) からコンテキストを受け取ることに焦点を当てていた既存のエージェントフローが、ライブの VS Code インスタンスと対話できるようになり... 変更が実行時に望ましい効果をもたらすことを検証できます。
 
-The first piece of this work can be found [in the test/mcp folder](https://github.com/microsoft/vscode/tree/main/test/mcp) of the vscode repo. If you're interested in trying it out, it's very easy to get started:
+この作業の最初の部分は、vscode リポジトリの [test/mcp フォルダー](https://github.com/microsoft/vscode/tree/main/test/mcp) にあります。試してみたい場合は、非常に簡単に始めることができます:
 
-1. Follow the [Contribution Guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute) for getting a local version of Code OSS running
-2. Then you can use [our trivial (for now) prompt file](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) to ask a question `/playwright your question here` in Agent mode.
+1. ローカルバージョンの Code OSS を実行するための [コントリビューションガイドライン](https://github.com/microsoft/vscode/wiki/How-to-Contribute) に従います
+2. 次に、[私たちの (今のところ) ささいなプロンプトファイル](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) を使用して、エージェントモードで `/playwright your question here` と質問できます。
 
-This is still an early exploration, but we are excited about the possibilities this opens up for us to use AI further in our inner development loop. The ground work is now laid, and we will be iterating on this to make it more robust and useful for the team.
+これはまだ初期の探求ですが、内部開発ループで AI をさらに使用する可能性に興奮しています。基礎は築かれ、これをより堅牢でチームにとって有用なものにするために反復していきます。
 
-This work was recently featured on the VS Code Insiders podcast, where we discussed the motivations behind this exploration and some of the technical details. You can listen to the episode of the [VS Code Insiders podcast](https://www.vscodepodcast.com/3).
+この作業は最近 VS Code Insiders ポッドキャストで取り上げられ、この探求の動機といくつかの技術的な詳細について議論しました。[VS Code Insiders ポッドキャスト](https://www.vscodepodcast.com/3) のエピソードを聴くことができます。
 
-## Notable fixes {#notable-fixes}
+## 注目すべき修正 {#notable-fixes}
 
-* [vscode#151902](https://github.com/microsoft/vscode/issues/151902) - Terminal: Copy on selection + new highlight in 1.68 copies previous term on CMD+F
-* [vscode#222075](https://github.com/microsoft/vscode/issues/222075) - Terminal sticky scroll can show up for 1 frame when using page down in a pager
-* [xtermjs/xterm.js#5390](https://github.com/xtermjs/xterm.js/pull/5390) - Fix scrollbar teleport after exiting alt buffer
+* [vscode#151902](https://github.com/microsoft/vscode/issues/151902) - ターミナル: 選択時にコピー + 1.68 の新しいハイライトで CMD+F 時に前の用語がコピーされる
+* [vscode#222075](https://github.com/microsoft/vscode/issues/222075) - ページャーでページダウンを使用すると、ターミナルのスティッキースクロールが 1 フレーム表示されることがある
+* [xtermjs/xterm.js#5390](https://github.com/xtermjs/xterm.js/pull/5390) - 代替バッファを終了した後のスクロールバーのテレポートを修正
 
-## Thank you {#thank-you}
+## 謝辞 {#thank-you}
 
-Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
+最後になりましたが、VS Code のコントリビューターの皆様に心から感謝申し上げます。
 
-### Issue tracking {#issue-tracking}
+### イシュートラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+私たちのイシュートラッキングへの貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 
-### Pull Requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@a-ariff (Ariff)](https://github.com/a-ariff): docs: fix grammar in Development Container section [PR #264162](https://github.com/microsoft/vscode/pull/264162)
+* [@a-ariff (Ariff)](https://github.com/a-ariff): docs: Development Container セクションの文法を修正 [PR #264162](https://github.com/microsoft/vscode/pull/264162)
 * [@alexkozy (Alexey)](https://github.com/alexkozy)
-  * fix: tiny memory leak in debugToolBar.ts [PR #259349](https://github.com/microsoft/vscode/pull/259349)
-  * fix: register WorkerTextModelSyncClient [PR #259442](https://github.com/microsoft/vscode/pull/259442)
-* [@alexvoedi (Alexander Vödisch)](https://github.com/alexvoedi): Fix linkedEditing desync [PR #242993](https://github.com/microsoft/vscode/pull/242993)
+  * fix: debugToolBar.ts の小さなメモリリークを修正 [PR #259349](https://github.com/microsoft/vscode/pull/259349)
+  * fix: WorkerTextModelSyncClient を登録 [PR #259442](https://github.com/microsoft/vscode/pull/259442)
+* [@alexvoedi (Alexander Vödisch)](https://github.com/alexvoedi): linkedEditing の非同期を修正 [PR #242993](https://github.com/microsoft/vscode/pull/242993)
 * [@bluedog13](https://github.com/bluedog13)
-  * Fix OAuth redirect URI format to align with Microsoft's URL standards [PR #260446](https://github.com/microsoft/vscode/pull/260446)
-  * Fix OAuth2 resource parameter compliance with RFC 8707 [PR #261815](https://github.com/microsoft/vscode/pull/261815)
-* [@CGNonofr (Loïc Mangeonjean)](https://github.com/CGNonofr): Fix theme not being synchronized with external windows on firefox [PR #259839](https://github.com/microsoft/vscode/pull/259839)
-* [@Da-nie-elT](https://github.com/Da-nie-elT): Update for-in loop snippet with `Object.hasOwn()` [PR #262682](https://github.com/microsoft/vscode/pull/262682)
-* [@DoctorKrolic](https://github.com/DoctorKrolic): Add `.slnx` to `xml` language extension list [PR #259049](https://github.com/microsoft/vscode/pull/259049)
-* [@DrSergei (Druzhkov Sergei)](https://github.com/DrSergei): Fix memory reference handling in Watch window [PR #259753](https://github.com/microsoft/vscode/pull/259753)
+  * Microsoft の URL 標準に合わせるために OAuth リダイレクト URI 形式を修正 [PR #260446](https://github.com/microsoft/vscode/pull/260446)
+  * RFC 8707 に準拠するように OAuth2 リソースパラメーターを修正 [PR #261815](https://github.com/microsoft/vscode/pull/261815)
+* [@CGNonofr (Loïc Mangeonjean)](https://github.com/CGNonofr): firefox で外部ウィンドウとテーマが同期されない問題を修正 [PR #259839](https://github.com/microsoft/vscode/pull/259839)
+* [@Da-nie-elT](https://github.com/Da-nie-elT): for-in ループスニペットを `Object.hasOwn()` で更新 [PR #262682](https://github.com/microsoft/vscode/pull/262682)
+* [@DoctorKrolic](https://github.com/DoctorKrolic): `.slnx` を `xml` 言語拡張機能リストに追加 [PR #259049](https://github.com/microsoft/vscode/pull/259049)
+* [@DrSergei (Druzhkov Sergei)](https://github.com/DrSergei): ウォッチウィンドウのメモリ参照処理を修正 [PR #259753](https://github.com/microsoft/vscode/pull/259753)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
-  * Add `Go to Test` to coverage sources quickpick [PR #259600](https://github.com/microsoft/vscode/pull/259600)
-  * Set correct active entry on test coverage toolbar's quickpick [PR #259639](https://github.com/microsoft/vscode/pull/259639)
-  * Test Results: Only offer `Go to Test` with a uri (fix #260443) [PR #260508](https://github.com/microsoft/vscode/pull/260508)
-* [@hihry (Himanshu Ravindra Iwanati)](https://github.com/hihry): fix: update capitalization for 'Restore to Last Checkpoint' hover text [PR #259572](https://github.com/microsoft/vscode/pull/259572)
-* [@j3iiifn](https://github.com/j3iiifn): Prompt file name cannot contain digits [PR #261704](https://github.com/microsoft/vscode/pull/261704)
+  * カバレッジソースのクイックピックに `Go to Test` を追加 [PR #259600](https://github.com/microsoft/vscode/pull/259600)
+  * テストカバレッジツールバーのクイックピックで正しいアクティブエントリを設定 [PR #259639](https://github.com/microsoft/vscode/pull/259639)
+  * テスト結果: uri がある場合のみ `Go to Test` を提供 (fix #260443) [PR #260508](https://github.com/microsoft/vscode/pull/260508)
+* [@hihry (Himanshu Ravindra Iwanati)](https://github.com/hihry): fix: 'Restore to Last Checkpoint' ホバーテキストの大文字小文字を更新 [PR #259572](https://github.com/microsoft/vscode/pull/259572)
+* [@j3iiifn](https://github.com/j3iiifn): プロンプトファイル名に数字を含めることはできません [PR #261704](https://github.com/microsoft/vscode/pull/261704)
 * [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen)
-  * Allow the canonical package name and version to be sent back from the install flow [PR #259081](https://github.com/microsoft/vscode/pull/259081)
-  * Support server.json being returned by assisted MCP install [PR #259634](https://github.com/microsoft/vscode/pull/259634)
-  * Add support for a help link when MCP assisted installation fails [PR #260215](https://github.com/microsoft/vscode/pull/260215)
-* [@kenherring (Ken Herring)](https://github.com/kenherring): terminal.copyOnSelection and terminalFindWidget - do not copy selection on focus [PR #254065](https://github.com/microsoft/vscode/pull/254065)
-* [@kplates (kplates)](https://github.com/kplates): feat: Include/ Exclude file types from file search [PR #254285](https://github.com/microsoft/vscode/pull/254285)
-* [@LeftPhalange (Ethan Bovard)](https://github.com/LeftPhalange): Add Open Active Diff Side option to Command Palette using DIFF_OPEN_SIDE command [PR #261699](https://github.com/microsoft/vscode/pull/261699)
+  * インストールフローから正規のパッケージ名とバージョンを返せるようにする [PR #259081](https://github.com/microsoft/vscode/pull/259081)
+  * アシスト付き MCP インストールによって返される server.json をサポート [PR #259634](https://github.com/microsoft/vscode/pull/259634)
+  * MCP アシスト付きインストールが失敗した場合のヘルプリンクのサポートを追加 [PR #260215](https://github.com/microsoft/vscode/pull/260215)
+* [@kenherring (Ken Herring)](https://github.com/kenherring): terminal.copyOnSelection と terminalFindWidget - フォーカス時に選択をコピーしない [PR #254065](https://github.com/microsoft/vscode/pull/254065)
+* [@kplates (kplates)](https://github.com/kplates): feat: ファイル検索からファイルタイプを含める/除外する [PR #254285](https://github.com/microsoft/vscode/pull/254285)
+* [@LeftPhalange (Ethan Bovard)](https://github.com/LeftPhalange): DIFF_OPEN_SIDE コマンドを使用してコマンドパレットに Open Active Diff Side オプションを追加 [PR #261699](https://github.com/microsoft/vscode/pull/261699)
 * [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
-  * Fix global access of MonacoEnvironment [PR #248075](https://github.com/microsoft/vscode/pull/248075)
-  * Highlight more languages in markdown code blocks [PR #263550](https://github.com/microsoft/vscode/pull/263550)
+  * MonacoEnvironment のグローバルアクセスを修正 [PR #248075](https://github.com/microsoft/vscode/pull/248075)
+  * markdown コードブロックでより多くの言語をハイライト [PR #263550](https://github.com/microsoft/vscode/pull/263550)
 * [@rwoll (Ross Wollman)](https://github.com/rwoll)
-  * Wait for agent loop to finish in automation [PR #262370](https://github.com/microsoft/vscode/pull/262370)
-  * support model switching in automation [PR #262420](https://github.com/microsoft/vscode/pull/262420)
-  * fix: parse commands in chat.open commands [PR #263458](https://github.com/microsoft/vscode/pull/263458)
-  * `workbench.action.chat.export` optionally accept path [PR #263507](https://github.com/microsoft/vscode/pull/263507)
-  * fix: confirm response based on promise [PR #263894](https://github.com/microsoft/vscode/pull/263894)
+  * 自動化でエージェントループが終了するのを待つ [PR #262370](https://github.com/microsoft/vscode/pull/262370)
+  * 自動化でのモデル切り替えをサポート [PR #262420](https://github.com/microsoft/vscode/pull/262420)
+  * fix: chat.open コマンドでコマンドを解析 [PR #263458](https://github.com/microsoft/vscode/pull/263458)
+  * `workbench.action.chat.export` がオプションでパスを受け入れるように [PR #263507](https://github.com/microsoft/vscode/pull/263507)
+  * fix: promise に基づいて応答を確認 [PR #263894](https://github.com/microsoft/vscode/pull/263894)
   * Revert "fix: confirm response based on promise (#263894)" [PR #264047](https://github.com/microsoft/vscode/pull/264047)
 * [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
-  * fix: memory leak in pattern input widget [PR #258152](https://github.com/microsoft/vscode/pull/258152)
-  * fix: memory leak in codelens controller [PR #263136](https://github.com/microsoft/vscode/pull/263136)
-  * fix: memory leak in accessibility signal scheduler [PR #263147](https://github.com/microsoft/vscode/pull/263147)
-  * fix: memory leak in QuickDiffModel [PR #265007](https://github.com/microsoft/vscode/pull/265007)
-* [@swordjjjkkk (Truman)](https://github.com/swordjjjkkk): Display Tab Indexes in VSCode [PR #209196](https://github.com/microsoft/vscode/pull/209196)
-* [@terreng (Terren)](https://github.com/terreng): Implement new option to control title scrollbar visibility [PR #246161](https://github.com/microsoft/vscode/pull/246161)
-* [@timheuer (Tim Heuer)](https://github.com/timheuer): Add collapse all functionality to test coverage view [PR #258906](https://github.com/microsoft/vscode/pull/258906)
+  * fix: パターン入力ウィジェットのメモリリークを修正 [PR #258152](https://github.com/microsoft/vscode/pull/258152)
+  * fix: codelens コントローラーのメモリリークを修正 [PR #263136](https://github.com/microsoft/vscode/pull/263136)
+  * fix: アクセシビリティシグナルスケジューラのメモリリークを修正 [PR #263147](https://github.com/microsoft/vscode/pull/263147)
+  * fix: QuickDiffModel のメモリリークを修正 [PR #265007](https://github.com/microsoft/vscode/pull/265007)
+* [@swordjjjkkk (Truman)](https://github.com/swordjjjkkk): VSCode にタブインデックスを表示 [PR #209196](https://github.com/microsoft/vscode/pull/209196)
+* [@terreng (Terren)](https://github.com/terreng): タイトルのスクロールバーの可視性を制御する新しいオプションを実装 [PR #246161](https://github.com/microsoft/vscode/pull/246161)
+* [@timheuer (Tim Heuer)](https://github.com/timheuer): テストカバレッジビューにすべて折りたたむ機能を追加 [PR #258906](https://github.com/microsoft/vscode/pull/258906)
 * [@tmm1 (Aman Karmani)](https://github.com/tmm1)
-  * fix some typos [PR #259747](https://github.com/microsoft/vscode/pull/259747)
-  * terminalProcessManager: fix disposable leak [PR #261710](https://github.com/microsoft/vscode/pull/261710)
-  * storage: optimize sqlite insert with upsert syntax [PR #261999](https://github.com/microsoft/vscode/pull/261999)
-* [@Tritlo (Matthías Páll Gissurarson)](https://github.com/Tritlo): extHostMcp: accept Content-Type parameters for SSE/JSON handling [PR #262787](https://github.com/microsoft/vscode/pull/262787)
-* [@ttttotem (ttttotem)](https://github.com/ttttotem): Fixes "Caret jumps to column 0 when clicking between first two characters" [PR #265131](https://github.com/microsoft/vscode/pull/265131)
-* [@JBlitzar (JBlitzar)](https://github.com/JBlitzar): Use `app.dock.hide` when connecting to an existing instance [PR #259352](https://github.com/microsoft/vscode/pull/259352)
+  * いくつかのタイプミスを修正 [PR #259747](https://github.com/microsoft/vscode/pull/259747)
+  * terminalProcessManager: 使い捨てリークを修正 [PR #261710](https://github.com/microsoft/vscode/pull/261710)
+  * storage: upsert 構文で sqlite の insert を最適化 [PR #261999](https://github.com/microsoft/vscode/pull/261999)
+* [@Tritlo (Matthías Páll Gissurarson)](https://github.com/Tritlo): extHostMcp: SSE/JSON 処理のために Content-Type パラメーターを受け入れる [PR #262787](https://github.com/microsoft/vscode/pull/262787)
+* [@ttttotem (ttttotem)](https://github.com/ttttotem): 「最初の 2 文字の間をクリックするとキャレットが 0 列目にジャンプする」を修正 [PR #265131](https://github.com/microsoft/vscode/pull/265131)
+* [@JBlitzar (JBlitzar)](https://github.com/JBlitzar): 既存のインスタンスに接続するときに `app.dock.hide` を使用 [PR #259352](https://github.com/microsoft/vscode/pull/259352)
 
-Contributions to `vscode-copilot-chat`:
+`vscode-copilot-chat` への貢献:
 
-* [@24anisha](https://github.com/24anisha): add sku data to github telemetry [PR #819](https://github.com/microsoft/vscode-copilot-chat/pull/819)
-* [@devm33 (Devraj Mehta)](https://github.com/devm33): Make logprobs field optional [PR #325](https://github.com/microsoft/vscode-copilot-chat/pull/325)
-* [@iann0036 (Ian Mckay)](https://github.com/iann0036): fix: Case sensitive adjustment for "GitHub" [PR #631](https://github.com/microsoft/vscode-copilot-chat/pull/631)
+* [@24anisha](https://github.com/24anisha): github テレメトリに sku データを追加 [PR #819](https://github.com/microsoft/vscode-copilot-chat/pull/819)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): logprobs フィールドをオプションにする [PR #325](https://github.com/microsoft/vscode-copilot-chat/pull/325)
+* [@iann0036 (Ian Mckay)](https://github.com/iann0036): fix: "GitHub" の大文字小文字の調整 [PR #631](https://github.com/microsoft/vscode-copilot-chat/pull/631)
 * [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen)
-  * Use .NET SDK to search for NuGet packages, emit events, add tests for all package types [PR #546](https://github.com/microsoft/vscode-copilot-chat/pull/546)
-  * Add command executor abstraction, only run dotnet CLI tests on CI [PR #607](https://github.com/microsoft/vscode-copilot-chat/pull/607)
-  * Hash package name during MCP server installation [PR #618](https://github.com/microsoft/vscode-copilot-chat/pull/618)
+  * .NET SDK を使用して NuGet パッケージを検索し、イベントを発行し、すべてのパッケージタイプのテストを追加 [PR #546](https://github.com/microsoft/vscode-copilot-chat/pull/546)
+  * コマンドエグゼキュータの抽象化を追加し、CI でのみ dotnet CLI テストを実行 [PR #607](https://github.com/microsoft/vscode-copilot-chat/pull/607)
+  * MCP サーバーのインストール中にパッケージ名をハッシュ化 [PR #618](https://github.com/microsoft/vscode-copilot-chat/pull/618)
 * [@jwangxx (James Wang)](https://github.com/jwangxx)
-  * Add "onExP" tag to enableRetryAfterFilteredResponse setting [PR #479](https://github.com/microsoft/vscode-copilot-chat/pull/479)
-  * Remove experimental setting for retrying after filtered response [PR #830](https://github.com/microsoft/vscode-copilot-chat/pull/830)
-* [@lipido (Daniel Glez-Peña)](https://github.com/lipido): Improve agent test coverage [PR #614](https://github.com/microsoft/vscode-copilot-chat/pull/614)
-* [@m4dc4p](https://github.com/m4dc4p): Update getErrors (GetErrors / problems) tool [PR #394](https://github.com/microsoft/vscode-copilot-chat/pull/394)
+  * enableRetryAfterFilteredResponse 設定に "onExP" タグを追加 [PR #479](https://github.com/microsoft/vscode-copilot-chat/pull/479)
+  * フィルタリングされた応答後に再試行するための実験的な設定を削除 [PR #830](https://github.com/microsoft/vscode-copilot-chat/pull/830)
+* [@lipido (Daniel Glez-Peña)](https://github.com/lipido): エージェントのテストカバレッジを改善 [PR #614](https://github.com/microsoft/vscode-copilot-chat/pull/614)
+* [@m4dc4p](https://github.com/m4dc4p): getErrors (GetErrors / problems) ツールを更新 [PR #394](https://github.com/microsoft/vscode-copilot-chat/pull/394)
 * [@rwoll (Ross Wollman)](https://github.com/rwoll)
-  * Fix auth for Copilot Chat running in automated VSC Extension Host [PR #609](https://github.com/microsoft/vscode-copilot-chat/pull/609)
-  * allow more services in Scenario Mode [PR #653](https://github.com/microsoft/vscode-copilot-chat/pull/653)
-  * plumb `code` on `ChatErrorDetails` [PR #680](https://github.com/microsoft/vscode-copilot-chat/pull/680)
+  * 自動化された VSC 拡張ホストで実行されている Copilot Chat の認証を修正 [PR #609](https://github.com/microsoft/vscode-copilot-chat/pull/609)
+  * シナリオモードでより多くのサービスを許可 [PR #653](https://github.com/microsoft/vscode-copilot-chat/pull/653)
+  * `ChatErrorDetails` に `code` を plumb [PR #680](https://github.com/microsoft/vscode-copilot-chat/pull/680)
 * [@shaunm-msft (Shaun Miller)](https://github.com/shaunm-msft)
-  * Remove the message copilot_cache_control field from a context where there is no understanding of it [PR #554](https://github.com/microsoft/vscode-copilot-chat/pull/554)
-  * port PR 665 to simulator [PR #694](https://github.com/microsoft/vscode-copilot-chat/pull/694)
-* [@sridharavinash (Avinash Sridhar)](https://github.com/sridharavinash): Add mode to conversation model messages [PR #517](https://github.com/microsoft/vscode-copilot-chat/pull/517)
-* [@yemohyleyemohyle](https://github.com/yemohyleyemohyle): Add message length events to MSFT internal telemetry  [PR #473](https://github.com/microsoft/vscode-copilot-chat/pull/473)
+  * 理解できないコンテキストからメッセージ copilot_cache_control フィールドを削除 [PR #554](https://github.com/microsoft/vscode-copilot-chat/pull/554)
+  * PR 665 をシミュレーターに移植 [PR #694](https://github.com/microsoft/vscode-copilot-chat/pull/694)
+* [@sridharavinash (Avinash Sridhar)](https://github.com/sridharavinash): 会話モデルメッセージにモードを追加 [PR #517](https://github.com/microsoft/vscode-copilot-chat/pull/517)
+* [@yemohyleyemohyle](https://github.com/yemohyleyemohyle): MSFT 内部テレメトリにメッセージ長イベントを追加 [PR #473](https://github.com/microsoft/vscode-copilot-chat/pull/473)
 * [@zhichli (Zhichao Li)](https://github.com/zhichli)
-  * Feature: add JSON export of chat prompt logs in chat debug view [PR #672](https://github.com/microsoft/vscode-copilot-chat/pull/672)
-  * Add tool and other metadata to chat debug json export  [PR #789](https://github.com/microsoft/vscode-copilot-chat/pull/789)
-  * Remove tool calls from `request` type JSON logs exported from chat debug [PR #794](https://github.com/microsoft/vscode-copilot-chat/pull/794)
+  * 機能: チャットデバッグビューにチャットプロンプトログの JSON エクスポートを追加 [PR #672](https://github.com/microsoft/vscode-copilot-chat/pull/672)
+  * チャットデバッグ JSON エクスポートにツールやその他のメタデータを追加 [PR #789](https://github.com/microsoft/vscode-copilot-chat/pull/789)
+  * チャットデバッグからエクスポートされた `request` タイプの JSON ログからツール呼び出しを削除 [PR #794](https://github.com/microsoft/vscode-copilot-chat/pull/794)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献:
 
 * [@AmarMuric04 (AmarMuric)](https://github.com/AmarMuric04)
-  * docs: Update ESLint installation and configuration instructions [PR #2062](https://github.com/microsoft/vscode-eslint/pull/2062)
-  * docs: Remove duplicate text in README.md [PR #2066](https://github.com/microsoft/vscode-eslint/pull/2066)
-* [@davidtaylorhq (David Taylor)](https://github.com/davidtaylorhq): Add probe support for Ember's glimmer-ts/glimmer-js format [PR #2069](https://github.com/microsoft/vscode-eslint/pull/2069)
+  * docs: ESLint のインストールと構成手順を更新 [PR #2062](https://github.com/microsoft/vscode-eslint/pull/2062)
+  * docs: README.md の重複テキストを削除 [PR #2066](https://github.com/microsoft/vscode-eslint/pull/2066)
+* [@davidtaylorhq (David Taylor)](https://github.com/davidtaylorhq): Ember の glimmer-ts/glimmer-js 形式のプローブサポートを追加 [PR #2069](https://github.com/microsoft/vscode-eslint/pull/2069)
 
-Contributions to `vscode-extension-samples`:
+`vscode-extension-samples` への貢献:
 
-* [@Sepush (Artea)](https://github.com/Sepush): refactor(lsp-embedded-request-forwarding): clean useless code [PR #1196](https://github.com/microsoft/vscode-extension-samples/pull/1196)
+* [@Sepush (Artea)](https://github.com/Sepush): refactor(lsp-embedded-request-forwarding): 不要なコードをクリーンアップ [PR #1196](https://github.com/microsoft/vscode-extension-samples/pull/1196)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@LittleLittleCloud (Xiaoyun Zhang)](https://github.com/LittleLittleCloud): fix: handle localhost hostname in constructInspectorWSUri function [PR #2260](https://github.com/microsoft/vscode-js-debug/pull/2260)
+* [@LittleLittleCloud (Xiaoyun Zhang)](https://github.com/LittleLittleCloud): fix: constructInspectorWSUri 関数で localhost ホスト名を処理 [PR #2260](https://github.com/microsoft/vscode-js-debug/pull/2260)
 
-Contributions to `vscode-jupyter`:
+`vscode-jupyter` への貢献:
 
-* [@hunterhogan (Hunter Hogan)](https://github.com/hunterhogan): Typos in package.nls.json [PR #16890](https://github.com/microsoft/vscode-jupyter/pull/16890)
-* [@krassowski (Michał Krassowski)](https://github.com/krassowski): Add support for custom CDN URLs [PR #16885](https://github.com/microsoft/vscode-jupyter/pull/16885)
+* [@hunterhogan (Hunter Hogan)](https://github.com/hunterhogan): package.nls.json のタイプミス [PR #16890](https://github.com/microsoft/vscode-jupyter/pull/16890)
+* [@krassowski (Michał Krassowski)](https://github.com/krassowski): カスタム CDN URL のサポートを追加 [PR #16885](https://github.com/microsoft/vscode-jupyter/pull/16885)
 
-Contributions to `vscode-languageserver-node`:
+`vscode-languageserver-node` への貢献:
 
-* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Add capability information to `textDocument/colorPresentation` [PR #1660](https://github.com/microsoft/vscode-languageserver-node/pull/1660)
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): `textDocument/colorPresentation` に機能情報を追加 [PR #1660](https://github.com/microsoft/vscode-languageserver-node/pull/1660)
 
-Contributions to `vscode-markdown-languageservice`:
+`vscode-markdown-languageservice` への貢献:
 
-* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Update @vscode/l10n to version 0.0.18 [PR #199](https://github.com/microsoft/vscode-markdown-languageservice/pull/199)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): @vscode/l10n をバージョン 0.0.18 に更新 [PR #199](https://github.com/microsoft/vscode-markdown-languageservice/pull/199)
 
-Contributions to `vscode-markdown-tm-grammar`:
+`vscode-markdown-tm-grammar` への貢献:
 
-* [@c-schuhmann (Christian Schuhmann)](https://github.com/c-schuhmann): Add support for SAP ABAP syntax [PR #176](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/176)
-* [@esmasth (Siddharth Sharma)](https://github.com/esmasth): Add support for YANG code fence [PR #169](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/169)
-* [@Morikko (Eric Masseran)](https://github.com/Morikko): Add restructuredtext support in markdown code block [PR #178](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/178)
+* [@c-schuhmann (Christian Schuhmann)](https://github.com/c-schuhmann): SAP ABAP 構文のサポートを追加 [PR #176](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/176)
+* [@esmasth (Siddharth Sharma)](https://github.com/esmasth): YANG コードフェンスのサポートを追加 [PR #169](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/169)
+* [@Morikko (Eric Masseran)](https://github.com/Morikko): markdown コードブロックに restructuredtext のサポートを追加 [PR #178](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/178)
 * [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing)
-  * Add support for jsonl code blocks [PR #181](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/181)
-  * Add support for ignore code blocks [PR #182](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/182)
+  * jsonl コードブロックのサポートを追加 [PR #181](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/181)
+  * ignore コードブロックのサポートを追加 [PR #182](https://github.com/microsoft/vscode-markdown-tm-grammar/pull/182)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@krassowski (Michał Krassowski)](https://github.com/krassowski): Fix typo "will be replace" → "will be replaced" [PR #7540](https://github.com/microsoft/vscode-pull-request-github/pull/7540)
+* [@krassowski (Michał Krassowski)](https://github.com/krassowski): タイプミス "will be replace" → "will be replaced" を修正 [PR #7540](https://github.com/microsoft/vscode-pull-request-github/pull/7540)
 
-Contributions to `vscode-python-environments`:
+`vscode-python-environments` への貢献:
 
-* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): fix: enhance conda executable retrieval with path existence checks [PR #677](https://github.com/microsoft/vscode-python-environments/pull/677)
-* [@sjsikora (Sam Sikora)](https://github.com/sjsikora): bug fix: Stricter pip list Package Parsing [PR #698](https://github.com/microsoft/vscode-python-environments/pull/698)
+* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): fix: パスの存在チェックで conda 実行可能ファイルの取得を強化 [PR #677](https://github.com/microsoft/vscode-python-environments/pull/677)
+* [@sjsikora (Sam Sikora)](https://github.com/sjsikora): バグ修正: より厳密な pip list パッケージの解析 [PR #698](https://github.com/microsoft/vscode-python-environments/pull/698)
 
-Contributions to `vscode-vsce`:
+`vscode-vsce` への貢献:
 
-* [@tgrospic (Tomislav Grospić)](https://github.com/tgrospic): Avoid Node.js DEP0190 warning by using string form for prepublish command [PR #1188](https://github.com/microsoft/vscode-vsce/pull/1188)
+* [@tgrospic (Tomislav Grospić)](https://github.com/tgrospic): prepublish コマンドに文字列形式を使用して Node.js DEP0190 警告を回避 [PR #1188](https://github.com/microsoft/vscode-vsce/pull/1188)
 
-Contributions to `debug-adapter-protocol`:
+`debug-adapter-protocol` への貢献:
 
-* [@jborean93 (Jordan Borean)](https://github.com/jborean93): Add Ansible implementation [PR #552](https://github.com/microsoft/debug-adapter-protocol/pull/552)
+* [@jborean93 (Jordan Borean)](https://github.com/jborean93): Ansible 実装を追加 [PR #552](https://github.com/microsoft/debug-adapter-protocol/pull/552)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@aartaka (Artyom Bologov)](https://github.com/aartaka): Add cl-lsp (Common Lisp) to implementations list [PR #2179](https://github.com/microsoft/language-server-protocol/pull/2179)
-* [@anakin4747 (Anakin Childerhose)](https://github.com/anakin4747): Add kconfig-language-server [PR #2177](https://github.com/microsoft/language-server-protocol/pull/2177)
-* [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721): add ty [PR #2175](https://github.com/microsoft/language-server-protocol/pull/2175)
-* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): Add capability information to `textDocument/colorPresentation` [PR #2173](https://github.com/microsoft/language-server-protocol/pull/2173)
+* [@aartaka (Artyom Bologov)](https://github.com/aartaka): 実装リストに cl-lsp (Common Lisp) を追加 [PR #2179](https://github.com/microsoft/language-server-protocol/pull/2179)
+* [@anakin4747 (Anakin Childerhose)](https://github.com/anakin4747): kconfig-language-server を追加 [PR #2177](https://github.com/microsoft/language-server-protocol/pull/2177)
+* [@asukaminato0721 (Asuka Minato)](https://github.com/asukaminato0721): ty を追加 [PR #2175](https://github.com/microsoft/language-server-protocol/pull/2175)
+* [@MariaSolOs (Maria José Solano)](https://github.com/MariaSolOs): `textDocument/colorPresentation` に機能情報を追加 [PR #2173](https://github.com/microsoft/language-server-protocol/pull/2173)
 * [@notpeter (Peter Tripp)](https://github.com/notpeter)
-  * Fix broken anchor links in changelog [PR #2171](https://github.com/microsoft/language-server-protocol/pull/2171)
-  * Markdown whitespace formatting improvements  [PR #2172](https://github.com/microsoft/language-server-protocol/pull/2172)
-* [@ribru17 (Riley Bruins)](https://github.com/ribru17): Fix 3.18 metamodel version [PR #2180](https://github.com/microsoft/language-server-protocol/pull/2180)
-* [@skewb1k](https://github.com/skewb1k): correct grammar and consistency in lazy property descriptions [PR #2170](https://github.com/microsoft/language-server-protocol/pull/2170)
+  * 変更履歴の壊れたアンカーリンクを修正 [PR #2171](https://github.com/microsoft/language-server-protocol/pull/2171)
+  * Markdown の空白フォーマットの改善 [PR #2172](https://github.com/microsoft/language-server-protocol/pull/2172)
+* [@ribru17 (Riley Bruins)](https://github.com/ribru17): 3.18 メタモデルのバージョンを修正 [PR #2180](https://github.com/microsoft/language-server-protocol/pull/2180)
+* [@skewb1k](https://github.com/skewb1k): 遅延プロパティの説明の文法と一貫性を修正 [PR #2170](https://github.com/microsoft/language-server-protocol/pull/2170)
 
-Contributions to `node-jsonc-parser`:
+`node-jsonc-parser` への貢献:
 
-* [@operagxsasha](https://github.com/operagxsasha): docs: edited the link to the badge tests [PR #98](https://github.com/microsoft/node-jsonc-parser/pull/98)
-* [@pimterry (Tim Perry)](https://github.com/pimterry): Add startLine & startCharacter to parser errors [PR #102](https://github.com/microsoft/node-jsonc-parser/pull/102)
+* [@operagxsasha](https://github.com/operagxsasha): docs: バッジテストへのリンクを編集 [PR #98](https://github.com/microsoft/node-jsonc-parser/pull/98)
+* [@pimterry (Tim Perry)](https://github.com/pimterry): パーサーエラーに startLine と startCharacter を追加 [PR #102](https://github.com/microsoft/node-jsonc-parser/pull/102)
 
-Contributions to `python-environment-tools`:
+`python-environment-tools` への貢献:
 
-* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): Fix conda env trace message [PR #241](https://github.com/microsoft/python-environment-tools/pull/241)
+* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): conda env トレースメッセージを修正 [PR #241](https://github.com/microsoft/python-environment-tools/pull/241)
 
-We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+新機能が準備でき次第、試してくださる皆様に心から感謝しています。頻繁にチェックして、最新情報を入手してください。
 
->If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+>以前の VS Code バージョンのリリースノートを読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
 
 <a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_104.md
+++ b/docs/release-notes/v1_104.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_104/release-highlights.png
 Date: 2025-09-11
 DownloadVersion: 1.104.1
 ---
-# August 2025 (version 1.104)
+# August 2025 (version 1.104) {#august-2025-version-1104}
 
 _Release date: September 11, 2025_
 
@@ -70,9 +70,9 @@ Welcome to the August 2025 release of Visual Studio Code. There are many updates
   <div class="notes-main">
 Navigation End -->
 
-## Chat
+## Chat {#chat}
 
-### Auto model selection (Preview)
+### Auto model selection (Preview) {#auto-model-selection-preview}
 
 This iteration, we're introducing auto model selection in chat. When you choose the **Auto** model in the model picker, VS Code automatically selects a model to ensure that you get the optimal performance and reduce rate limits.
 
@@ -88,7 +88,7 @@ You can view the selected model and the model multiplier by hovering over the re
 
 Learn more about [auto model selection in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
 
-### Confirm edits to sensitive files
+### Confirm edits to sensitive files {#confirm-edits-to-sensitive-files}
 
 **Setting**: `setting(chat.tools.edits.autoApprove)`
 
@@ -100,7 +100,7 @@ Common system folders, dotfiles, and files outside your workspace will require c
 
 ![Screenshot showing the confirmation dialog for sensitive file edits in the Chat view.](https://code.visualstudio.com/assets/updates/1_104/chat-edit-sensitive-file.png)
 
-### Support for AGENTS.md files (Experimental)
+### Support for AGENTS.md files (Experimental) {#support-for-agentsmd-files-experimental}
 
 **Setting**: `setting(chat.useAgentsMdFile)`
 
@@ -110,7 +110,7 @@ Support for `AGENTS.md` files is enabled by default and can be controlled with t
 
 Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) to your practices and team workflows.
 
-### Improved changed files experience
+### Improved changed files experience {#improved-changed-files-experience}
 
 This iteration, the changed files list has been reworked with several quality-of-life features. These changes should improve your experience when working in agent mode!
 
@@ -124,7 +124,7 @@ This iteration, the changed files list has been reworked with several quality-of
 
 <video src="https://code.visualstudio.com/assets/updates/1_104/changed-files-list.mp4" title="Video uncollapsing the changed files list and accepting file entries to remove them from the list." autoplay loop controls muted></video>
 
-### Use custom chat modes in prompt files
+### Use custom chat modes in prompt files {#use-custom-chat-modes-in-prompt-files}
 
 Prompt files are Markdown files in which you write reusable chat prompts. To run a prompt file, type `/` followed by the prompt file name in the chat input field, or use the Play button when you have the prompt file open in the editor.
 
@@ -134,7 +134,7 @@ You can specify which chat mode should be used for running the prompt file. Prev
 
 Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) with prompt files, chat modes, and custom instructions.
 
-### Configure prompt file suggestions (Experimental)
+### Configure prompt file suggestions (Experimental) {#configure-prompt-file-suggestions-experimental}
 
 **Setting**: `setting(chat.promptFilesRecommendations)`
 
@@ -155,7 +155,7 @@ The new `setting(chat.promptFilesRecommendations)` setting supports both simple 
 
 This helps teams surface the right AI workflows at the right time, making custom prompts more discoverable and relevant to your workspace and file type.
 
-### Select tools in tool sets
+### Select tools in tool sets {#select-tools-in-tool-sets}
 
 [Tool sets](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_define-tool-sets) are a convenient way to group related tools together and VS Code has several built-in tool sets like `edit` or `search`.
 
@@ -163,7 +163,7 @@ The tools picker now shows which tools are part of each tool set and you can ind
 
 ![Screenshot showing the tools picker with an expanded edit tool set, listing all available tools.](https://code.visualstudio.com/assets/updates/1_104/tools_in_toolsets.png)
 
-### Configure font used in chat
+### Configure font used in chat {#configure-font-used-in-chat}
 
 **Settings**: `setting(chat.fontFamily)`, `setting(chat.fontSize)`
 
@@ -173,11 +173,11 @@ VS Code lets you choose which font to use across the editor, however the Chat vi
 
 > **Note**: content for lists currently does not yet honor these settings, but this is something that we are working on fixing in the upcoming releases.
 
-### Collaborate with coding agents (Experimental)
+### Collaborate with coding agents (Experimental) {#collaborate-with-coding-agents-experimental}
 
 With coding agents, you delegate tasks to AI agents to be worked on in the background. You can have multiple such agents work in parallel. We're continuing to evolve the chat sessions experience to help you collaborate more effectively with coding agents.
 
-#### Chat Sessions view
+#### Chat Sessions view {#chat-sessions-view}
 
 **Setting**: `setting(chat.agentSessionsViewLocation)`
 
@@ -188,7 +188,7 @@ The Chat Sessions view provides a single, unified view for managing both local a
 * **Expanded context menus**: Access more actions to interact with your coding agents efficiently.
 * **Rich descriptions**: With rich description enabled, each list entry now includes detailed context to help you quickly find relevant information.
 
-#### GitHub coding agent integration
+#### GitHub coding agent integration {#github-coding-agent-integration}
 
 We've improved the integration of [GitHub coding agents](https://code.visualstudio.com/docs/copilot/copilot-coding-agent) with chat sessions to deliver a smoother, more intuitive experience.
 
@@ -199,7 +199,7 @@ We've improved the integration of [GitHub coding agents](https://code.visualstud
 
 <video src="https://code.visualstudio.com/assets/updates/1_104/chat-sessions-view.mp4" title="Video showing Chat Sessions view and integration with GitHub coding agents." autoplay loop controls muted></video>
 
-#### Delegate to coding agent
+#### Delegate to coding agent {#delegate-to-coding-agent}
 
 We continued to expand on ways to delegate local tasks in VS Code to a Copilot coding agent:
 
@@ -218,7 +218,7 @@ We continued to expand on ways to delegate local tasks in VS Code to a Copilot c
 _Theme: [Sharp Solarized](https://marketplace.visualstudio.com/items?itemName=joshspicer.sharp-solarized) (preview on [vscode.dev](https://vscode.dev/editor/theme/joshspicer.sharp-solarized))_
 
 
-### Social sign in with Google
+### Social sign in with Google {#social-sign-in-with-google}
 
 The option to sign in or sign up to GitHub Copilot with a Google account is now generally available and rolling out to all users in VS Code.
 
@@ -226,7 +226,7 @@ The option to sign in or sign up to GitHub Copilot with a Google account is now 
 
 You can find more information about this in the [announcement GitHub blog post](https://github.blog/changelog/2025-07-15-social-login-with-google-is-now-generally-available).
 
-### Terminal auto approve
+### Terminal auto approve {#terminal-auto-approve}
 
 **Setting**: `setting(chat.tools.terminal.enableAutoApprove)`
 
@@ -258,7 +258,7 @@ Automatically approving terminal commands can greatly streamline agent interacti
 
 Learn more about [terminal auto approve](https://code.visualstudio.com/docs/copilot/chat/chat-agent-mode#_autoapprove-terminal-commands) in our documentation.
 
-### Global auto approve
+### Global auto approve {#global-auto-approve}
 
 Global auto approve has been [an experimental setting since v1.99](https://code.visualstudio.com/updates/v1_99#_agent-mode-tool-approvals). What we have observed is that users have been enabling this setting without thinking deeply enough about the consequences. Additionally, some users thought that enabling the `setting(chat.tools.autoApprove)` setting was a prerequisite to enabling terminal auto approve, which was never the case.
 
@@ -268,7 +268,7 @@ To combat these misconceptions and to further protect our users, there is now a 
 
 The setting has also been changed to the clearer `setting(chat.tools.global.autoApprove)` without any automatic migration, so all users (accidental or intentional) need to go and explicitly set it again.
 
-### Math rendering enabled by default
+### Math rendering enabled by default {#math-rendering-enabled-by-default}
 
 **Setting**: `setting(chat.math.enabled)`
 
@@ -278,7 +278,7 @@ Rendering of mathematical equations in chat responses is now generally available
 
 This feature is powered by [KaTeX](https://katex.org) and supports both inline and block math equations. Inline math equations can be written by wrapping the markup in single dollar signs (`$...$`), while block math equations use two dollar signs (`$$...$$`).
 
-### Chat view default visibility
+### Chat view default visibility {#chat-view-default-visibility}
 
 **Setting**: `setting(workbench.secondarySideBar.defaultVisibility)`
 
@@ -286,7 +286,7 @@ When you first open a workspace, the Secondary Side Bar with the Chat view is vi
 
 ![Screenshot showing Chat view menu with the option to set the default Secondary Side Bar visibility.](https://code.visualstudio.com/assets/updates/1_104/auxview.png)
 
-### Improved task support
+### Improved task support {#improved-task-support}
 
 * Input request detection
 
@@ -306,7 +306,7 @@ When you first open a workspace, the Secondary Side Bar with the Chat view is vi
 
     <video src="https://code.visualstudio.com/assets/updates/1_104/build-task.mp4" title="Example of agent running the VS Code - Build task" autoplay loop controls muted></video>
 
-### Improved terminal support
+### Improved terminal support {#improved-terminal-support}
 
 * Moved more terminal tools to core
 
@@ -322,23 +322,23 @@ When you first open a workspace, the Secondary Side Bar with the Chat view is vi
 
     If, for some reason, you want Copilot to use Command Prompt, this is currently not possible. We will likely be adding the ability to customize the terminal profile used by Copilot soon, which is tracked in [#253945](https://github.com/microsoft/vscode/issues/253945).
 
-### Todo List tool
+### Todo List tool {#todo-list-tool}
 
 The todo list tool helps agents break down complex multi-step tasks into smaller tasks and report progress to help you track individual items. We've made improvements to this tool, which is now enabled by default.
 
 Tool progress is displayed in the Todo control at the top of the Chat view, which automatically collapses as the todo list is worked through and shows only the current task in progress.
 
-### Skip tool calls
+### Skip tool calls {#skip-tool-calls}
 
 When the agent requests confirmation for a tool call, you can now choose to skip the tool call and let the agent continue. You can still cancel the request or enter a new request via the chat input box.
 
-### Improvements to semantic workspace search
+### Improvements to semantic workspace search {#improvements-to-semantic-workspace-search}
 
 We've upgraded the `#codebase` tool to use a new [embeddings](https://en.wikipedia.org/wiki/Embedding_(machine_learning)) model for semantic searching for code in your workspace. This new model provides better results for code searches. The new embeddings also use less storage space, requiring only 6% of our previous model's on-disk storage size for each embedding.
 
 We'll be gradually rolling out this new embeddings model over the next few weeks. Your workspace will be automatically updated to use this new embeddings model, so no action is required. VS Code Insiders is already using the new model if you want to try it out before it rolls out to you.
 
-### Hide and disable GitHub Copilot AI features
+### Hide and disable GitHub Copilot AI features {#hide-and-disable-github-copilot-ai-features}
 
 **Setting**: `setting(chat.disableAIFeatures)`
 
@@ -354,19 +354,19 @@ The command to "Hide AI Features" was renamed to reflect this change and will no
 
 > **Note**: users that were hiding AI features previously will continue to see AI features hidden. You can update the setting in addition if you want to synchronize your choice across devices.
 
-## MCP
+## MCP {#mcp}
 
-### Support for server instructions
+### Support for server instructions {#support-for-server-instructions}
 
 VS Code now reads MCP server instructions and will include them in its base prompt.
 
-### MCP auto discovery disabled by default
+### MCP auto discovery disabled by default {#mcp-auto-discovery-disabled-by-default}
 
 **Setting**: `setting(chat.mcp.discovery.enabled)`
 
 VS Code supports [automatic discovery of MCP servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) installed in other apps like Claude Code. As MCP support has matured in VS Code, auto-discovery is now disabled by default, but you can re-enable it using the `setting(chat.mcp.discovery.enabled)` setting.
 
-### Enable MCP
+### Enable MCP {#enable-mcp}
 
 **Setting**: `setting(chat.mcp.access)`
 
@@ -375,23 +375,23 @@ The `chat.mcp.enabled` setting that previously controlled whether MCP servers co
 * `all`: allow all MCP servers to run (equivalent to the previous `true` value)
 * `none`: disable MCP support entirely (equivalent to the previous `false` value)
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Focus chat confirmation action
+### Focus chat confirmation action {#focus-chat-confirmation-action}
 
 We've added a command, **Focus Chat Confirmation** `(kb(workbench.action.chat.focusConfirmation))`, which focuses the confirmation dialog, if present, or announces to screen reader users that confirmation is not required.
 
-## Code Editing
+## Code Editing {#code-editing}
 
-### Configurable inline suggestion delay
+### Configurable inline suggestion delay {#configurable-inline-suggestion-delay}
 
 **Setting**: `setting(editor.inlineSuggest.minShowDelay)`
 
 A new setting `setting(editor.inlineSuggest.minShowDelay)` enables you to configure how quickly inline suggestions can appear after you type. This can be useful if you find that suggestions are appearing too quickly and getting in the way of your typing.
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Window border color support on Windows
+### Window border color support on Windows {#window-border-color-support-on-windows}
 
 **Setting**: `setting(window.border)`
 
@@ -408,13 +408,13 @@ You can configure colors per workspace, making it easier to distinguish which wo
 
 When you configure `setting(window.border)` as `default`, a theme is able to set the border color for active and inactive windows using the `window.activeBorder` and `window.inactiveBorder` color keys. You can further override these colors from the `setting(workbench.colorCustomizations)` setting.
 
-### Manage extension account preference
+### Manage extension account preference {#manage-extension-account-preference}
 
 We've added an **Accounts: Manage Extension Account Preferences** command to the Command Palette. When invoked, it shows a list of extensions that have access to authentication accounts and lets you change the account that those extensions use. You are even able to sign in to a new account right from the list.
 
 This builds on the [account management functionality that we added a year ago](https://code.visualstudio.com/updates/v1_94#_change-an-extensions-account-preference).
 
-### Editor tab index
+### Editor tab index {#editor-tab-index}
 
 **Setting**: `setting(workbench.editor.showTabIndex)`
 
@@ -422,29 +422,29 @@ You can now render the index of an editor tab in the tab's label. This can be he
 
 ![Screenshot of editor tabs with numbers in front of them, indicating their index.](https://code.visualstudio.com/assets/updates/1_104/editorTabIndex.png)
 
-### Editor tab bar scrollbar visibility
+### Editor tab bar scrollbar visibility {#editor-tab-bar-scrollbar-visibility}
 
 **Setting**: `setting(workbench.editor.titleScrollbarVisibility)`
 
 The `setting(workbench.editor.titleScrollbarVisibility)` enables you to control when the scrollbar in the editor tab bar is visible. The default value `auto` shows the scrollbar only when the tabs overflow and a tab is hovered. You can also set it to `visible` to always show the scrollbar when the tabs overflow, or `hidden` to never show it.
 
-### Issue reporter improvements
+### Issue reporter improvements {#issue-reporter-improvements}
 
 When reporting issues in VS Code or extensions via the built-in issue reporter, you can now choose either **Create on GitHub** or **Preview on GitHub** via a dropdown on the report button. If the button does not populate a dropdown and only shows Create or Preview, this likely means that you are still loading extension data or need to ensure that you are signed in with a GitHub account that provides the correct scopes.
 
 ![Screenshot of a dropdown showing Create on Github and Preview on Github in the issue reporter.](https://code.visualstudio.com/assets/updates/1_104/issue-reporter-dropdown.png)
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Improved NES suggestions (Experimental)
+### Improved NES suggestions (Experimental) {#improved-nes-suggestions-experimental}
 
 **Setting**: `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)`
 
 We are experimenting with improving the quality of next edit suggestions for notebooks. Currently, the language model has access to the contents of the active cell when generating suggestions. With the `setting(github.copilot.chat.notebook.enhancedNextEditSuggestions.enabled)` setting enabled, the language model has access to the entire notebook, enabling it to generate more accurate and higher-quality next edit suggestions.
 
-## Source Control
+## Source Control {#source-control}
 
-### Preview and migrate Git worktree changes
+### Preview and migrate Git worktree changes {#preview-and-migrate-git-worktree-changes}
 
 You can now preview differences between worktree files and your current workspace by right-clicking on a worktree file to open the context menu in the Source Control Changes view and selecting **Compare with Workspace**.
 
@@ -454,9 +454,9 @@ After reviewing your changes, you can use the **Migrate Worktree Changes...** co
 
 Learn more about [Git worktrees in VS Code](https://code.visualstudio.com/docs/sourcecontrol/overview#_worktrees).
 
-## Terminal
+## Terminal {#terminal}
 
-### Terminal window discoverability and polish
+### Terminal window discoverability and polish {#terminal-window-discoverability-and-polish}
 
 A common request is to allow terminals to be opened in separate windows. This functionality has existed for about one and a half years, but it has not been particularly discoverable. This iteration, we added multiple entry points for this functionality:
 
@@ -469,7 +469,7 @@ We also polished the experience where these new terminal windows open in compact
 
 ![Screenshot of the terminal window open in compact mode, hiding tabs to make more room for terminal content.](https://code.visualstudio.com/assets/updates/1_104/terminal-window.png)
 
-### Terminal actions in terminal editors
+### Terminal actions in terminal editors {#terminal-actions-in-terminal-editors}
 
 The actions that are available in the terminal view (new terminal dropdown, clear terminal, etc.) are now also available for terminals in the editor area and terminal windows.
 
@@ -477,7 +477,7 @@ The actions that are available in the terminal view (new terminal dropdown, clea
 
 Just like in the terminal view, you can right-click the actions area to move them out of the overflow menu.
 
-### Terminal IntelliSense improvements (Preview)
+### Terminal IntelliSense improvements (Preview) {#terminal-intellisense-improvements-preview}
 
 Terminal IntelliSense is getting several improvements this release:
 
@@ -487,35 +487,35 @@ Terminal IntelliSense is getting several improvements this release:
     ![Screenshot of new icons showing for tags and branches on completions for "git checkout"](https://code.visualstudio.com/assets/updates/1_104/terminal-suggest.png)
 * A large number of completion specs were added: `adb`, `basename`, `bundle`, `clear`, `cut`, `date`, `dd`, `diff`, `dig`, `dirname`, `docker-compose`, `docker`, `dotnet`, `env`, `export`, `fdisk`, `fmt`, `fold`, `gh`, `go`, `htop`, `id`, `jq`, `ln`, `lsblk`, `lsof`, `mount`, `nl`, `od`, `paste`, `ping`, `pkill`, `readlink`, `rsync`, `ruby`, `ruff`, `sed`, `seq`, `shred`, `sort`, `source`, `split`, `stat`, `su`, `sudo`, `tac`, `tar`, `tee`, `time`, `tr`, `traceroute`, `tree`, `truncate`, `uniq`, `unzip`, `wc`, `where`, `whereis`, `which`, `who`, `xargs`, `xxd`, `yo`, `zip`
 
-### Terminal sticky scroll improvements
+### Terminal sticky scroll improvements {#terminal-sticky-scroll-improvements}
 
 We have now enabled terminal sticky scroll by default. We have made several improvements for a better experience, such as improved behavior when using a pager. Terminal sticky scroll is now compatible with the `setting(editor.tabFocusMode)` setting.
 
-## Languages
+## Languages {#languages}
 
-### JavaScript and TypeScript
+### JavaScript and TypeScript {#javascript-and-typescript}
 
 After reviewing usage numbers, we decided to remove our built-in `bower.json` IntelliSense. Bower has been [deprecated since 2017](https://bower.io/blog/2017/how-to-migrate-away-from-bower/) and our built-in support had little usage and was not being actively maintained.
 
 Bower recommends that users migrate to `npm` or `yarn`. Continued support for Bower in VS Code can be provided by extensions.
 
-### Python
+### Python {#python}
 
-#### Python Environments extension support for Pipenv
+#### Python Environments extension support for Pipenv {#python-environments-extension-support-for-pipenv}
 
 Pipenv environments can now be discovered and selected just like in the Python extension. In addition, they appear in the **Environment Manager** view in the Python sidebar, where they are grouped and displayed alongside your other environment types.
 
 ![Screenshot showing the Python sidebar with Pipenv environments expanded.](https://code.visualstudio.com/assets/updates/1_104/pipenv-supported-screenshot.png)
 
-#### Configure environment variable injection
+#### Configure environment variable injection {#configure-environment-variable-injection}
 
 A new setting, `setting(python.useEnvFile)`, controls whether environment variables from `.env` files and the `setting(python.envFile)` setting are injected into terminals when the Python Environments extension is enabled.
 
-#### Python Environments extension improvements
+#### Python Environments extension improvements {#python-environments-extension-improvements}
 
 The [Python Environments Extension](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-python-envs) continued to receive bug fixes and improvements as part of the controlled roll-out to stable users. To use the Python Environments extension during the roll-out, make sure the extension is installed and add the following to your VS Code `settings.json` file: `"python.useEnvironmentsExtension": true`.
 
-#### AI-powered hover summaries with Pylance (Experimental)
+#### AI-powered hover summaries with Pylance (Experimental) {#aipowered-hover-summaries-with-pylance-experimental}
 
 A new experimental AI hover summaries feature is now available for Python when using the latest pre-release version of Pylance. When you enable the `setting(python.analysis.aiHoverSummaries)` setting, you can get helpful summaries on-the-fly for symbols that do not already have documentation. This makes it easier to understand unfamiliar code and boosts productivity as you explore Python projects. AI hover summaries are currently available to GitHub Copilot Pro, Pro+, and Enterprise users.
 
@@ -523,7 +523,7 @@ A new experimental AI hover summaries feature is now available for Python when u
 
 We look forward to bringing this experimental experience to the stable extension version soon.
 
-#### Run code snippet tool
+#### Run code snippet tool {#run-code-snippet-tool}
 
 Instead of relying on terminal commands like `python -c "code"` or creating temporary files to be executed, the Pylance run code snippets tool enables GitHub Copilot to execute Python snippets entirely in memory. It automatically uses the correct Python interpreter configured for your workspace, and it eliminates common issues with shell escaping and quoting that sometimes arise during terminal execution.
 
@@ -535,17 +535,17 @@ To try it out, make sure to use the latest pre-release version of the Pylance ex
 
 <video src="https://code.visualstudio.com/assets/updates/1_104/pylance-run-code-snippet.mp4" title="Code snippet generated and executed by GitHub Copilot in the Chat panel via the pylancerunCodeSnippet tool." autoplay loop controls muted></video>
 
-#### Pylance IntelliSense enabled in all Python documents
+#### Pylance IntelliSense enabled in all Python documents {#pylance-intellisense-enabled-in-all-python-documents}
 
 The `python.analysis.supportAllPythonDocuments` setting has been removed from the latest Pylance pre-release version, with Pylance IntelliSense now being enabled by default in all Python documents, including terminal and diff views. This means you can get rich code completions, hover and code navigation wherever you work with Python in VS Code.
 
-#### Activation hooks
+#### Activation hooks {#activation-hooks}
 
 Python activation hooks can now run from shell integration scripts, instead of requiring the Python environment extension to modify your shell profile. This provides more reliable terminal activation when `setting(python-envs.terminal.autoActivationType)` is set to `shellStartup` and, importantly, ensures Copilot terminals are activated as expected.
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### GitHub Pull Requests
+### GitHub Pull Requests {#github-pull-requests}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
 
@@ -556,13 +556,13 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 Review the [changelog for the 0.118.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01180) release of the extension to learn about everything in the release.
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### shellIntegrationNonce for extension launched terminals
+### shellIntegrationNonce for extension launched terminals {#shellintegrationnonce-for-extension-launched-terminals}
 
 `shellIntegrationNonce` can now be passed to `createTerminal` in `TerminalOptions` and `ExtensionTerminalOptions`. This enables the extension to control the nonce, which is used to verify commands [in shell integration escape sequences](https://code.visualstudio.com/docs/terminal/shell-integration#_supported-escape-sequences).
 
-### Language Model Chat Provider API
+### Language Model Chat Provider API {#language-model-chat-provider-api}
 
 This iteration, we finalized the `LanguageModelChatProviders` API. This enables extensions to contribute one or more language models, cloud-hosted or local. By installing the extension, users can select these models through the model picker in chat.
 
@@ -572,9 +572,9 @@ You can learn more about how to utilize this API in our [Language Model Chat Pro
 
 > **Note**: Models provided through this API are currently only available to users on [individual GitHub Copilot plans](https://docs.github.com/en/copilot/concepts/billing/individual-plans).
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Authentication: Supporting `WWW-Authenticate` challenges in `getSession`
+### Authentication: Supporting `WWW-Authenticate` challenges in `getSession` {#authentication-supporting-www-authenticate-challenges-in-getsession}
 
 A well-established pattern of HTTP is that a request to an API can return a 401 Unauthorized status code with a [WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) header, which defines _auth challenges_. These are essentially things that the API needs in order to resolve past the 401.
 
@@ -608,7 +608,7 @@ createSessionFromChallenges(constraint: AuthenticationConstraint, options: Authe
 
 and an auth provider can declare support for challenges when registered via `supportsChallenges: true` in `AuthenticationProviderOptions`.
 
-#### Example: Azure MFA
+#### Example: Azure MFA {#example-azure-mfa}
 
 This work was initially done [due to an upcoming change to require MFA in Azure APIs](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) so let's also use that as an example of this API.
 
@@ -626,20 +626,20 @@ const sessionWithMFA = await vscode.authentication.getSession('microsoft', newRe
 
 This will pass that header value down to the `microsoft` auth provider, and the auth provider will be responsible for minting a session in which the challenges are satisfied.
 
-#### Next steps
+#### Next steps {#next-steps}
 
 Next iteration we will finalize the `getSession` (aka extension asking for auth) parts of this proposal so if you have any feedback on that or the shape of the `AuthenticationProvider` changes, let us know! You can [find the full proposal on GitHub here](https://github.com/microsoft/vscode/blob/a924f20c72bd8f9665894be8213ce7f5680ab528/src/vscode-dts/vscode.proposed.authenticationChallenges.d.ts).
 
 Another use case that will be lit up soon regarding `WWW-Authenticate`, is for MCP servers to issue a `WWW-Authenticate` header asking for a token with more scopes. There's [a proposal in the MCP specification for this](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/835).
 
-### View containers in the Secondary Side Bar
+### View containers in the Secondary Side Bar {#view-containers-in-the-secondary-side-bar}
 
 Extensions can contribute view containers to the `activitybar` and `panel`. We have now added support for contributing to the `secondarySidebar` as well. This is currently behind the `contribSecondarySideBar` proposed API. We are hoping to finalize this API soon.
 
 
-## Engineering
+## Engineering {#engineering}
 
-### Exploring Playwright and Playwright MCP in the inner development loop of VS Code
+### Exploring Playwright and Playwright MCP in the inner development loop of VS Code {#exploring-playwright-and-playwright-mcp-in-the-inner-development-loop-of-vs-code}
 
 Agent mode and other AI features of VS Code have become a core tool (no pun intended) for the VS Code team to build VS Code itself. We wanted to explore how we can apply these features further to make the inner development loop of VS Code even better. To that end, we have been experimenting with extending our existing smoke test [automation project](https://github.com/microsoft/vscode/tree/main/test/automation), which uses [Playwright](https://playwright.dev/), to create an MCP server that can drive a local instance of VS Code. This allows our existing agentic flows, which focused on receiving context from build/test-time artifacts (compilation, linters, tests, etc.), to now also interact with a live instance of VS Code... verifying that changes have the desired effect at runtime.
 
@@ -652,17 +652,17 @@ This is still an early exploration, but we are excited about the possibilities t
 
 This work was recently featured on the VS Code Insiders podcast, where we discussed the motivations behind this exploration and some of the technical details. You can listen to the episode of the [VS Code Insiders podcast](https://www.vscodepodcast.com/3).
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [vscode#151902](https://github.com/microsoft/vscode/issues/151902) - Terminal: Copy on selection + new highlight in 1.68 copies previous term on CMD+F
 * [vscode#222075](https://github.com/microsoft/vscode/issues/222075) - Terminal sticky scroll can show up for 1 frame when using page down in a pager
 * [xtermjs/xterm.js#5390](https://github.com/xtermjs/xterm.js/pull/5390) - Fix scrollbar teleport after exiting alt buffer
 
-## Thank you
+## Thank you {#thank-you}
 
 Last but certainly not least, a big _**Thank You**_ to the contributors of VS Code.
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -671,7 +671,7 @@ Contributions to our issue tracking:
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 
-### Pull Requests
+### Pull Requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_104.md
     - release-notes/v1_103.md
     - release-notes/v1_102.md
     - release-notes/v1_101.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/719b2f7a073f9a98038630239df4f9dc47fc8198

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_104.md https://github.com/microsoft/vscode-docs/raw/719b2f7a073f9a98038630239df4f9dc47fc8198/release-notes/v1_104.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Agent mode - GPT-5 mini)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edit mode - Gemini 2.5 Pro)
   ```
   Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```