### PR TITLE
Translate-v1_105

### DIFF
--- a/docs/release-notes/v1_105.md
+++ b/docs/release-notes/v1_105.md
@@ -1,0 +1,589 @@
+---
+Order: 114
+TOCTitle: September 2025
+PageTitle: Visual Studio Code September 2025
+MetaDescription: Learn what is new in the Visual Studio Code September 2025 Release (1.105).
+MetaSocialImage: 1_105/release-highlights.png
+Date: 2025-10-09
+DownloadVersion: 1.105.0
+---
+# September 2025 (version 1.105)
+
+_Release date: October 9, 2025_
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the September 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+<table class="highlights-table">
+  <tr>
+    <th>OS integration</th>
+    <th>Developer productivity</th>
+    <th>Agent tools</th>
+  </tr>
+  <tr>
+    <td>Get notified about task completion and chat responses <a href="#os-notifications-for-chat-responses"><br>Show more</a></td>
+    <td>Resolve merge conflicts with AI assistance <a href="#resolve-merge-conflicts-with-ai"><br>Show more</a></td>
+    <td>Install MCP servers from the MCP marketplace <a href="#mcp-marketplace-preview"><br>Show more</a></td>
+  </tr>
+  <tr>
+    <td>Native authentication experience on macOS <a href="#macos-native-broker-support-for-microsoft-authentication"><br>Show more</a></td>
+    <td>Pick up where you left off with the recent chats <a href="#show-recent-chat-sessions-experimental"><br>Show more</a></td>
+    <td>Use fully-qualified tool names to avoid conflicts <a href="#fully-qualified-tool-names"><br>Show more</a></td>
+  </tr>
+</table>
+
+<br>
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+
+> **Insiders: Want to try new features as soon as possible?**<br>
+> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> [Download Insiders](https://code.visualstudio.com/insiders)<br>
+
+<!-- TOC
+<div class="toc-nav-layout">
+  <nav id="toc-nav">
+    <div>In this update</div>
+    <ul>
+      <li><a href="#chat">Chat</a></li>
+      <li><a href="#mcp">MCP</a></li>
+      <li><a href="#accessibility">Accessibility</a></li>
+      <li><a href="#editor-experience">Editor Experience</a></li>
+      <li><a href="#source-control">Source Control</a></li>
+      <li><a href="#tasks">Tasks</a></li>
+      <li><a href="#terminal">Terminal</a></li>
+      <li><a href="#languages">Languages</a></li>
+      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
+      <li><a href="#extension-authoring">Extension Authoring</a></li>
+      <li><a href="#engineering">Engineering</a></li>
+      <li><a href="#notable-fixes">Notable fixes</a></li>
+      <li><a href="#thank-you">Thank you</a></li>
+    </ul>
+  </nav>
+  <div class="notes-main">
+Navigation End -->
+
+## Chat
+
+### Fully qualified tool names
+
+Prompt files and custom chat modes enable you to specify which tools can be used. To avoid naming conflicts between built-in tools and tools provided by MCP servers or extensions, we now support fully qualified tool names for prompt files and chat modes. This also helps with discovering missing extensions or MCP servers.
+
+Tool names are now qualified by the MCP server, extension, or tool set they are part of. For example, instead of `codebase`, you would use `search/codebase` or `list_issues` would be `github/github-mcp-server/list_issues`.
+
+You can still use the previous notation, however a code action helps you migrate to the new names.
+
+![Screenshot of a prompt file showing a Code Action to update an unqualified tool name.](images/1_105/qualified_tool_names.png)
+
+### Improved edit tools for custom models
+
+**Setting**: `setting(github.copilot.chat.customOAIModels)`
+
+We improved the set of edit tools for [Bring Your Own Key (BYOK)](https://code.visualstudio.com/docs/copilot/customization/language-models#_bring-your-own-language-model-key) custom models to better integrate with VS Code built-in tools. In addition, we enhanced our default tools and added a 'learning' mechanism to select the optimal tool set for custom models.
+
+If you're [using OpenAI-compatible models](https://code.visualstudio.com/docs/copilot/customization/language-models#_use-an-openaicompatible-model), you can also explicitly configure the list of edit tools with the `setting(github.copilot.chat.customOAIModels)` setting.
+
+### Support for nested AGENTS.md files (Experimental)
+
+**Setting**: `setting(chat.useNestedAgentsMdFiles)`
+
+Last milestone, we introduced support for `AGENTS.md` at the root of your workspace. This functionality is now generally available and enabled by default.
+
+We now also added support for nested `AGENTS.md` files in subfolders of your workspace. This enables you to provide more specific context and instructions for different parts of your codebase. For example, you might have different instructions for frontend and backend code. This functionality is currently experimental and can be enabled with the `setting(chat.useNestedAgentsMdFiles)` setting.
+
+Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) to your practices and team workflows.
+
+### Chat user experience improvements
+
+#### OS notifications for chat responses
+
+**Setting**: `setting(chat.notifyWindowOnResponseReceived)`
+
+In VS Code 1.103, we introduced OS notifications for chat sessions that required a user confirmation when the VS Code window was not focused. In this release, we are expanding this functionality to show an OS badge and notification toast when a chat response is received. The notification includes a preview of the response, and selecting it brings focus to the chat input.
+
+![Screenshot showing an OS notification while the VS Code window is unfocused.](images/1_105/chat-notification.png)
+
+You can control the notification behavior with the `setting(chat.notifyWindowOnResponseReceived)` setting.
+
+#### Chain of thought (Experimental)
+
+**Setting**: `setting(chat.agent.thinkingStyle)`
+
+Chain of thought shows the model’s reasoning as it responds, which can be great for debugging or understanding suggestions the model provides. With the introduction of GPT-5-Codex, thinking tokens are now shown in chat as expandable sections in the response.
+
+![Screenshot of a chat response showing thinking tokens as expandable sections in the response.](images/1_105/chat-thinking-tokens.png)
+
+You can configure how to display or hide chain of thought with the `setting(chat.agent.thinkingStyle)` setting. Thinking tokens will soon be available in more models as well!
+
+#### Show recent chat sessions (Experimental)
+
+**Setting**: `setting(chat.emptyState.history.enabled)`
+
+Last milestone, we introduced [prompt file suggestions](https://code.visualstudio.com/updates/v1_104#_configure-prompt-file-suggestions-experimental) to help you get started when creating a new chat session (`kb(workbench.action.chat.newChat)`). In this release, we are building on that by showing your recent local chat conversations. This helps you quickly pick up where you left off or revisit past conversations.
+
+![Screenshot of the Chat view showing recent local chat conversations when there are no active chat sessions.](images/1_105/chat-history-on-empty.png)
+
+By default, this functionality is off, but you can enable it with the `setting(chat.emptyState.history.enabled)` setting.
+
+#### Keep or undo changes during an agent loop
+
+Previously, when an agent was still processing your chat request, you could not keep or undo file edits until the agent finished. Now, you can keep or undo changes to files while an edit loop is happening. This enables you to have more control, especially for long-running tasks.
+
+#### Keyboard shortcuts for navigating user chat messages
+
+To quickly navigate through your previous chat prompts in the chat session, we added keyboard shortcuts for navigating up and down through your chat messages:
+
+* Navigate previous:  `kb(workbench.action.chat.previousUserPrompt)`
+* Navigate next:  `kb(workbench.action.chat.nextUserPrompt)`
+
+### Agent sessions
+
+This milestone, we made several improvements to the Chat Sessions view and the experience of delegating tasks to remote coding agents:
+
+#### Chat Sessions view enhancements
+
+**Setting**: `setting(chat.agentSessionsViewLocation)`
+
+The [Chat Sessions view](https://code.visualstudio.com/docs/copilot/copilot-coding-agent#_manage-sessions-with-dedicated-chat-editor-experimental) provides a centralized location for managing both local chat conversations and remote coding agent sessions. This view enables you to work with multiple AI sessions simultaneously, track their progress, and manage long-running tasks efficiently.
+
+In this release, we made several UI refinements and performance improvements to enhance the Chat Sessions experience.
+
+* The Chat Sessions view continues to support features like Status Bar tracking for monitoring multiple coding agents, context menus for session management, and rich descriptions to provide detailed context for each session.
+
+* Quickly initiate a new session by using the "+" button in the view header.
+
+    ![Screenshot of the Chat Sessions view with a new session open via the + button.](images/1_105/chat-sessions.png)
+
+### Delegating to remote coding agents
+
+A typical scenario for working with remote coding agents is to first discuss and plan a task in a local chat session, where you have access to the full context of your codebase, and then delegate the implementation work to a remote coding agent. The remote agent can then work on the task in the background and create a pull request with the solution.
+
+If you're working in a repository that has [Copilot coding agent enabled](https://aka.ms/coding-agent-docs), the **Delegate to coding agent** button in the Chat view now appears by default.
+
+![Screenshot of the Chat view with the Delegate to coding agent button highlighted.](images/1_105/delegate-button.png)
+
+When you use the delegate action, all context from your chat conversation, including file references, is forwarded to the coding agent. If your conversation exceeds the coding agent's context window, VS Code automatically summarizes and condenses the information to fit the window.
+
+### Chat terminal profiles
+
+We added platform-specific settings `setting(chat.tools.terminal.terminalProfile.windows)`, `setting(chat.tools.terminal.terminalProfile.osx)` and `setting(chat.tools.terminal.terminalProfile.linux)` for configuring the shell that is launched by the run-in-terminal tool.
+
+Having a chat-specific shell is useful to simplify or remove interactive elements from your regular shell setup and make it easier for the agent to use. At the same time, it keeps your regular environment and shell launch scripts unchanged.
+
+```jsonc
+"chat.tools.terminal.terminalProfile.osx": {
+  "path": "bash", // bash instead of zsh
+  "args": [], // non-login instead of login on macOS
+  "env": {
+    "COPILOT": "1" // environment variable that can be used in init scripts
+  }
+}
+```
+
+### Terminal commands
+
+#### Auto-reply to terminal prompts (Experimental)
+
+**Setting**: `setting(chat.tools.terminal.autoReplyToPrompts)`
+
+We introduced an opt-in setting, `setting(chat.tools.terminal.autoReplyToPrompts)`, which enables the agent to respond to prompts for input in the terminal automatically, like `Confirm? y/n`.
+
+#### Terminal free-form input request detection
+
+When the terminal requires free-form input, we now display a confirmation prompt. This lets you stay focused on your current work and only shift attention when input is needed.
+
+### Sign in with Apple accounts
+
+In addition to signing in with a GitHub or Google account, you can now also sign in or set up a GitHub Copilot account by using an Apple account. This functionality will be rolling out to VS Code users.
+
+![Screenshot showing the sign in dialog showing the option to use an Apple account.](images/1_105/apple-sign-in.png)
+
+You can find more information about this in the announcement [GitHub blog post](https://github.blog/changelog/2025-10-07-github-now-supports-social-login-with-apple/).
+
+### Model availability
+
+This milestone, we added support for the following models in chat. The available models depend on your Copilot plan and configuration.
+
+* **GPT-5-Codex**, OpenAI’s GPT-5 model, optimized for agentic coding.
+
+* **Claude Sonnet 4.5**, Anthropic’s most advanced model for coding and real-world agents.
+
+You can choose between different models with the model picker in chat. Learn more about [language models in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
+
+## MCP
+
+### MCP marketplace (Preview)
+
+**Setting**: `setting(chat.mcp.gallery.enabled)`
+
+VS Code now includes a built-in MCP marketplace that enables users to browse and install MCP servers directly from the Extensions view. This is powered by the [GitHub MCP registry](https://github.com/mcp) and provides a seamless experience for discovering and managing MCP servers directly within the editor.
+
+> **Note**: This feature is currently in preview. Not all features are available yet and the experience might still have some rough edges.
+
+The MCP marketplace is disabled by default. When no MCP servers are installed, you see a welcome view in the Extensions view that provides easy access to enable the marketplace. You can also enable the MCP marketplace manually by using the `setting(chat.mcp.gallery.enabled)` setting.
+
+![Screenshot showing the MCP Servers welcome view with text describing how to browse and install Model Context Protocol servers, and an "Enable MCP Servers Marketplace" button.](images/1_105/mcp-servers-welcome.png)
+
+To browse the MCP servers from the Extensions view:
+
+* Use the `@mcp` filter in the Extensions view search box
+* Select **MCP Servers** from the filter dropdown in the Extensions view
+* Search for specific MCP servers by name
+
+![Screenshot showing the GitHub MCP server details from the MCP server marketplace inside VS Code.](images/1_105/mcp-server-editor.png)
+
+### Autostart MCP servers
+
+**Setting**: `setting(chat.mcp.autostart)`
+
+In this release, new or outdated MCP servers are now started automatically when you send a chat message. VS Code also avoids triggering interactions such as dialogs when autostarting a server, and instead adds an indicator in chat to let you know that a server needs attention.
+
+![Screenshot of the Chat view, showing a notification message that the GitHub MCP requires restarting.](./images/1_105/mcp_autostart_prompt.png)
+
+With MCP autostart on by default, we no longer eagerly activate extensions and instead only activate MCP-providing extensions when the first chat message is sent.
+
+For extension developers, we also added support for the `when` clause on the `mcpServerDefinitionProviders` contribution point, so you can avoid activation when it's not relevant.
+
+### Improved representation of MCP resources returned from tools
+
+Previously, our implementation of tool results that contain resources left it up to the model to retrieve those resources, without clear instructions on how to do so. In this version of VS Code, by default, we include a preview of the resource content and add instructions to retrieve the complete contents. This should lead to better model performance when using such tools.
+
+### MCP specification updates
+
+This milestone, we adopted the following updates to the MCP specification:
+
+* [SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/955), which lets MCP servers specify `icons` to associate with their data. This can be used to give a custom icon to servers, resources, and tools.
+
+    ![Screenshot of the tools picker, showing one of the MCP servers in the list with a custom icon.](./images/1_105/mcp_icons.png)
+
+    HTTP MCP servers must provide icons from the same authority that the MCP server itself is listening on, while stdio servers are allowed to reference `file:///` URIs on disk.
+
+* [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1035), which lets MCP servers provide `default` values when using elicitation.
+
+## Accessibility
+
+### Shell integration for pwsh on Windows support for screen readers
+
+PSReadLine has historically been disabled when a screen reader is detected to avoid overwhelming users with excessive auditory feedback. Since our terminal's shell integration relies on PSReadLine support, we now activate a streamlined version of PSReadLine in screen reader mode. This ensures shell integration and its features work for screen reader users.
+
+### Chat improvements
+
+**Setting**: `setting(accessibility.verboseChatProgressUpdates)`
+
+A new setting, `setting(accessibility.verboseChatProgressUpdates)`, enables more detailed announcements for screen reader users about chat activity.
+
+From the chat input, users can focus the last focused chat response item `kb(workbench.chat.action.focusLastFocused)`.
+
+### Accessible view persistence
+
+When switching between VS Code and other windows, we now maintain the user's position in the Accessible view for a seamless workflow.
+
+## Editor Experience
+
+### Override default shortcuts for Quick Input
+
+The Quick Input controls, like the ones used in the Command Palette (Quick Pick, Input Box), used to hard-code keyboard shortcuts for navigation, such as moving up or down the list, accepting (`kbstyle(Enter)`), and a few other interactions.
+
+These actions are now moved to commands, which enables you to override their keyboard shortcuts. For example, if you want `kbstyle(Tab)` to be used to accept something in the Quick Pick, this is now possible. To see all keyboard shortcuts that you can override, open the Keyboard Shortcuts editor `(kb(workbench.action.openGlobalKeybindings))` and search for `quickInput.`
+
+### Disallow whitespace-only next edit suggestions
+
+**Setting**: `setting(github.copilot.nextEditSuggestions.allowWhitespaceOnlyChanges)`
+
+It is now possible to disallow next edit suggestions (NES) to propose whitespace-only changes such as code formatting.
+
+## Source Control
+
+### Resolve merge conflicts with AI
+
+When opening a file with git merge conflict markers, you are now able to resolve merge conflicts with AI. We added a new action in the lower right-hand corner of the editor. Selecting this new action opens the Chat view and starts an agentic flow with the merge base and changes from each branch as context.
+
+![Screenshot of the proposed merge conflict resolution in the editor.](images/1_105/merge-conflict-resolution.png)
+
+You can review the proposed merge conflict resolution in the editor and follow up with additional context if needed. You can customize the merge conflict resolution by using an `AGENTS.md` file.
+
+### Add file commit to chat context
+
+A couple of milestones ago, we added the capability to view the files in each history item shown in the Source Control Graph view. You can now add a file from a history item as context to a chat request. This can be useful when you want to provide the contents of a specific version of a file as context to your chat prompt.
+
+To add a file from a past commit to chat, select a commit to view the list of files, right-click on a particular file, and then select **Add to Chat** from the context menu.
+
+![Screenshot of the Source Control Graph view showing the context menu for a file in a history item with the Add to Chat option highlighted.](images/1_105/add-history-item-to-chat.png)
+
+## Testing
+
+### Run tests with code coverage
+
+If you have a testing extension installed for your code, the `runTests` tool in chat enables the agent to run tests in your codebase by using the [VS Code testing integration](https://code.visualstudio.com/docs/debugtest/testing) rather than running them from the command line.
+
+In this release, the `runTests` tool now also reports test code coverage to the agent. This enables the agent to generate and verify tests that cover the entirety of your code.
+
+### Swap test result column
+
+You can change the side on which the result tree is displayed in the Test Results view by using the new swap ↔️ button in the view's title menu.
+
+![Screenshot of the Test Results view with the swap button highlighted.](images/1_105/swap-test-result-column.png)
+
+## Tasks
+
+### OS notification for long-running task completion
+
+**Setting**: `setting(task.notifyWindowOnTaskCompletion)`
+
+When a user-initiated, long-running task completes while the VS Code window is not focused, an OS badge and notification toast are shown. Selecting the notification focuses the window where the task completed. You can configure this behavior with the `setting(task.notifyWindowOnTaskCompletion)` setting.
+
+![Screenshot of an OS notification that shows a task completion message saying Task "build" completed in 1 minute 21 seconds.](images/1_105/task-notification.png)
+
+### Task terminal title persistence
+
+**Setting**: `setting(terminal.integrated.tabs.title)`
+
+You can configure the title of terminal tabs with the `setting(terminal.integrated.tabs.title)` setting. By default, the value is `${process}`, which shows the name of the process running in the terminal.
+
+For tasks, this means that the terminal title might change when the task starts a different process, which can be confusing. To address this, we now persist the task's name as the terminal title when a task is started.
+
+## Terminal
+
+### Start dictation exposed
+
+We added the **Start dictation** action to the terminal overflow menu. This action enables you to use voice dictation to input text into the terminal.
+A corresponding **Stop dictation** action appears when relevant.
+
+![Screenshot of the terminal overflow menu with a Start Dictation option.](images/1_105/start-dictation-terminal.png)
+
+## Authentication
+
+### macOS native broker support for Microsoft Authentication
+
+**Setting**: `setting(microsoft-authentication.implementation)`
+
+This milestone, we adopted the latest MSAL libraries and with that you are now able to sign in through a native experience on macOS (in addition to Windows):
+
+![Screenshot of a native broker dialog window asking to sign into VS Code.](images/1_105/macOS-auth-broker.png)
+
+Native broker authentication is only available for:
+
+* M-series (also known as ARM) macOS devices
+* macOS machines that are Intune-enrolled with the policy to go through the broker
+
+This enables nice single sign-on flows and is the recommended way of acquiring a Microsoft authentication session. The MSAL team will enable this up for the remaining platforms (Linux, Windows ARM, macOS Intel/x64) over time, so stay tuned!
+
+> NOTE: If you have trouble authenticating via the broker, you can change the `setting(microsoft-authentication.implementation)` to `msal-no-broker`, which will use your browser to authenticate instead.
+
+### PKCE support for GitHub Authentication
+
+[GitHub recently enabled](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/) PKCE ([Proof Key for Code Exchange](https://www.rfc-editor.org/rfc/rfc7636)) support in their authentication flows. We have adopted this in the flow that VS Code uses to authenticate to GitHub.
+
+## Languages
+
+### Python
+
+#### Copy test ID action
+
+The run gutter icon context menu now includes a **Copy Test Id** command to copy the fully qualified pytest or unittest test identifier.
+
+<video src="images/1_105/py_copy_test_id.mp4" title="Video showing the Copy Test Id command in the run gutter context menu." autoplay loop controls muted></video>
+
+## Contributions to extensions
+
+### GitHub Pull Requests
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+
+* The `#openPullRequest` tool recognizes open PR diffs and PR files as being the "open pull request".
+* The setting `setting(githubIssues.issueAvatarDisplay)` can be used to control whether the first assignee's avatar or the author's avatar is shown in the Issues view.
+* Instead of always running the pull request queries that back the Pull Requests view when refreshing, we now check to see if there are new PRs in the repo before running the queries. This should reduce API usage when there are no new PRs.
+
+Review the [changelog for the 0.120.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01200) release of the extension to learn about everything in the release.
+
+## Extension Authoring
+
+### Microsoft Authentication now supports WWW-Authenticate claims challenges
+
+[Azure is now enforcing](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) that all create/delete operations to Azure resources must be done using authenticated sessions that used MFA to sign in. While some organizations require MFA for any authentication reason, some organizations do not enforce this, and those are affected by this MFA enforcement.
+
+If you have an extension that uses Microsoft Authentication and talks to ARM, you need to handle the case when the ARM API call returns a `401 Unauthorized` with a `WWW-Authenticate` header like so:
+
+```text
+Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", error="insufficient_claims", claims="SOME VALUE HERE"
+```
+
+The good news is that we have introduced a finalized API that you can use to handle this status code:
+
+```ts
+const wwwAuthenticateFromRequest = headers['WWW-Authenticate']; // the string above
+vscode.authentication.getSession(
+  'microsoft',
+  {
+    wwwAuthenticate: wwwAuthenticateFromRequest,
+    fallbackScopes: scopesFromOriginalRequest
+  },
+  {
+    createIfNone: true
+  })
+```
+
+All you have to do is pass in, verbatim, that `WWW-Authenticate` value along with the scopes that you originally asked for (most likely the ARM scope), and the Microsoft Authentication Provider handles the rest and makes sure the user goes through MFA.
+
+We have worked with the Azure Tools team, who owns the Azure Resources extension, to adopt this new API. If you are using that extension or something that uses that extension, this enforcement should be handled. If you experience problems, open an issue on the [Azure Resources extension](https://github.com/microsoft/vscode-azureresourcegroups).
+
+> NOTE: Looking to support `WWW-Authenticate` challenges in _your_ `AuthenticationProvider`? Provide your thoughts on the proposed API in issue [#267992](https://github.com/microsoft/vscode/issues/267992).
+
+### Prompt and instructions file contributions
+
+Extensions can now contribute prompt and instructions files.
+
+```json
+  "contributes": {
+    "chatPromptFiles": [
+      {
+        "name": "ReviewAndCreateIssue",
+        "description": "Review the selected code and create an issue",
+        "path": "./prompts/reviewAndCreateIssue.prompt.md"
+      }
+    ],
+    "chatInstructions": [
+      {
+        "name": "TextMateGuidelines",
+        "description": "Use these instructions when creating or modifying TextMate grammars",
+        "path": "./prompts/textMateGuidelines.instructions.md"
+      }
+    ]
+  }
+```
+
+Chat mode contributions (`chatModes`) are currently behind a proposed API flag.
+
+### List keys in SecretStorage
+
+This iteration, we have finalized the API to list all keys that your extension has stored in Secret Storage. This can be found in the `context.secrets` object:
+
+```ts
+export function activate(context: ExtensionContext) {
+  const keys: string[] = await context.secrets.keys();
+
+  const value = await context.secrets.get(keys[0]); // a value that exists
+}
+```
+
+One example where this can be used is on `deactivate`, where you might want to delete all secret storage data.
+
+## Engineering
+
+### Playwright VS Code MCP server
+
+We further explored using an MCP server that can control a local build of VS Code to help in the development loop for VS Code. While we had mixed results on model comprehension for parsing screenshots, orchestration for subagents using the `#executePrompt` tool (which can be enabled with `setting(github.copilot.chat.executePrompt.enabled)`) was effective at not polluting context.
+
+We plan to explore this further in future releases, so stay tuned!
+
+To try this MCP Server, you can find it [in the test/mcp folder](https://github.com/microsoft/vscode/tree/main/test/mcp) of the vscode repo. It's very easy to get started:
+
+1. Follow the [Contribution Guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute) for getting a local version of Code OSS running.
+2. Use [our trivial (for now) prompt file](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) in agent mode to ask a question: `/playwright <your question here>`.
+
+## Notable fixes
+
+* [vscode#265842](https://github.com/microsoft/vscode/issues/265842) - Chat: fix a file corruption issue affecting Sonnet, Gemini, and Grok models
+* [vscode#221255](https://github.com/microsoft/vscode/issues/221255) - Fix terminal links opening regardless of confirmation of "Opening URIs can be insecure" warning.
+* [vscode#229374](https://github.com/microsoft/vscode/issues/229374) - Fix to open terminal OSC 8 hyperlink to a folder in VS Code's explorer instead of native file explorer.
+* [vscode#268443](https://github.com/microsoft/vscode/issues/268443) - Settings links in Release Notes do nothing.
+
+## Thank you
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+
+### Pull Requests
+
+Contributions to `vscode`:
+
+* [@alpalla (Alessio Palladino)](https://github.com/alpalla): Maintain line breaks in transform to Camel and Pascal case actions [PR #263781](https://github.com/microsoft/vscode/pull/263781)
+* [@andr8928](https://github.com/andr8928): Suggest widget: Bug fix - when widget is too tall, ensure larger of above and below space is used. [PR #260583](https://github.com/microsoft/vscode/pull/260583)
+* [@avarayr (avarayr)](https://github.com/avarayr): Fix: Disable window shadows on macOS Tahoe to prevent GPU performance issues [PR #267724](https://github.com/microsoft/vscode/pull/267724)
+* [@bwateratmsft (Brandon Waterloo [MSFT])](https://github.com/bwateratmsft): Fix the type incompatibility issue in the MCP HTTP server handler [PR #268548](https://github.com/microsoft/vscode/pull/268548)
+* [@CGNonofr (Loïc Mangeonjean)](https://github.com/CGNonofr)
+  * fix: race condition on supported task types [PR #265847](https://github.com/microsoft/vscode/pull/265847)
+  * fix: properly update cloned stylesheets on mutation in firefox [PR #269126](https://github.com/microsoft/vscode/pull/269126)
+* [@dmiska25 (Dylan Miska)](https://github.com/dmiska25): dispose of ref instead of object itself to avoid null objects. [PR #266299](https://github.com/microsoft/vscode/pull/266299)
+* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): Improve canSetExpressionValue check [PR #268952](https://github.com/microsoft/vscode/pull/268952)
+* [@essjay05 (Joy Serquiña)](https://github.com/essjay05): fix: adds aria-description to provide screen reader context for tooltip [PR #267818](https://github.com/microsoft/vscode/pull/267818)
+* [@garciasdos (Diego García)](https://github.com/garciasdos): fix: elicitation email validator [PR #265326](https://github.com/microsoft/vscode/pull/265326)
+* [@harbin1053020115 (ermin.zem)](https://github.com/harbin1053020115): feat: split editor group direction according to workbench.editor.splitInGroupLayout configuration when clicking walkthrough ':toSide' commands  [PR #267557](https://github.com/microsoft/vscode/pull/267557)
+* [@hron (Aleksei Gusev)](https://github.com/hron): Allow to bind `diffEditor.revert` to keyboard [PR #225881](https://github.com/microsoft/vscode/pull/225881)
+* [@leonard520 (Xiaoyun Ding)](https://github.com/leonard520): Add conversation id to mcp meta [PR #265303](https://github.com/microsoft/vscode/pull/265303)
+* [@lukocode](https://github.com/lukocode): fix: ensure SVG images are loaded before clipboard copy
+ [PR #263799](https://github.com/microsoft/vscode/pull/263799)
+* [@mawosoft (Matthias Wolf)](https://github.com/mawosoft)
+  * Fix PowerShell shell integration when strict mode is enabled. [PR #266260](https://github.com/microsoft/vscode/pull/266260)
+  * Restore PSReadline key remapping in PowerShell shell integration [PR #267311](https://github.com/microsoft/vscode/pull/267311)
+* [@narbit (Natalya Arbit)](https://github.com/narbit): Do not allow localhost redirect in favor of loopback IP redirect [PR #267546](https://github.com/microsoft/vscode/pull/267546)
+* [@Peter-developer01 (Peter)](https://github.com/Peter-developer01): Fix a typo in nls.localize(...) in localization.contribution.ts [PR #263228](https://github.com/microsoft/vscode/pull/263228)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): Fix RangeFormat wrong document race condition [PR #267628](https://github.com/microsoft/vscode/pull/267628)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
+  * fix: memory leak in ReplAccessibilityAnnouncer [PR #264937](https://github.com/microsoft/vscode/pull/264937)
+  * fix: memory leak in chat widget [PR #265002](https://github.com/microsoft/vscode/pull/265002)
+  * reduce memory by ~1.2 MB [PR #267785](https://github.com/microsoft/vscode/pull/267785)
+  * fix: memory leak in folding [PR #269071](https://github.com/microsoft/vscode/pull/269071)
+* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): Treat ellipsis character as search wildcard [PR #262462](https://github.com/microsoft/vscode/pull/262462)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Fix disposable leak in BrowserSocketFactory [PR #263736](https://github.com/microsoft/vscode/pull/263736)
+* [@turansky (Victor Turansky)](https://github.com/turansky): fix: `lm.registerLanguageModelChatProvider` jsdoc formatting [PR #266485](https://github.com/microsoft/vscode/pull/266485)
+* [@witsaint (DQ)](https://github.com/witsaint): fix: confirmation btn style [PR #267438](https://github.com/microsoft/vscode/pull/267438)
+* [@yiliang114 (易良)](https://github.com/yiliang114): Fix to #263546, for submenu of treeView view/item/context z-index iss… [PR #263555](https://github.com/microsoft/vscode/pull/263555)
+
+Contributions to `vscode-copilot-chat`:
+
+* [@24anisha](https://github.com/24anisha): Adding accept/reject and survival to GH Telemetry [PR #1059](https://github.com/microsoft/vscode-copilot-chat/pull/1059)
+* [@DGideas (Wanlin Wang 王万霖)](https://github.com/DGideas): improve custom OpenAI Compatible model URL resolution [PR #1074](https://github.com/microsoft/vscode-copilot-chat/pull/1074)
+* [@johan-j (Johan Jansson)](https://github.com/johan-j): Grouping of BYOK custom models in model picker [PR #1111](https://github.com/microsoft/vscode-copilot-chat/pull/1111)
+* [@shaunm-msft (Shaun Miller)](https://github.com/shaunm-msft)
+  * Modifications to allow direct-endpoint tests to use responses api [PR #1047](https://github.com/microsoft/vscode-copilot-chat/pull/1047)
+  * restore correct service creation for list-models [PR #1090](https://github.com/microsoft/vscode-copilot-chat/pull/1090)
+* [@vritant24 (Vritant Bhardwaj)](https://github.com/vritant24): Ungroup tools based on embedding rankings [PR #678](https://github.com/microsoft/vscode-copilot-chat/pull/678)
+* [@yemohyleyemohyle](https://github.com/yemohyleyemohyle)
+  * Yemohyle/dedup messages telemetry [PR #952](https://github.com/microsoft/vscode-copilot-chat/pull/952)
+  * Yemohyle/edit feedback msft internal [PR #984](https://github.com/microsoft/vscode-copilot-chat/pull/984)
+
+Contributions to `vscode-eslint`:
+
+* [@frodi-karlsson (Fróði Karlsson)](https://github.com/frodi-karlsson)
+  * Support realpaths with config [PR #2068](https://github.com/microsoft/vscode-eslint/pull/2068)
+  * support setting command in config for lintTask [PR #2081](https://github.com/microsoft/vscode-eslint/pull/2081)
+* [@fronterior (Low Front)](https://github.com/fronterior): Fix workspaceFolder check to use optional chaining [PR #2075](https://github.com/microsoft/vscode-eslint/pull/2075)
+
+Contributions to `vscode-json-languageservice`:
+
+* [@danila-schelkov (Danila Schelkov)](https://github.com/danila-schelkov): feat: examples completion for propertyNames [PR #286](https://github.com/microsoft/vscode-json-languageservice/pull/286)
+
+Contributions to `vscode-mypy`:
+
+* [@cnaples79 (Chase Naples)](https://github.com/cnaples79): Fix: parse mypy diagnostics from stderr in non_interactive mode [PR #375](https://github.com/microsoft/vscode-mypy/pull/375)
+
+Contributions to `vscode-python-environments`:
+
+* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): fix conda env refresh not waiting for promises [PR #751](https://github.com/microsoft/vscode-python-environments/pull/751)
+* [@renan-r-santos (Renan Santos)](https://github.com/renan-r-santos): Display activate button when a terminal is moved to the editor window [PR #764](https://github.com/microsoft/vscode-python-environments/pull/764)
+
+Contributions to `vscode-vsce`:
+
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): fix: generate language model tag for `languageModelChatProvider` contributions [PR #1199](https://github.com/microsoft/vscode-vsce/pull/1199)
+
+Contributions to `debug-adapter-protocol`:
+
+* [@dmjio (David M. Johnson)](https://github.com/dmjio): Update debug adapters list in adapters.md [PR #562](https://github.com/microsoft/debug-adapter-protocol/pull/562)
+
+
+We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+
+>If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_105.md
+++ b/docs/release-notes/v1_105.md
@@ -1,420 +1,420 @@
 ---
 Order: 114
-TOCTitle: September 2025
-PageTitle: Visual Studio Code September 2025
-MetaDescription: Learn what is new in the Visual Studio Code September 2025 Release (1.105).
+TOCTitle: 2025 年 9 月
+PageTitle: Visual Studio Code 2025 年 9 月
+MetaDescription: Visual Studio Code 2025 年 9 月リリース (1.105) の新機能について説明します。
 MetaSocialImage: 1_105/release-highlights.png
 Date: 2025-10-09
 DownloadVersion: 1.105.0
 ---
-# September 2025 (version 1.105) {#september-2025-version-1105}
+# 2025 年 9 月 (バージョン 1.105) {#september-2025-version-1105}
 
-_Release date: October 9, 2025_
+_リリース日: 2025 年 10 月 9 日_
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the September 2025 release of Visual Studio Code. There are many updates in this version that we hope you'll like, some of the key highlights include:
+Visual Studio Code 2025 年 9 月のリリースへようこそ。このバージョンには多くの更新があり、皆様に気に入っていただけることを願っています。主なハイライトは次のとおりです:
 
 <table class="highlights-table">
   <tr>
-    <th>OS integration</th>
-    <th>Developer productivity</th>
-    <th>Agent tools</th>
+    <th>OS 統合</th>
+    <th>開発者の生産性</th>
+    <th>エージェントツール</th>
   </tr>
   <tr>
-    <td>Get notified about task completion and chat responses <a href="#os-notifications-for-chat-responses"><br>Show more</a></td>
-    <td>Resolve merge conflicts with AI assistance <a href="#resolve-merge-conflicts-with-ai"><br>Show more</a></td>
-    <td>Install MCP servers from the MCP marketplace <a href="#mcp-marketplace-preview"><br>Show more</a></td>
+    <td>タスク完了とチャット応答の通知を受け取る <a href="#os-notifications-for-chat-responses"><br>詳細</a></td>
+    <td>AI 支援でマージコンフリクトを解決 <a href="#resolve-merge-conflicts-with-ai"><br>詳細</a></td>
+    <td>MCP マーケットプレイスから MCP サーバーをインストール <a href="#mcp-marketplace-preview"><br>詳細</a></td>
   </tr>
   <tr>
-    <td>Native authentication experience on macOS <a href="#macos-native-broker-support-for-microsoft-authentication"><br>Show more</a></td>
-    <td>Pick up where you left off with the recent chats <a href="#show-recent-chat-sessions-experimental"><br>Show more</a></td>
-    <td>Use fully-qualified tool names to avoid conflicts <a href="#fully-qualified-tool-names"><br>Show more</a></td>
+    <td>macOS でのネイティブ認証エクスペリエンス <a href="#macos-native-broker-support-for-microsoft-authentication"><br>詳細</a></td>
+    <td>最近のチャットで中断したところから再開 <a href="#show-recent-chat-sessions-experimental"><br>詳細</a></td>
+    <td>競合を避けるために完全修飾ツール名を使用 <a href="#fully-qualified-tool-names"><br>詳細</a></td>
   </tr>
 </table>
 
 <br>
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+>これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。<br>
 
-> **Insiders: Want to try new features as soon as possible?**<br>
-> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> **Insiders: 新機能をいち早く試したいですか？**<br>
+> 夜間の Insiders ビルドをダウンロードして、利用可能になった最新の更新をすぐに試すことができます。<br>
 > [Download Insiders](https://code.visualstudio.com/insiders)<br>
 
 <!-- TOC
 <div class="toc-nav-layout">
   <nav id="toc-nav">
-    <div>In this update</div>
+    <div>このアップデートの内容</div>
     <ul>
-      <li><a href="#chat">Chat</a></li>
+      <li><a href="#chat">チャット</a></li>
       <li><a href="#mcp">MCP</a></li>
-      <li><a href="#accessibility">Accessibility</a></li>
-      <li><a href="#editor-experience">Editor Experience</a></li>
-      <li><a href="#source-control">Source Control</a></li>
-      <li><a href="#tasks">Tasks</a></li>
-      <li><a href="#terminal">Terminal</a></li>
-      <li><a href="#languages">Languages</a></li>
-      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
-      <li><a href="#extension-authoring">Extension Authoring</a></li>
-      <li><a href="#engineering">Engineering</a></li>
-      <li><a href="#notable-fixes">Notable fixes</a></li>
-      <li><a href="#thank-you">Thank you</a></li>
+      <li><a href="#accessibility">アクセシビリティ</a></li>
+      <li><a href="#editor-experience">エディターエクスペリエンス</a></li>
+      <li><a href="#source-control">ソース管理</a></li>
+      <li><a href="#tasks">タスク</a></li>
+      <li><a href="#terminal">ターミナル</a></li>
+      <li><a href="#languages">言語</a></li>
+      <li><a href="#contributions-to-extensions">拡張機能への貢献</a></li>
+      <li><a href="#extension-authoring">拡張機能のオーサリング</a></li>
+      <li><a href="#engineering">エンジニアリング</a></li>
+      <li><a href="#notable-fixes">注目すべき修正</a></li>
+      <li><a href="#thank-you">謝辞</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Fully qualified tool names {#fully-qualified-tool-names}
+### 完全修飾ツール名 {#fully-qualified-tool-names}
 
-Prompt files and custom chat modes enable you to specify which tools can be used. To avoid naming conflicts between built-in tools and tools provided by MCP servers or extensions, we now support fully qualified tool names for prompt files and chat modes. This also helps with discovering missing extensions or MCP servers.
+プロンプトファイルとカスタムチャットモードでは、使用できるツールを指定できます。組み込みツールと MCP サーバーまたは拡張機能によって提供されるツールとの間の名前の競合を避けるために、プロンプトファイルとチャットモードで完全修飾ツール名をサポートするようになりました。これは、不足している拡張機能や MCP サーバーを発見するのにも役立ちます。
 
-Tool names are now qualified by the MCP server, extension, or tool set they are part of. For example, instead of `codebase`, you would use `search/codebase` or `list_issues` would be `github/github-mcp-server/list_issues`.
+ツール名は、それが属する MCP サーバー、拡張機能、またはツールセットによって修飾されるようになりました。たとえば、`codebase` の代わりに `search/codebase` を使用し、`list_issues` は `github/github-mcp-server/list_issues` となります。
 
-You can still use the previous notation, however a code action helps you migrate to the new names.
+以前の表記法も引き続き使用できますが、コードアクションが新しい名前への移行を支援します。
 
-![Screenshot of a prompt file showing a Code Action to update an unqualified tool name.](https://code.visualstudio.com/assets/updates/1_105/qualified_tool_names.png)
+![非修飾ツール名を更新するためのコードアクションを示すプロンプトファイルのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/qualified_tool_names.png)
 
-### Improved edit tools for custom models {#improved-edit-tools-for-custom-models}
+### カスタムモデル用の改善された編集ツール {#improved-edit-tools-for-custom-models}
 
-**Setting**: `setting(github.copilot.chat.customOAIModels)`
+**設定**: `setting(github.copilot.chat.customOAIModels)`
 
-We improved the set of edit tools for [Bring Your Own Key (BYOK)](https://code.visualstudio.com/docs/copilot/customization/language-models#_bring-your-own-language-model-key) custom models to better integrate with VS Code built-in tools. In addition, we enhanced our default tools and added a 'learning' mechanism to select the optimal tool set for custom models.
+[Bring Your Own Key (BYOK)](https://code.visualstudio.com/docs/copilot/customization/language-models#_bring-your-own-language-model-key) カスタムモデル用の編集ツールセットを改善し、VS Code の組み込みツールとの統合を向上させました。さらに、デフォルトのツールを強化し、カスタムモデルに最適なツールセットを選択するための「学習」メカニズムを追加しました。
 
-If you're [using OpenAI-compatible models](https://code.visualstudio.com/docs/copilot/customization/language-models#_use-an-openaicompatible-model), you can also explicitly configure the list of edit tools with the `setting(github.copilot.chat.customOAIModels)` setting.
+[OpenAI 互換モデルを使用している](https://code.visualstudio.com/docs/copilot/customization/language-models#_use-an-openaicompatible-model) 場合は、`setting(github.copilot.chat.customOAIModels)` 設定で編集ツールのリストを明示的に構成することもできます。
 
-### Support for nested AGENTS.md files (Experimental) {#support-for-nested-agentsmd-files-experimental}
+### ネストされた AGENTS.md ファイルのサポート (実験的) {#support-for-nested-agentsmd-files-experimental}
 
-**Setting**: `setting(chat.useNestedAgentsMdFiles)`
+**設定**: `setting(chat.useNestedAgentsMdFiles)`
 
-Last milestone, we introduced support for `AGENTS.md` at the root of your workspace. This functionality is now generally available and enabled by default.
+前回のマイルストーンでは、ワークスペースのルートに `AGENTS.md` のサポートを導入しました。この機能は現在一般的に利用可能で、デフォルトで有効になっています。
 
-We now also added support for nested `AGENTS.md` files in subfolders of your workspace. This enables you to provide more specific context and instructions for different parts of your codebase. For example, you might have different instructions for frontend and backend code. This functionality is currently experimental and can be enabled with the `setting(chat.useNestedAgentsMdFiles)` setting.
+また、ワークスペースのサブフォルダーにネストされた `AGENTS.md` ファイルのサポートも追加しました。これにより、コードベースのさまざまな部分に対して、より具体的なコンテキストと指示を提供できます。たとえば、フロントエンドとバックエンドのコードで異なる指示を持つことができます。この機能は現在実験的であり、`setting(chat.useNestedAgentsMdFiles)` 設定で有効にできます。
 
-Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) to your practices and team workflows.
+VS Code でのチャットをあなたのプラクティスやチームのワークフローに [カスタマイズする方法](https://code.visualstudio.com/docs/copilot/customization/overview) について詳しく学びましょう。
 
-### Chat user experience improvements {#chat-user-experience-improvements}
+### チャットのユーザーエクスペリエンスの向上 {#chat-user-experience-improvements}
 
-#### OS notifications for chat responses {#os-notifications-for-chat-responses}
+#### チャット応答の OS 通知 {#os-notifications-for-chat-responses}
 
-**Setting**: `setting(chat.notifyWindowOnResponseReceived)`
+**設定**: `setting(chat.notifyWindowOnResponseReceived)`
 
-In VS Code 1.103, we introduced OS notifications for chat sessions that required a user confirmation when the VS Code window was not focused. In this release, we are expanding this functionality to show an OS badge and notification toast when a chat response is received. The notification includes a preview of the response, and selecting it brings focus to the chat input.
+VS Code 1.103 では、VS Code ウィンドウがフォーカスされていないときにユーザーの確認が必要なチャットセッションに対して OS 通知を導入しました。このリリースでは、この機能を拡張し、チャット応答が受信されたときに OS バッジと通知トーストを表示するようにしました。通知には応答のプレビューが含まれ、それを選択するとチャット入力にフォーカスが移動します。
 
-![Screenshot showing an OS notification while the VS Code window is unfocused.](https://code.visualstudio.com/assets/updates/1_105/chat-notification.png)
+![VS Code ウィンドウがフォーカスされていないときの OS 通知を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/chat-notification.png)
 
-You can control the notification behavior with the `setting(chat.notifyWindowOnResponseReceived)` setting.
+`setting(chat.notifyWindowOnResponseReceived)` 設定で通知の動作を制御できます。
 
-#### Chain of thought (Experimental) {#chain-of-thought-experimental}
+#### 思考の連鎖 (実験的) {#chain-of-thought-experimental}
 
-**Setting**: `setting(chat.agent.thinkingStyle)`
+**設定**: `setting(chat.agent.thinkingStyle)`
 
-Chain of thought shows the model’s reasoning as it responds, which can be great for debugging or understanding suggestions the model provides. With the introduction of GPT-5-Codex, thinking tokens are now shown in chat as expandable sections in the response.
+思考の連鎖は、モデルが応答する際の推論を示します。これは、モデルが提供する提案をデバッグしたり理解したりするのに非常に役立ちます。GPT-5-Codex の導入により、思考トークンはチャット内で応答の展開可能なセクションとして表示されるようになりました。
 
-![Screenshot of a chat response showing thinking tokens as expandable sections in the response.](https://code.visualstudio.com/assets/updates/1_105/chat-thinking-tokens.png)
+![応答の展開可能なセクションとして思考トークンを示すチャット応答のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/chat-thinking-tokens.png)
 
-You can configure how to display or hide chain of thought with the `setting(chat.agent.thinkingStyle)` setting. Thinking tokens will soon be available in more models as well!
+`setting(chat.agent.thinkingStyle)` 設定で思考の連鎖の表示または非表示を構成できます。思考トークンは、まもなく他のモデルでも利用可能になります！
 
-#### Show recent chat sessions (Experimental) {#show-recent-chat-sessions-experimental}
+#### 最近のチャットセッションを表示 (実験的) {#show-recent-chat-sessions-experimental}
 
-**Setting**: `setting(chat.emptyState.history.enabled)`
+**設定**: `setting(chat.emptyState.history.enabled)`
 
-Last milestone, we introduced [prompt file suggestions](https://code.visualstudio.com/updates/v1_104#_configure-prompt-file-suggestions-experimental) to help you get started when creating a new chat session (`kb(workbench.action.chat.newChat)`). In this release, we are building on that by showing your recent local chat conversations. This helps you quickly pick up where you left off or revisit past conversations.
+前回のマイルストーンでは、新しいチャットセッション (`kb(workbench.action.chat.newChat)`) を作成する際に役立つ [プロンプトファイルの提案](https://code.visualstudio.com/updates/v1_104#_configure-prompt-file-suggestions-experimental) を導入しました。このリリースでは、それを基に、最近のローカルチャットの会話を表示するようにしました。これにより、中断したところからすばやく再開したり、過去の会話を再訪したりできます。
 
-![Screenshot of the Chat view showing recent local chat conversations when there are no active chat sessions.](https://code.visualstudio.com/assets/updates/1_105/chat-history-on-empty.png)
+![アクティブなチャットセッションがない場合に、最近のローカルチャットの会話を表示するチャットビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/chat-history-on-empty.png)
 
-By default, this functionality is off, but you can enable it with the `setting(chat.emptyState.history.enabled)` setting.
+デフォルトではこの機能はオフですが、`setting(chat.emptyState.history.enabled)` 設定で有効にできます。
 
-#### Keep or undo changes during an agent loop {#keep-or-undo-changes-during-an-agent-loop}
+#### エージェントループ中の変更を保持または元に戻す {#keep-or-undo-changes-during-an-agent-loop}
 
-Previously, when an agent was still processing your chat request, you could not keep or undo file edits until the agent finished. Now, you can keep or undo changes to files while an edit loop is happening. This enables you to have more control, especially for long-running tasks.
+以前は、エージェントがまだチャットリクエストを処理している間は、エージェントが終了するまでファイルの編集を保持したり元に戻したりすることはできませんでした。 現在では、編集ループが発生している間にファイルの変更を保持したり元に戻したりできます。これにより、特に長時間のタスクに対して、より多くの制御が可能になります。
 
-#### Keyboard shortcuts for navigating user chat messages {#keyboard-shortcuts-for-navigating-user-chat-messages}
+#### ユーザーのチャットメッセージをナビゲートするためのキーボードショートカット {#keyboard-shortcuts-for-navigating-user-chat-messages}
 
-To quickly navigate through your previous chat prompts in the chat session, we added keyboard shortcuts for navigating up and down through your chat messages:
+チャットセッションで以前のチャットプロンプトをすばやくナビゲートするために、チャットメッセージを上下に移動するためのキーボードショートカットを追加しました:
 
-* Navigate previous:  `kb(workbench.action.chat.previousUserPrompt)`
-* Navigate next:  `kb(workbench.action.chat.nextUserPrompt)`
+* 前のユーザープロンプトに移動: `kb(workbench.action.chat.previousUserPrompt)`
+* 次のユーザープロンプトに移動: `kb(workbench.action.chat.nextUserPrompt)`
 
-### Agent sessions {#agent-sessions}
+### エージェントセッション {#agent-sessions}
 
-This milestone, we made several improvements to the Chat Sessions view and the experience of delegating tasks to remote coding agents:
+このマイルストーンでは、チャットセッションビューと、リモートコーディングエージェントにタスクを委任するエクスペリエンスにいくつかの改善を加えました:
 
-#### Chat Sessions view enhancements {#chat-sessions-view-enhancements}
+#### チャットセッションビューの強化 {#chat-sessions-view-enhancements}
 
-**Setting**: `setting(chat.agentSessionsViewLocation)`
+**設定**: `setting(chat.agentSessionsViewLocation)`
 
-The [Chat Sessions view](https://code.visualstudio.com/docs/copilot/copilot-coding-agent#_manage-sessions-with-dedicated-chat-editor-experimental) provides a centralized location for managing both local chat conversations and remote coding agent sessions. This view enables you to work with multiple AI sessions simultaneously, track their progress, and manage long-running tasks efficiently.
+[チャットセッションビュー](https://code.visualstudio.com/docs/copilot/copilot-coding-agent#_manage-sessions-with-dedicated-chat-editor-experimental) は、ローカルのチャット会話とリモートコーディングエージェントセッションの両方を管理するための一元的な場所を提供します。このビューにより、複数の AI セッションを同時に操作し、その進捗を追跡し、長時間のタスクを効率的に管理できます。
 
-In this release, we made several UI refinements and performance improvements to enhance the Chat Sessions experience.
+このリリースでは、チャットセッションのエクスペリエンスを向上させるために、いくつかの UI の改良とパフォーマンスの改善を行いました。
 
-* The Chat Sessions view continues to support features like Status Bar tracking for monitoring multiple coding agents, context menus for session management, and rich descriptions to provide detailed context for each session.
+* チャットセッションビューは、複数のコーディングエージェントを監視するためのステータスバー追跡、セッション管理のためのコンテキストメニュー、各セッションに詳細なコンテキストを提供するためのリッチな説明などの機能を引き続きサポートします。
 
-* Quickly initiate a new session by using the "+" button in the view header.
+* ビューヘッダーの「+」ボタンを使用して、新しいセッションをすばやく開始します。
 
-    ![Screenshot of the Chat Sessions view with a new session open via the + button.](https://code.visualstudio.com/assets/updates/1_105/chat-sessions.png)
+    ![「+」ボタンで新しいセッションが開かれたチャットセッションビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/chat-sessions.png)
 
-### Delegating to remote coding agents {#delegating-to-remote-coding-agents}
+### リモートコーディングエージェントへの委任 {#delegating-to-remote-coding-agents}
 
-A typical scenario for working with remote coding agents is to first discuss and plan a task in a local chat session, where you have access to the full context of your codebase, and then delegate the implementation work to a remote coding agent. The remote agent can then work on the task in the background and create a pull request with the solution.
+リモートコーディングエージェントと連携する一般的なシナリオは、まずローカルのチャットセッションでタスクを議論し計画することです。そこではコードベースの完全なコンテキストにアクセスでき、その後、実装作業をリモートコーディングエージェントに委任します。リモートエージェントはバックグラウンドでタスクに取り組み、解決策を含むプルリクエストを作成できます。
 
-If you're working in a repository that has [Copilot coding agent enabled](https://aka.ms/coding-agent-docs), the **Delegate to coding agent** button in the Chat view now appears by default.
+[Copilot コーディングエージェントが有効になっている](https://aka.ms/coding-agent-docs) リポジトリで作業している場合、チャットビューの **Delegate to coding agent** ボタンがデフォルトで表示されるようになりました。
 
-![Screenshot of the Chat view with the Delegate to coding agent button highlighted.](https://code.visualstudio.com/assets/updates/1_105/delegate-button.png)
+![Delegate to coding agent ボタンがハイライトされたチャットビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/delegate-button.png)
 
-When you use the delegate action, all context from your chat conversation, including file references, is forwarded to the coding agent. If your conversation exceeds the coding agent's context window, VS Code automatically summarizes and condenses the information to fit the window.
+委任アクションを使用すると、ファイル参照を含むチャット会話のすべてのコンテキストがコーディングエージェントに転送されます。会話がコーディングエージェントのコンテキストウィンドウを超えた場合、VS Code は自動的に情報を要約および圧縮してウィンドウに収めます。
 
-### Chat terminal profiles {#chat-terminal-profiles}
+### チャットターミナルプロファイル {#chat-terminal-profiles}
 
-We added platform-specific settings `setting(chat.tools.terminal.terminalProfile.windows)`, `setting(chat.tools.terminal.terminalProfile.osx)` and `setting(chat.tools.terminal.terminalProfile.linux)` for configuring the shell that is launched by the run-in-terminal tool.
+run-in-terminal ツールによって起動されるシェルを構成するために、プラットフォーム固有の設定 `setting(chat.tools.terminal.terminalProfile.windows)`、`setting(chat.tools.terminal.terminalProfile.osx)`、および `setting(chat.tools.terminal.terminalProfile.linux)` を追加しました。
 
-Having a chat-specific shell is useful to simplify or remove interactive elements from your regular shell setup and make it easier for the agent to use. At the same time, it keeps your regular environment and shell launch scripts unchanged.
+チャット固有のシェルを持つことは、通常のシェル設定から対話型要素を簡素化または削除し、エージェントが使いやすくするのに役立ちます。同時に、通常の環境とシェルの起動スクリプトは変更されません。
 
 ```jsonc
 "chat.tools.terminal.terminalProfile.osx": {
-  "path": "bash", // bash instead of zsh
-  "args": [], // non-login instead of login on macOS
+  "path": "bash", // zsh の代わりに bash
+  "args": [], // macOS でのログインの代わりに非ログイン
   "env": {
-    "COPILOT": "1" // environment variable that can be used in init scripts
+    "COPILOT": "1" // init スクリプトで使用できる環境変数
   }
 }
 ```
 
-### Terminal commands {#terminal-commands}
+### ターミナルコマンド {#terminal-commands}
 
-#### Auto-reply to terminal prompts (Experimental) {#auto-reply-to-terminal-prompts-experimental}
+#### ターミナルのプロンプトへの自動応答 (実験的) {#auto-reply-to-terminal-prompts-experimental}
 
-**Setting**: `setting(chat.tools.terminal.autoReplyToPrompts)`
+**設定**: `setting(chat.tools.terminal.autoReplyToPrompts)`
 
-We introduced an opt-in setting, `setting(chat.tools.terminal.autoReplyToPrompts)`, which enables the agent to respond to prompts for input in the terminal automatically, like `Confirm? y/n`.
+オプトイン設定 `setting(chat.tools.terminal.autoReplyToPrompts)` を導入しました。これにより、エージェントはターミナルでの入力プロンプト (`Confirm? y/n` など) に自動的に応答できます。
 
-#### Terminal free-form input request detection {#terminal-free-form-input-request-detection}
+#### ターミナルの自由形式入力要求の検出 {#terminal-free-form-input-request-detection}
 
-When the terminal requires free-form input, we now display a confirmation prompt. This lets you stay focused on your current work and only shift attention when input is needed.
+ターミナルが自由形式の入力を必要とする場合、確認プロンプトを表示するようになりました。これにより、現在の作業に集中し続け、入力が必要なときにのみ注意を向けることができます。
 
-### Sign in with Apple accounts {#sign-in-with-apple-accounts}
+### Apple アカウントでサインイン {#sign-in-with-apple-accounts}
 
-In addition to signing in with a GitHub or Google account, you can now also sign in or set up a GitHub Copilot account by using an Apple account. This functionality will be rolling out to VS Code users.
+GitHub または Google アカウントでのサインインに加えて、Apple アカウントを使用して GitHub Copilot アカウントにサインインまたは設定できるようになりました。この機能は VS Code ユーザーに順次展開されます。
 
-![Screenshot showing the sign in dialog showing the option to use an Apple account.](https://code.visualstudio.com/assets/updates/1_105/apple-sign-in.png)
+![Apple アカウントを使用するオプションが表示されたサインインダイアログのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/apple-sign-in.png)
 
-You can find more information about this in the announcement [GitHub blog post](https://github.blog/changelog/2025-10-07-github-now-supports-social-login-with-apple/).
+詳細については、[GitHub ブログ投稿](https://github.blog/changelog/2025-10-07-github-now-supports-social-login-with-apple/) の発表をご覧ください。
 
-### Model availability {#model-availability}
+### モデルの可用性 {#model-availability}
 
-This milestone, we added support for the following models in chat. The available models depend on your Copilot plan and configuration.
+このマイルストーンでは、チャットで以下のモデルのサポートを追加しました。利用可能なモデルは、Copilot プランと構成によって異なります。
 
-* **GPT-5-Codex**, OpenAI’s GPT-5 model, optimized for agentic coding.
+* **GPT-5-Codex**、OpenAI の GPT-5 モデルで、エージェント的なコーディングに最適化されています。
 
-* **Claude Sonnet 4.5**, Anthropic’s most advanced model for coding and real-world agents.
+* **Claude Sonnet 4.5**、Anthropic のコーディングおよび現実世界のエージェント向けの最先端モデル。
 
-You can choose between different models with the model picker in chat. Learn more about [language models in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
+チャットのモデルピッカーで異なるモデルを選択できます。[VS Code の言語モデル](https://code.visualstudio.com/docs/copilot/customization/language-models) について詳しく学びましょう。
 
 ## MCP {#mcp}
 
-### MCP marketplace (Preview) {#mcp-marketplace-preview}
+### MCP マーケットプレイス (プレビュー) {#mcp-marketplace-preview}
 
-**Setting**: `setting(chat.mcp.gallery.enabled)`
+**設定**: `setting(chat.mcp.gallery.enabled)`
 
-VS Code now includes a built-in MCP marketplace that enables users to browse and install MCP servers directly from the Extensions view. This is powered by the [GitHub MCP registry](https://github.com/mcp) and provides a seamless experience for discovering and managing MCP servers directly within the editor.
+VS Code には、ユーザーが拡張機能ビューから直接 MCP サーバーを閲覧およびインストールできる組み込みの MCP マーケットプレイスが含まれるようになりました。これは [GitHub MCP レジストリ](https://github.com/mcp) によって提供され、エディター内で直接 MCP サーバーを発見および管理するためのシームレスなエクスペリエンスを提供します。
 
-> **Note**: This feature is currently in preview. Not all features are available yet and the experience might still have some rough edges.
+> **注**: この機能は現在プレビュー段階です。まだすべての機能が利用可能ではなく、エクスペリエンスにはまだいくつかの粗い部分があるかもしれません。
 
-The MCP marketplace is disabled by default. When no MCP servers are installed, you see a welcome view in the Extensions view that provides easy access to enable the marketplace. You can also enable the MCP marketplace manually by using the `setting(chat.mcp.gallery.enabled)` setting.
+MCP マーケットプレイスはデフォルトで無効になっています。MCP サーバーがインストールされていない場合、拡張機能ビューにウェルカムビューが表示され、マーケットプレイスを簡単に有効にできます。`setting(chat.mcp.gallery.enabled)` 設定を使用して手動で MCP マーケットプレイスを有効にすることもできます。
 
-![Screenshot showing the MCP Servers welcome view with text describing how to browse and install Model Context Protocol servers, and an "Enable MCP Servers Marketplace" button.](https://code.visualstudio.com/assets/updates/1_105/mcp-servers-welcome.png)
+![Model Context Protocol サーバーを閲覧およびインストールする方法を説明するテキストと、「MCP サーバーマーケットプレイスを有効にする」ボタンが表示された MCP サーバーウェルカムビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/mcp-servers-welcome.png)
 
-To browse the MCP servers from the Extensions view:
+拡張機能ビューから MCP サーバーを閲覧するには:
 
-* Use the `@mcp` filter in the Extensions view search box
-* Select **MCP Servers** from the filter dropdown in the Extensions view
-* Search for specific MCP servers by name
+* 拡張機能ビューの検索ボックスで `@mcp` フィルターを使用する
+* 拡張機能ビューのフィルタードロップダウンから **MCP Servers** を選択する
+* 名前で特定の MCP サーバーを検索する
 
-![Screenshot showing the GitHub MCP server details from the MCP server marketplace inside VS Code.](https://code.visualstudio.com/assets/updates/1_105/mcp-server-editor.png)
+![VS Code 内の MCP サーバーマーケットプレイスからの GitHub MCP サーバーの詳細を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/mcp-server-editor.png)
 
-### Autostart MCP servers {#autostart-mcp-servers}
+### MCP サーバーの自動起動 {#autostart-mcp-servers}
 
-**Setting**: `setting(chat.mcp.autostart)`
+**設定**: `setting(chat.mcp.autostart)`
 
-In this release, new or outdated MCP servers are now started automatically when you send a chat message. VS Code also avoids triggering interactions such as dialogs when autostarting a server, and instead adds an indicator in chat to let you know that a server needs attention.
+このリリースでは、チャットメッセージを送信すると、新しいまたは古い MCP サーバーが自動的に起動されるようになりました。VS Code はまた、サーバーを自動起動する際にダイアログなどのインタラクションをトリガーするのを避け、代わりにチャットにインジケーターを追加して、サーバーに注意が必要であることを知らせます。
 
-![Screenshot of the Chat view, showing a notification message that the GitHub MCP requires restarting.](https://code.visualstudio.com/assets/updates/1_105/mcp_autostart_prompt.png)
+![GitHub MCP の再起動が必要であることを示す通知メッセージが表示されたチャットビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/mcp_autostart_prompt.png)
 
-With MCP autostart on by default, we no longer eagerly activate extensions and instead only activate MCP-providing extensions when the first chat message is sent.
+MCP の自動起動がデフォルトでオンになったため、拡張機能を積極的にアクティブ化するのではなく、最初のチャットメッセージが送信されたときにのみ MCP を提供する拡張機能をアクティブ化します。
 
-For extension developers, we also added support for the `when` clause on the `mcpServerDefinitionProviders` contribution point, so you can avoid activation when it's not relevant.
+拡張機能開発者向けに、`mcpServerDefinitionProviders` コントリビューションポイントに `when` 句のサポートも追加しました。これにより、関連性のない場合にアクティベーションを回避できます。
 
-### Improved representation of MCP resources returned from tools {#improved-representation-of-mcp-resources-returned-from-tools}
+### ツールから返される MCP リソースの表現の改善 {#improved-representation-of-mcp-resources-returned-from-tools}
 
-Previously, our implementation of tool results that contain resources left it up to the model to retrieve those resources, without clear instructions on how to do so. In this version of VS Code, by default, we include a preview of the resource content and add instructions to retrieve the complete contents. This should lead to better model performance when using such tools.
+以前は、リソースを含むツール結果の実装では、それらのリソースを取得する方法について明確な指示なしに、モデルに任せていました。このバージョンの VS Code では、デフォルトでリソースコンテンツのプレビューを含め、完全なコンテンツを取得するための指示を追加します。これにより、そのようなツールを使用する際のモデルのパフォーマンスが向上するはずです。
 
-### MCP specification updates {#mcp-specification-updates}
+### MCP 仕様の更新 {#mcp-specification-updates}
 
-This milestone, we adopted the following updates to the MCP specification:
+このマイルストーンでは、MCP 仕様に以下の更新を取り入れました:
 
-* [SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/955), which lets MCP servers specify `icons` to associate with their data. This can be used to give a custom icon to servers, resources, and tools.
+* [SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/955)。これにより、MCP サーバーはデータに関連付ける `icons` を指定できます。これは、サーバー、リソース、およびツールにカスタムアイコンを付与するために使用できます。
 
-    ![Screenshot of the tools picker, showing one of the MCP servers in the list with a custom icon.](https://code.visualstudio.com/assets/updates/1_105/mcp_icons.png)
+    ![リスト内の MCP サーバーの 1 つにカスタムアイコンが表示されているツールピッカーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/mcp_icons.png)
 
-    HTTP MCP servers must provide icons from the same authority that the MCP server itself is listening on, while stdio servers are allowed to reference `file:///` URIs on disk.
+    HTTP MCP サーバーは、MCP サーバー自体がリッスンしているのと同じオーソリティからアイコンを提供する必要がありますが、stdio サーバーはディスク上の `file:///` URI を参照することが許可されています。
 
-* [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1035), which lets MCP servers provide `default` values when using elicitation.
+* [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1035)。これにより、MCP サーバーは elicitation を使用する際に `default` 値を提供できます。
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Shell integration for pwsh on Windows support for screen readers {#shell-integration-for-pwsh-on-windows-support-for-screen-readers}
+### Windows 上の pwsh のシェル統合がスクリーンリーダーをサポート {#shell-integration-for-pwsh-on-windows-support-for-screen-readers}
 
-PSReadLine has historically been disabled when a screen reader is detected to avoid overwhelming users with excessive auditory feedback. Since our terminal's shell integration relies on PSReadLine support, we now activate a streamlined version of PSReadLine in screen reader mode. This ensures shell integration and its features work for screen reader users.
+PSReadLine は、過剰な音声フィードバックでユーザーを圧倒するのを避けるため、スクリーンリーダーが検出されると歴史的に無効にされてきました。ターミナルのシェル統合は PSReadLine のサポートに依存しているため、スクリーンリーダーモードで PSReadLine の合理化されたバージョンをアクティブ化するようになりました。これにより、スクリーンリーダーユーザーに対してシェル統合とその機能が動作することが保証されます。
 
-### Chat improvements {#chat-improvements}
+### チャットの改善 {#chat-improvements}
 
-**Setting**: `setting(accessibility.verboseChatProgressUpdates)`
+**設定**: `setting(accessibility.verboseChatProgressUpdates)`
 
-A new setting, `setting(accessibility.verboseChatProgressUpdates)`, enables more detailed announcements for screen reader users about chat activity.
+新しい設定 `setting(accessibility.verboseChatProgressUpdates)` は、スクリーンリーダーユーザーに対してチャットのアクティビティに関するより詳細なアナウンスを有効にします。
 
-From the chat input, users can focus the last focused chat response item `kb(workbench.chat.action.focusLastFocused)`.
+チャット入力から、ユーザーは最後にフォーカスされたチャット応答項目にフォーカスできます `kb(workbench.chat.action.focusLastFocused)`。
 
-### Accessible view persistence {#accessible-view-persistence}
+### アクセシブルビューの永続性 {#accessible-view-persistence}
 
-When switching between VS Code and other windows, we now maintain the user's position in the Accessible view for a seamless workflow.
+VS Code と他のウィンドウを切り替える際、シームレスなワークフローのためにアクセシブルビューでのユーザーの位置を維持するようになりました。
 
-## Editor Experience {#editor-experience}
+## エディターエクスペリエンス {#editor-experience}
 
-### Override default shortcuts for Quick Input {#override-default-shortcuts-for-quick-input}
+### クイック入力のデフォルトショートカットを上書き {#override-default-shortcuts-for-quick-input}
 
-The Quick Input controls, like the ones used in the Command Palette (Quick Pick, Input Box), used to hard-code keyboard shortcuts for navigation, such as moving up or down the list, accepting (`kbstyle(Enter)`), and a few other interactions.
+コマンドパレット (クイックピック、入力ボックス) で使用されるようなクイック入力コントロールは、リストの上下移動、承諾 (`kbstyle(Enter)`)、その他いくつかのインタラクションなど、ナビゲーションのためのキーボードショートカットをハードコードしていました。
 
-These actions are now moved to commands, which enables you to override their keyboard shortcuts. For example, if you want `kbstyle(Tab)` to be used to accept something in the Quick Pick, this is now possible. To see all keyboard shortcuts that you can override, open the Keyboard Shortcuts editor `(kb(workbench.action.openGlobalKeybindings))` and search for `quickInput.`
+これらのアクションはコマンドに移動され、キーボードショートカットを上書きできるようになりました。たとえば、クイックピックで何かを承諾するために `kbstyle(Tab)` を使用したい場合、これが可能になりました。上書きできるすべてのキーボードショートカットを確認するには、キーボードショートカットエディター `(kb(workbench.action.openGlobalKeybindings))` を開き、`quickInput.` を検索してください。
 
-### Disallow whitespace-only next edit suggestions {#disallow-whitespace-only-next-edit-suggestions}
+### 空白のみの次の編集提案を禁止 {#disallow-whitespace-only-next-edit-suggestions}
 
-**Setting**: `setting(github.copilot.nextEditSuggestions.allowWhitespaceOnlyChanges)`
+**設定**: `setting(github.copilot.nextEditSuggestions.allowWhitespaceOnlyChanges)`
 
-It is now possible to disallow next edit suggestions (NES) to propose whitespace-only changes such as code formatting.
+次の編集提案 (NES) がコードフォーマットなどの空白のみの変更を提案するのを禁止できるようになりました。
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Resolve merge conflicts with AI {#resolve-merge-conflicts-with-ai}
+### AI でマージコンフリクトを解決 {#resolve-merge-conflicts-with-ai}
 
-When opening a file with git merge conflict markers, you are now able to resolve merge conflicts with AI. We added a new action in the lower right-hand corner of the editor. Selecting this new action opens the Chat view and starts an agentic flow with the merge base and changes from each branch as context.
+git マージコンフリクトマーカーのあるファイルを開くと、AI でマージコンフリクトを解決できるようになりました。エディターの右下隅に新しいアクションを追加しました。この新しいアクションを選択すると、チャットビューが開き、マージベースと各ブランチからの変更をコンテキストとしてエージェントフローが開始されます。
 
-![Screenshot of the proposed merge conflict resolution in the editor.](https://code.visualstudio.com/assets/updates/1_105/merge-conflict-resolution.png)
+![エディターで提案されたマージコンフリクトの解決策のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/merge-conflict-resolution.png)
 
-You can review the proposed merge conflict resolution in the editor and follow up with additional context if needed. You can customize the merge conflict resolution by using an `AGENTS.md` file.
+エディターで提案されたマージコンフリクトの解決策を確認し、必要に応じて追加のコンテキストでフォローアップできます。`AGENTS.md` ファイルを使用して、マージコンフリクトの解決策をカスタマイズできます。
 
-### Add file commit to chat context {#add-file-commit-to-chat-context}
+### ファイルコミットをチャットコンテキストに追加 {#add-file-commit-to-chat-context}
 
-A couple of milestones ago, we added the capability to view the files in each history item shown in the Source Control Graph view. You can now add a file from a history item as context to a chat request. This can be useful when you want to provide the contents of a specific version of a file as context to your chat prompt.
+数マイルストーン前に、ソース管理グラフビューに表示される各履歴項目のファイルを表示する機能を追加しました。 अब、履歴項目からファイルをチャットリクエストのコンテキストとして追加できます。これは、特定のバージョンのファイルの内容をチャットプロンプトのコンテキストとして提供したい場合に便利です。
 
-To add a file from a past commit to chat, select a commit to view the list of files, right-click on a particular file, and then select **Add to Chat** from the context menu.
+過去のコミットからファイルをチャットに追加するには、コミットを選択してファイルのリストを表示し、特定のファイルを右クリックして、コンテキストメニューから **Add to Chat** を選択します。
 
-![Screenshot of the Source Control Graph view showing the context menu for a file in a history item with the Add to Chat option highlighted.](https://code.visualstudio.com/assets/updates/1_105/add-history-item-to-chat.png)
+![ソース管理グラフビューで、履歴項目のファイルのコンテキストメニューに Add to Chat オプションがハイライトされているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/add-history-item-to-chat.png)
 
-## Testing {#testing}
+## テスト {#testing}
 
-### Run tests with code coverage {#run-tests-with-code-coverage}
+### コードカバレッジ付きでテストを実行 {#run-tests-with-code-coverage}
 
-If you have a testing extension installed for your code, the `runTests` tool in chat enables the agent to run tests in your codebase by using the [VS Code testing integration](https://code.visualstudio.com/docs/debugtest/testing) rather than running them from the command line.
+コード用のテスト拡張機能がインストールされている場合、チャットの `runTests` ツールを使用すると、エージェントはコマンドラインからではなく [VS Code テスト統合](https://code.visualstudio.com/docs/debugtest/testing) を使用してコードベースのテストを実行できます。
 
-In this release, the `runTests` tool now also reports test code coverage to the agent. This enables the agent to generate and verify tests that cover the entirety of your code.
+このリリースでは、`runTests` ツールはテストコードカバレッジもエージェントに報告するようになりました。これにより、エージェントはコード全体をカバーするテストを生成および検証できます。
 
-### Swap test result column {#swap-test-result-column}
+### テスト結果の列を入れ替える {#swap-test-result-column}
 
-You can change the side on which the result tree is displayed in the Test Results view by using the new swap ↔️ button in the view's title menu.
+テスト結果ビューのタイトルメニューにある新しい入れ替え ↔️ ボタンを使用して、結果ツリーが表示される側を変更できます。
 
-![Screenshot of the Test Results view with the swap button highlighted.](https://code.visualstudio.com/assets/updates/1_105/swap-test-result-column.png)
+![テスト結果ビューで入れ替えボタンがハイライトされているスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/swap-test-result-column.png)
 
-## Tasks {#tasks}
+## タスク {#tasks}
 
-### OS notification for long-running task completion {#os-notification-for-long-running-task-completion}
+### 長時間実行タスク完了の OS 通知 {#os-notification-for-long-running-task-completion}
 
-**Setting**: `setting(task.notifyWindowOnTaskCompletion)`
+**設定**: `setting(task.notifyWindowOnTaskCompletion)`
 
-When a user-initiated, long-running task completes while the VS Code window is not focused, an OS badge and notification toast are shown. Selecting the notification focuses the window where the task completed. You can configure this behavior with the `setting(task.notifyWindowOnTaskCompletion)` setting.
+ユーザーが開始した長時間実行タスクが、VS Code ウィンドウがフォーカスされていない間に完了すると、OS バッジと通知トーストが表示されます。通知を選択すると、タスクが完了したウィンドウにフォーカスが移動します。この動作は `setting(task.notifyWindowOnTaskCompletion)` 設定で構成できます。
 
-![Screenshot of an OS notification that shows a task completion message saying Task "build" completed in 1 minute 21 seconds.](https://code.visualstudio.com/assets/updates/1_105/task-notification.png)
+![「Task "build" completed in 1 minute 21 seconds」というタスク完了メッセージを示す OS 通知のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/task-notification.png)
 
-### Task terminal title persistence {#task-terminal-title-persistence}
+### タスクターミナルタイトルの永続性 {#task-terminal-title-persistence}
 
-**Setting**: `setting(terminal.integrated.tabs.title)`
+**設定**: `setting(terminal.integrated.tabs.title)`
 
-You can configure the title of terminal tabs with the `setting(terminal.integrated.tabs.title)` setting. By default, the value is `${process}`, which shows the name of the process running in the terminal.
+`setting(terminal.integrated.tabs.title)` 設定でターミナルタブのタイトルを構成できます。デフォルト値は `${process}` で、ターミナルで実行中のプロセスの名前を表示します。
 
-For tasks, this means that the terminal title might change when the task starts a different process, which can be confusing. To address this, we now persist the task's name as the terminal title when a task is started.
+タスクの場合、これはタスクが別のプロセスを開始するとターミナルタイトルが変更される可能性があり、混乱を招く可能性があります。これに対処するため、タスクが開始されるとタスクの名前をターミナルタイトルとして永続化するようになりました。
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Start dictation exposed {#start-dictation-exposed}
+### ディクテーションの開始を公開 {#start-dictation-exposed}
 
-We added the **Start dictation** action to the terminal overflow menu. This action enables you to use voice dictation to input text into the terminal.
-A corresponding **Stop dictation** action appears when relevant.
+ターミナルのオーバーフローメニューに **Start dictation** アクションを追加しました。このアクションにより、音声ディクテーションを使用してターミナルにテキストを入力できます。
+関連する場合、対応する **Stop dictation** アクションが表示されます。
 
-![Screenshot of the terminal overflow menu with a Start Dictation option.](https://code.visualstudio.com/assets/updates/1_105/start-dictation-terminal.png)
+![Start Dictation オプションが表示されたターミナルオーバーフローメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/start-dictation-terminal.png)
 
-## Authentication {#authentication}
+## 認証 {#authentication}
 
-### macOS native broker support for Microsoft Authentication {#macos-native-broker-support-for-microsoft-authentication}
+### macOS での Microsoft 認証のネイティブブローカーサポート {#macos-native-broker-support-for-microsoft-authentication}
 
-**Setting**: `setting(microsoft-authentication.implementation)`
+**設定**: `setting(microsoft-authentication.implementation)`
 
-This milestone, we adopted the latest MSAL libraries and with that you are now able to sign in through a native experience on macOS (in addition to Windows):
+このマイルストーンでは、最新の MSAL ライブラリを採用し、これにより macOS (Windows に加えて) でネイティブエクスペリエンスを通じてサインインできるようになりました:
 
-![Screenshot of a native broker dialog window asking to sign into VS Code.](https://code.visualstudio.com/assets/updates/1_105/macOS-auth-broker.png)
+![VS Code へのサインインを求めるネイティブブローカーダイアログウィンドウのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_105/macOS-auth-broker.png)
 
-Native broker authentication is only available for:
+ネイティブブローカー認証は以下でのみ利用可能です:
 
-* M-series (also known as ARM) macOS devices
-* macOS machines that are Intune-enrolled with the policy to go through the broker
+* M シリーズ (ARM とも呼ばれる) macOS デバイス
+* ブローカーを経由するポリシーで Intune に登録されている macOS マシン
 
-This enables nice single sign-on flows and is the recommended way of acquiring a Microsoft authentication session. The MSAL team will enable this up for the remaining platforms (Linux, Windows ARM, macOS Intel/x64) over time, so stay tuned!
+これにより、優れたシングルサインオンフローが可能になり、Microsoft 認証セッションを取得するための推奨される方法です。MSAL チームは、残りのプラットフォーム (Linux、Windows ARM、macOS Intel/x64) でもこれを順次有効にしていく予定ですので、ご期待ください！
 
-> NOTE: If you have trouble authenticating via the broker, you can change the `setting(microsoft-authentication.implementation)` to `msal-no-broker`, which will use your browser to authenticate instead.
+> 注: ブローカー経由での認証に問題がある場合は、`setting(microsoft-authentication.implementation)` を `msal-no-broker` に変更できます。これにより、代わりにブラウザーを使用して認証されます。
 
-### PKCE support for GitHub Authentication {#pkce-support-for-github-authentication}
+### GitHub 認証の PKCE サポート {#pkce-support-for-github-authentication}
 
-[GitHub recently enabled](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/) PKCE ([Proof Key for Code Exchange](https://www.rfc-editor.org/rfc/rfc7636)) support in their authentication flows. We have adopted this in the flow that VS Code uses to authenticate to GitHub.
+[GitHub は最近](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/)、認証フローで PKCE ([Proof Key for Code Exchange](https://www.rfc-editor.org/rfc/rfc7636)) サポートを有効にしました。VS Code が GitHub への認証に使用するフローでこれを採用しました。
 
-## Languages {#languages}
+## 言語 {#languages}
 
 ### Python {#python}
 
-#### Copy test ID action {#copy-test-id-action}
+#### テスト ID のコピーアクション {#copy-test-id-action}
 
-The run gutter icon context menu now includes a **Copy Test Id** command to copy the fully qualified pytest or unittest test identifier.
+実行ガターアイコンのコンテキストメニューに、完全修飾された pytest または unittest のテスト識別子をコピーするための **Copy Test Id** コマンドが含まれるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_105/py_copy_test_id.mp4" title="Video showing the Copy Test Id command in the run gutter context menu." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_105/py_copy_test_id.mp4" title="実行ガターのコンテキストメニューに Copy Test Id コマンドが表示されているビデオ。" autoplay loop controls muted></video>
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### GitHub Pull Requests {#github-pull-requests}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+プルリクエストやイシューの作業、作成、管理を可能にする [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能でさらなる進展がありました。新機能は次のとおりです:
 
-* The `#openPullRequest` tool recognizes open PR diffs and PR files as being the "open pull request".
-* The setting `setting(githubIssues.issueAvatarDisplay)` can be used to control whether the first assignee's avatar or the author's avatar is shown in the Issues view.
-* Instead of always running the pull request queries that back the Pull Requests view when refreshing, we now check to see if there are new PRs in the repo before running the queries. This should reduce API usage when there are no new PRs.
+* `#openPullRequest` ツールは、開いている PR の差分と PR ファイルを「開いているプルリクエスト」として認識します。
+* `setting(githubIssues.issueAvatarDisplay)` 設定を使用して、Issues ビューに最初のアサイニーのアバターまたは作成者のアバターのどちらを表示するかを制御できます。
+* プルリクエストビューを更新する際に、常にプルリクエストクエリを実行する代わりに、クエリを実行する前にリポジトリに新しい PR があるかどうかを確認するようになりました。これにより、新しい PR がない場合の API 使用量が削減されるはずです。
 
-Review the [changelog for the 0.120.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01200) release of the extension to learn about everything in the release.
+拡張機能の [0.120.0 リリースの変更履歴](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01200) を確認して、リリースのすべてについて学びましょう。
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能のオーサリング {#extension-authoring}
 
-### Microsoft Authentication now supports WWW-Authenticate claims challenges {#microsoft-authentication-now-supports-wwwauthenticate-claims-challenges}
+### Microsoft 認証が WWW-Authenticate クレームチャレンジをサポート {#microsoft-authentication-now-supports-wwwauthenticate-claims-challenges}
 
-[Azure is now enforcing](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) that all create/delete operations to Azure resources must be done using authenticated sessions that used MFA to sign in. While some organizations require MFA for any authentication reason, some organizations do not enforce this, and those are affected by this MFA enforcement.
+[Azure は現在](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication)、Azure リソースへのすべての作成/削除操作が、サインインに MFA を使用した認証済みセッションを使用して行われることを強制しています。一部の組織では、あらゆる認証理由で MFA を要求しますが、一部の組織ではこれを強制しておらず、それらの組織がこの MFA 強制の影響を受けます。
 
-If you have an extension that uses Microsoft Authentication and talks to ARM, you need to handle the case when the ARM API call returns a `401 Unauthorized` with a `WWW-Authenticate` header like so:
+Microsoft 認証を使用し、ARM と通信する拡張機能がある場合、ARM API 呼び出しが `401 Unauthorized` を返し、次のような `WWW-Authenticate` ヘッダーが含まれるケースを処理する必要があります:
 
 ```text
 Bearer realm="", authorization_uri="https://login.microsoftonline.com/common/oauth2/authorize", error="insufficient_claims", claims="SOME VALUE HERE"
 ```
 
-The good news is that we have introduced a finalized API that you can use to handle this status code:
+良いニュースは、このステータスコードを処理するために使用できる最終化された API を導入したことです:
 
 ```ts
-const wwwAuthenticateFromRequest = headers['WWW-Authenticate']; // the string above
+const wwwAuthenticateFromRequest = headers['WWW-Authenticate']; // 上記の文字列
 vscode.authentication.getSession(
   'microsoft',
   {
@@ -426,164 +426,164 @@ vscode.authentication.getSession(
   })
 ```
 
-All you have to do is pass in, verbatim, that `WWW-Authenticate` value along with the scopes that you originally asked for (most likely the ARM scope), and the Microsoft Authentication Provider handles the rest and makes sure the user goes through MFA.
+あなたがする必要があるのは、その `WWW-Authenticate` 値を、元々要求したスコープ (おそらく ARM スコープ) と一緒にそのまま渡すことだけです。そうすれば、Microsoft 認証プロバイダーが残りを処理し、ユーザーが MFA を通過するようにします。
 
-We have worked with the Azure Tools team, who owns the Azure Resources extension, to adopt this new API. If you are using that extension or something that uses that extension, this enforcement should be handled. If you experience problems, open an issue on the [Azure Resources extension](https://github.com/microsoft/vscode-azureresourcegroups).
+私たちは、Azure Resources 拡張機能を所有する Azure Tools チームと協力して、この新しい API を採用しました。その拡張機能またはそれを使用するものを使用している場合、この強制は処理されるはずです。問題が発生した場合は、[Azure Resources 拡張機能](https://github.com/microsoft/vscode-azureresourcegroups) に issue をオープンしてください。
 
-> NOTE: Looking to support `WWW-Authenticate` challenges in _your_ `AuthenticationProvider`? Provide your thoughts on the proposed API in issue [#267992](https://github.com/microsoft/vscode/issues/267992).
+> 注: _あなたの_ `AuthenticationProvider` で `WWW-Authenticate` チャレンジをサポートしたいですか？ issue [#267992](https://github.com/microsoft/vscode/issues/267992) で提案された API についてご意見をお聞かせください。
 
-### Prompt and instructions file contributions {#prompt-and-instructions-file-contributions}
+### プロンプトと指示ファイルのコントリビューション {#prompt-and-instructions-file-contributions}
 
-Extensions can now contribute prompt and instructions files.
+拡張機能がプロンプトと指示ファイルをコントリビュートできるようになりました。
 
 ```json
   "contributes": {
     "chatPromptFiles": [
       {
         "name": "ReviewAndCreateIssue",
-        "description": "Review the selected code and create an issue",
+        "description": "選択したコードを確認し、イシューを作成します",
         "path": "./prompts/reviewAndCreateIssue.prompt.md"
       }
     ],
     "chatInstructions": [
       {
         "name": "TextMateGuidelines",
-        "description": "Use these instructions when creating or modifying TextMate grammars",
+        "description": "TextMate 文法を作成または変更する際にこれらの指示を使用します",
         "path": "./prompts/textMateGuidelines.instructions.md"
       }
     ]
   }
 ```
 
-Chat mode contributions (`chatModes`) are currently behind a proposed API flag.
+チャットモードのコントリビューション (`chatModes`) は現在、提案された API フラグの背後にあります。
 
-### List keys in SecretStorage {#list-keys-in-secretstorage}
+### SecretStorage のキーを一覧表示 {#list-keys-in-secretstorage}
 
-This iteration, we have finalized the API to list all keys that your extension has stored in Secret Storage. This can be found in the `context.secrets` object:
+このイテレーションでは、拡張機能がシークレットストレージに保存したすべてのキーを一覧表示する API を最終化しました。これは `context.secrets` オブジェクトにあります:
 
 ```ts
 export function activate(context: ExtensionContext) {
   const keys: string[] = await context.secrets.keys();
 
-  const value = await context.secrets.get(keys[0]); // a value that exists
+  const value = await context.secrets.get(keys[0]); // 存在する値
 }
 ```
 
-One example where this can be used is on `deactivate`, where you might want to delete all secret storage data.
+これが使用できる一例は `deactivate` で、すべてのシークレットストレージデータを削除したい場合です。
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### Playwright VS Code MCP server {#playwright-vs-code-mcp-server}
+### Playwright VS Code MCP サーバー {#playwright-vs-code-mcp-server}
 
-We further explored using an MCP server that can control a local build of VS Code to help in the development loop for VS Code. While we had mixed results on model comprehension for parsing screenshots, orchestration for subagents using the `#executePrompt` tool (which can be enabled with `setting(github.copilot.chat.executePrompt.enabled)`) was effective at not polluting context.
+VS Code の開発ループを支援するために、VS Code のローカルビルドを制御できる MCP サーバーの使用をさらに探求しました。スクリーンショットの解析に関するモデルの理解についてはまちまちな結果でしたが、`#executePrompt` ツール (`setting(github.copilot.chat.executePrompt.enabled)` で有効にできます) を使用したサブエージェントのオーケストレーションは、コンテキストを汚染しない点で効果的でした。
 
-We plan to explore this further in future releases, so stay tuned!
+今後のリリースでこれをさらに探求する予定ですので、ご期待ください！
 
-To try this MCP Server, you can find it [in the test/mcp folder](https://github.com/microsoft/vscode/tree/main/test/mcp) of the vscode repo. It's very easy to get started:
+この MCP サーバーを試すには、vscode リポジトリの [test/mcp フォルダー](https://github.com/microsoft/vscode/tree/main/test/mcp) にあります。始めるのは非常に簡単です:
 
-1. Follow the [Contribution Guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute) for getting a local version of Code OSS running.
-2. Use [our trivial (for now) prompt file](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) in agent mode to ask a question: `/playwright <your question here>`.
+1. Code OSS のローカルバージョンを実行するための [コントリビューションガイドライン](https://github.com/microsoft/vscode/wiki/How-to-Contribute) に従ってください。
+2. エージェントモードで [私たちの (今のところ) 簡単なプロンプトファイル](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) を使用して質問します: `/playwright <あなたの質問>`。
 
-## Notable fixes {#notable-fixes}
+## 注目すべき修正 {#notable-fixes}
 
-* [vscode#265842](https://github.com/microsoft/vscode/issues/265842) - Chat: fix a file corruption issue affecting Sonnet, Gemini, and Grok models
-* [vscode#221255](https://github.com/microsoft/vscode/issues/221255) - Fix terminal links opening regardless of confirmation of "Opening URIs can be insecure" warning.
-* [vscode#229374](https://github.com/microsoft/vscode/issues/229374) - Fix to open terminal OSC 8 hyperlink to a folder in VS Code's explorer instead of native file explorer.
-* [vscode#268443](https://github.com/microsoft/vscode/issues/268443) - Settings links in Release Notes do nothing.
+* [vscode#265842](https://github.com/microsoft/vscode/issues/265842) - チャット: Sonnet、Gemini、Grok モデルに影響するファイル破損の問題を修正
+* [vscode#221255](https://github.com/microsoft/vscode/issues/221255) - 「URI を開くことは安全でない可能性があります」という警告の確認に関係なくターミナルリンクが開く問題を修正。
+* [vscode#229374](https://github.com/microsoft/vscode/issues/229374) - ターミナル OSC 8 のフォルダーへのハイパーリンクを、ネイティブのファイルエクスプローラーではなく VS Code のエクスプローラーで開くように修正。
+* [vscode#268443](https://github.com/microsoft/vscode/issues/268443) - リリースノートの設定リンクが何もしない。
 
-## Thank you {#thank-you}
+## 謝辞 {#thank-you}
 
-### Issue tracking {#issue-tracking}
+### イシュートラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+私たちのイシュートラッキングへの貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull Requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@alpalla (Alessio Palladino)](https://github.com/alpalla): Maintain line breaks in transform to Camel and Pascal case actions [PR #263781](https://github.com/microsoft/vscode/pull/263781)
-* [@andr8928](https://github.com/andr8928): Suggest widget: Bug fix - when widget is too tall, ensure larger of above and below space is used. [PR #260583](https://github.com/microsoft/vscode/pull/260583)
-* [@avarayr (avarayr)](https://github.com/avarayr): Fix: Disable window shadows on macOS Tahoe to prevent GPU performance issues [PR #267724](https://github.com/microsoft/vscode/pull/267724)
-* [@bwateratmsft (Brandon Waterloo [MSFT])](https://github.com/bwateratmsft): Fix the type incompatibility issue in the MCP HTTP server handler [PR #268548](https://github.com/microsoft/vscode/pull/268548)
+* [@alpalla (Alessio Palladino)](https://github.com/alpalla): キャメルケースとパスカルケースへの変換アクションで改行を維持 [PR #263781](https://github.com/microsoft/vscode/pull/263781)
+* [@andr8928](https://github.com/andr8928): 提案ウィジェット: バグ修正 - ウィジェットが高すぎる場合、上下のスペースの大きい方が使用されるようにする。 [PR #260583](https://github.com/microsoft/vscode/pull/260583)
+* [@avarayr (avarayr)](https://github.com/avarayr): 修正: GPU パフォーマンスの問題を防ぐため、macOS Tahoe でウィンドウの影を無効にする [PR #267724](https://github.com/microsoft/vscode/pull/267724)
+* [@bwateratmsft (Brandon Waterloo [MSFT])](https://github.com/bwateratmsft): MCP HTTP サーバーハンドラーの型非互換性の問題を修正 [PR #268548](https://github.com/microsoft/vscode/pull/268548)
 * [@CGNonofr (Loïc Mangeonjean)](https://github.com/CGNonofr)
-  * fix: race condition on supported task types [PR #265847](https://github.com/microsoft/vscode/pull/265847)
-  * fix: properly update cloned stylesheets on mutation in firefox [PR #269126](https://github.com/microsoft/vscode/pull/269126)
-* [@dmiska25 (Dylan Miska)](https://github.com/dmiska25): dispose of ref instead of object itself to avoid null objects. [PR #266299](https://github.com/microsoft/vscode/pull/266299)
-* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): Improve canSetExpressionValue check [PR #268952](https://github.com/microsoft/vscode/pull/268952)
-* [@essjay05 (Joy Serquiña)](https://github.com/essjay05): fix: adds aria-description to provide screen reader context for tooltip [PR #267818](https://github.com/microsoft/vscode/pull/267818)
-* [@garciasdos (Diego García)](https://github.com/garciasdos): fix: elicitation email validator [PR #265326](https://github.com/microsoft/vscode/pull/265326)
-* [@harbin1053020115 (ermin.zem)](https://github.com/harbin1053020115): feat: split editor group direction according to workbench.editor.splitInGroupLayout configuration when clicking walkthrough ':toSide' commands  [PR #267557](https://github.com/microsoft/vscode/pull/267557)
-* [@hron (Aleksei Gusev)](https://github.com/hron): Allow to bind `diffEditor.revert` to keyboard [PR #225881](https://github.com/microsoft/vscode/pull/225881)
-* [@leonard520 (Xiaoyun Ding)](https://github.com/leonard520): Add conversation id to mcp meta [PR #265303](https://github.com/microsoft/vscode/pull/265303)
-* [@lukocode](https://github.com/lukocode): fix: ensure SVG images are loaded before clipboard copy
+  * 修正: サポートされているタスクタイプの競合状態 [PR #265847](https://github.com/microsoft/vscode/pull/265847)
+  * 修正: firefox でのミューテーション時にクローンされたスタイルシートを正しく更新する [PR #269126](https://github.com/microsoft/vscode/pull/269126)
+* [@dmiska25 (Dylan Miska)](https://github.com/dmiska25): null オブジェクトを避けるためにオブジェクト自体の代わりに ref を破棄する。 [PR #266299](https://github.com/microsoft/vscode/pull/266299)
+* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): canSetExpressionValue チェックを改善 [PR #268952](https://github.com/microsoft/vscode/pull/268952)
+* [@essjay05 (Joy Serquiña)](https://github.com/essjay05): 修正: ツールチップにスクリーンリーダーのコンテキストを提供するために aria-description を追加 [PR #267818](https://github.com/microsoft/vscode/pull/267818)
+* [@garciasdos (Diego García)](https://github.com/garciasdos): 修正: elicitation メールバリデーター [PR #265326](https://github.com/microsoft/vscode/pull/265326)
+* [@harbin1053020115 (ermin.zem)](https://github.com/harbin1053020115): 機能: ウォークスルーの ':toSide' コマンドをクリックしたときに、workbench.editor.splitInGroupLayout 設定に従ってエディターグループの分割方向を決定する [PR #267557](https://github.com/microsoft/vscode/pull/267557)
+* [@hron (Aleksei Gusev)](https://github.com/hron): `diffEditor.revert` をキーボードにバインドできるようにする [PR #225881](https://github.com/microsoft/vscode/pull/225881)
+* [@leonard520 (Xiaoyun Ding)](https://github.com/leonard520): mcp メタに会話 ID を追加 [PR #265303](https://github.com/microsoft/vscode/pull/265303)
+* [@lukocode](https://github.com/lukocode): 修正: クリップボードコピーの前に SVG 画像がロードされるようにする
  [PR #263799](https://github.com/microsoft/vscode/pull/263799)
 * [@mawosoft (Matthias Wolf)](https://github.com/mawosoft)
-  * Fix PowerShell shell integration when strict mode is enabled. [PR #266260](https://github.com/microsoft/vscode/pull/266260)
-  * Restore PSReadline key remapping in PowerShell shell integration [PR #267311](https://github.com/microsoft/vscode/pull/267311)
-* [@narbit (Natalya Arbit)](https://github.com/narbit): Do not allow localhost redirect in favor of loopback IP redirect [PR #267546](https://github.com/microsoft/vscode/pull/267546)
-* [@Peter-developer01 (Peter)](https://github.com/Peter-developer01): Fix a typo in nls.localize(...) in localization.contribution.ts [PR #263228](https://github.com/microsoft/vscode/pull/263228)
-* [@RedCMD (RedCMD)](https://github.com/RedCMD): Fix RangeFormat wrong document race condition [PR #267628](https://github.com/microsoft/vscode/pull/267628)
+  * 厳格モードが有効な場合の PowerShell シェル統合を修正。 [PR #266260](https://github.com/microsoft/vscode/pull/266260)
+  * PowerShell シェル統合で PSReadline キーの再マッピングを復元 [PR #267311](https://github.com/microsoft/vscode/pull/267311)
+* [@narbit (Natalya Arbit)](https://github.com/narbit): ループバック IP リダイレクトを優先して localhost リダイレクトを許可しない [PR #267546](https://github.com/microsoft/vscode/pull/267546)
+* [@Peter-developer01 (Peter)](https://github.com/Peter-developer01): localization.contribution.ts の nls.localize(...) のタイポを修正 [PR #263228](https://github.com/microsoft/vscode/pull/263228)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): RangeFormat の間違ったドキュメントの競合状態を修正 [PR #267628](https://github.com/microsoft/vscode/pull/267628)
 * [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
-  * fix: memory leak in ReplAccessibilityAnnouncer [PR #264937](https://github.com/microsoft/vscode/pull/264937)
-  * fix: memory leak in chat widget [PR #265002](https://github.com/microsoft/vscode/pull/265002)
-  * reduce memory by ~1.2 MB [PR #267785](https://github.com/microsoft/vscode/pull/267785)
-  * fix: memory leak in folding [PR #269071](https://github.com/microsoft/vscode/pull/269071)
-* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): Treat ellipsis character as search wildcard [PR #262462](https://github.com/microsoft/vscode/pull/262462)
-* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Fix disposable leak in BrowserSocketFactory [PR #263736](https://github.com/microsoft/vscode/pull/263736)
-* [@turansky (Victor Turansky)](https://github.com/turansky): fix: `lm.registerLanguageModelChatProvider` jsdoc formatting [PR #266485](https://github.com/microsoft/vscode/pull/266485)
-* [@witsaint (DQ)](https://github.com/witsaint): fix: confirmation btn style [PR #267438](https://github.com/microsoft/vscode/pull/267438)
-* [@yiliang114 (易良)](https://github.com/yiliang114): Fix to #263546, for submenu of treeView view/item/context z-index iss… [PR #263555](https://github.com/microsoft/vscode/pull/263555)
+  * 修正: ReplAccessibilityAnnouncer のメモリリーク [PR #264937](https://github.com/microsoft/vscode/pull/264937)
+  * 修正: チャットウィジェットのメモリリーク [PR #265002](https://github.com/microsoft/vscode/pull/265002)
+  * メモリを約 1.2 MB 削減 [PR #267785](https://github.com/microsoft/vscode/pull/267785)
+  * 修正: フォールディングのメモリリーク [PR #269071](https://github.com/microsoft/vscode/pull/269071)
+* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): 省略記号を検索ワイルドカードとして扱う [PR #262462](https://github.com/microsoft/vscode/pull/262462)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): BrowserSocketFactory の使い捨てリークを修正 [PR #263736](https://github.com/microsoft/vscode/pull/263736)
+* [@turansky (Victor Turansky)](https://github.com/turansky): 修正: `lm.registerLanguageModelChatProvider` jsdoc のフォーマット [PR #266485](https://github.com/microsoft/vscode/pull/266485)
+* [@witsaint (DQ)](https://github.com/witsaint): 修正: 確認ボタンのスタイル [PR #267438](https://github.com/microsoft/vscode/pull/267438)
+* [@yiliang114 (易良)](https://github.com/yiliang114): #263546 の修正、treeView view/item/context のサブメニューの z-index の問題… [PR #263555](https://github.com/microsoft/vscode/pull/263555)
 
-Contributions to `vscode-copilot-chat`:
+`vscode-copilot-chat` への貢献:
 
-* [@24anisha](https://github.com/24anisha): Adding accept/reject and survival to GH Telemetry [PR #1059](https://github.com/microsoft/vscode-copilot-chat/pull/1059)
-* [@DGideas (Wanlin Wang 王万霖)](https://github.com/DGideas): improve custom OpenAI Compatible model URL resolution [PR #1074](https://github.com/microsoft/vscode-copilot-chat/pull/1074)
-* [@johan-j (Johan Jansson)](https://github.com/johan-j): Grouping of BYOK custom models in model picker [PR #1111](https://github.com/microsoft/vscode-copilot-chat/pull/1111)
+* [@24anisha](https://github.com/24anisha): GH テレメトリに accept/reject と survival を追加 [PR #1059](https://github.com/microsoft/vscode-copilot-chat/pull/1059)
+* [@DGideas (Wanlin Wang 王万霖)](https://github.com/DGideas): カスタム OpenAI 互換モデルの URL 解決を改善 [PR #1074](https://github.com/microsoft/vscode-copilot-chat/pull/1074)
+* [@johan-j (Johan Jansson)](https://github.com/johan-j): モデルピッカーでの BYOK カスタムモデルのグループ化 [PR #1111](https://github.com/microsoft/vscode-copilot-chat/pull/1111)
 * [@shaunm-msft (Shaun Miller)](https://github.com/shaunm-msft)
-  * Modifications to allow direct-endpoint tests to use responses api [PR #1047](https://github.com/microsoft/vscode-copilot-chat/pull/1047)
-  * restore correct service creation for list-models [PR #1090](https://github.com/microsoft/vscode-copilot-chat/pull/1090)
-* [@vritant24 (Vritant Bhardwaj)](https://github.com/vritant24): Ungroup tools based on embedding rankings [PR #678](https://github.com/microsoft/vscode-copilot-chat/pull/678)
+  * ダイレクトエンドポイントテストが responses api を使用できるようにする変更 [PR #1047](https://github.com/microsoft/vscode-copilot-chat/pull/1047)
+  * list-models の正しいサービス作成を復元 [PR #1090](https://github.com/microsoft/vscode-copilot-chat/pull/1090)
+* [@vritant24 (Vritant Bhardwaj)](https://github.com/vritant24): 埋め込みランキングに基づいてツールをグループ解除 [PR #678](https://github.com/microsoft/vscode-copilot-chat/pull/678)
 * [@yemohyleyemohyle](https://github.com/yemohyleyemohyle)
   * Yemohyle/dedup messages telemetry [PR #952](https://github.com/microsoft/vscode-copilot-chat/pull/952)
   * Yemohyle/edit feedback msft internal [PR #984](https://github.com/microsoft/vscode-copilot-chat/pull/984)
 
-Contributions to `vscode-eslint`:
+`vscode-eslint` への貢献:
 
 * [@frodi-karlsson (Fróði Karlsson)](https://github.com/frodi-karlsson)
-  * Support realpaths with config [PR #2068](https://github.com/microsoft/vscode-eslint/pull/2068)
-  * support setting command in config for lintTask [PR #2081](https://github.com/microsoft/vscode-eslint/pull/2081)
-* [@fronterior (Low Front)](https://github.com/fronterior): Fix workspaceFolder check to use optional chaining [PR #2075](https://github.com/microsoft/vscode-eslint/pull/2075)
+  * config で realpath をサポート [PR #2068](https://github.com/microsoft/vscode-eslint/pull/2068)
+  * lintTask の config で command を設定するのをサポート [PR #2081](https://github.com/microsoft/vscode-eslint/pull/2081)
+* [@fronterior (Low Front)](https://github.com/fronterior): workspaceFolder チェックをオプショナルチェイニングを使用するように修正 [PR #2075](https://github.com/microsoft/vscode-eslint/pull/2075)
 
-Contributions to `vscode-json-languageservice`:
+`vscode-json-languageservice` への貢献:
 
-* [@danila-schelkov (Danila Schelkov)](https://github.com/danila-schelkov): feat: examples completion for propertyNames [PR #286](https://github.com/microsoft/vscode-json-languageservice/pull/286)
+* [@danila-schelkov (Danila Schelkov)](https://github.com/danila-schelkov): 機能: propertyNames の examples 補完 [PR #286](https://github.com/microsoft/vscode-json-languageservice/pull/286)
 
-Contributions to `vscode-mypy`:
+`vscode-mypy` への貢献:
 
-* [@cnaples79 (Chase Naples)](https://github.com/cnaples79): Fix: parse mypy diagnostics from stderr in non_interactive mode [PR #375](https://github.com/microsoft/vscode-mypy/pull/375)
+* [@cnaples79 (Chase Naples)](https://github.com/cnaples79): 修正: non_interactive モードで stderr から mypy 診断を解析する [PR #375](https://github.com/microsoft/vscode-mypy/pull/375)
 
-Contributions to `vscode-python-environments`:
+`vscode-python-environments` への貢献:
 
-* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): fix conda env refresh not waiting for promises [PR #751](https://github.com/microsoft/vscode-python-environments/pull/751)
-* [@renan-r-santos (Renan Santos)](https://github.com/renan-r-santos): Display activate button when a terminal is moved to the editor window [PR #764](https://github.com/microsoft/vscode-python-environments/pull/764)
+* [@almarouk (Abdelrahman AL MAROUK)](https://github.com/almarouk): conda env のリフレッシュが promise を待たない問題を修正 [PR #751](https://github.com/microsoft/vscode-python-environments/pull/751)
+* [@renan-r-santos (Renan Santos)](https://github.com/renan-r-santos): ターミナルがエディターウィンドウに移動されたときにアクティベートボタンを表示 [PR #764](https://github.com/microsoft/vscode-python-environments/pull/764)
 
-Contributions to `vscode-vsce`:
+`vscode-vsce` への貢献:
 
-* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): fix: generate language model tag for `languageModelChatProvider` contributions [PR #1199](https://github.com/microsoft/vscode-vsce/pull/1199)
+* [@joyceerhl (Joyce Er)](https://github.com/joyceerhl): 修正: `languageModelChatProvider` コントリビューションの言語モデルタグを生成 [PR #1199](https://github.com/microsoft/vscode-vsce/pull/1199)
 
-Contributions to `debug-adapter-protocol`:
+`debug-adapter-protocol` への貢献:
 
-* [@dmjio (David M. Johnson)](https://github.com/dmjio): Update debug adapters list in adapters.md [PR #562](https://github.com/microsoft/debug-adapter-protocol/pull/562)
+* [@dmjio (David M. Johnson)](https://github.com/dmjio): adapters.md のデバッグアダプターリストを更新 [PR #562](https://github.com/microsoft/debug-adapter-protocol/pull/562)
 
 
-We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+新機能が準備でき次第、試してくださる皆様に心から感謝いたします。頻繁にこちらをチェックして、新機能をご確認ください。
 
->If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+>以前の VS Code バージョンのリリースノートを読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
 
-<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" title="トップへスクロール" aria-label="トップへスクロール" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_105.md
+++ b/docs/release-notes/v1_105.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_105/release-highlights.png
 Date: 2025-10-09
 DownloadVersion: 1.105.0
 ---
-# September 2025 (version 1.105)
+# September 2025 (version 1.105) {#september-2025-version-1105}
 
 _Release date: October 9, 2025_
 
@@ -66,9 +66,9 @@ Welcome to the September 2025 release of Visual Studio Code. There are many upda
   <div class="notes-main">
 Navigation End -->
 
-## Chat
+## Chat {#chat}
 
-### Fully qualified tool names
+### Fully qualified tool names {#fully-qualified-tool-names}
 
 Prompt files and custom chat modes enable you to specify which tools can be used. To avoid naming conflicts between built-in tools and tools provided by MCP servers or extensions, we now support fully qualified tool names for prompt files and chat modes. This also helps with discovering missing extensions or MCP servers.
 
@@ -78,7 +78,7 @@ You can still use the previous notation, however a code action helps you migrate
 
 ![Screenshot of a prompt file showing a Code Action to update an unqualified tool name.](https://code.visualstudio.com/assets/updates/1_105/qualified_tool_names.png)
 
-### Improved edit tools for custom models
+### Improved edit tools for custom models {#improved-edit-tools-for-custom-models}
 
 **Setting**: `setting(github.copilot.chat.customOAIModels)`
 
@@ -86,7 +86,7 @@ We improved the set of edit tools for [Bring Your Own Key (BYOK)](https://code.v
 
 If you're [using OpenAI-compatible models](https://code.visualstudio.com/docs/copilot/customization/language-models#_use-an-openaicompatible-model), you can also explicitly configure the list of edit tools with the `setting(github.copilot.chat.customOAIModels)` setting.
 
-### Support for nested AGENTS.md files (Experimental)
+### Support for nested AGENTS.md files (Experimental) {#support-for-nested-agentsmd-files-experimental}
 
 **Setting**: `setting(chat.useNestedAgentsMdFiles)`
 
@@ -96,9 +96,9 @@ We now also added support for nested `AGENTS.md` files in subfolders of your wor
 
 Learn more about [customizing chat in VS Code](https://code.visualstudio.com/docs/copilot/customization/overview) to your practices and team workflows.
 
-### Chat user experience improvements
+### Chat user experience improvements {#chat-user-experience-improvements}
 
-#### OS notifications for chat responses
+#### OS notifications for chat responses {#os-notifications-for-chat-responses}
 
 **Setting**: `setting(chat.notifyWindowOnResponseReceived)`
 
@@ -108,7 +108,7 @@ In VS Code 1.103, we introduced OS notifications for chat sessions that required
 
 You can control the notification behavior with the `setting(chat.notifyWindowOnResponseReceived)` setting.
 
-#### Chain of thought (Experimental)
+#### Chain of thought (Experimental) {#chain-of-thought-experimental}
 
 **Setting**: `setting(chat.agent.thinkingStyle)`
 
@@ -118,7 +118,7 @@ Chain of thought shows the model’s reasoning as it responds, which can be grea
 
 You can configure how to display or hide chain of thought with the `setting(chat.agent.thinkingStyle)` setting. Thinking tokens will soon be available in more models as well!
 
-#### Show recent chat sessions (Experimental)
+#### Show recent chat sessions (Experimental) {#show-recent-chat-sessions-experimental}
 
 **Setting**: `setting(chat.emptyState.history.enabled)`
 
@@ -128,22 +128,22 @@ Last milestone, we introduced [prompt file suggestions](https://code.visualstudi
 
 By default, this functionality is off, but you can enable it with the `setting(chat.emptyState.history.enabled)` setting.
 
-#### Keep or undo changes during an agent loop
+#### Keep or undo changes during an agent loop {#keep-or-undo-changes-during-an-agent-loop}
 
 Previously, when an agent was still processing your chat request, you could not keep or undo file edits until the agent finished. Now, you can keep or undo changes to files while an edit loop is happening. This enables you to have more control, especially for long-running tasks.
 
-#### Keyboard shortcuts for navigating user chat messages
+#### Keyboard shortcuts for navigating user chat messages {#keyboard-shortcuts-for-navigating-user-chat-messages}
 
 To quickly navigate through your previous chat prompts in the chat session, we added keyboard shortcuts for navigating up and down through your chat messages:
 
 * Navigate previous:  `kb(workbench.action.chat.previousUserPrompt)`
 * Navigate next:  `kb(workbench.action.chat.nextUserPrompt)`
 
-### Agent sessions
+### Agent sessions {#agent-sessions}
 
 This milestone, we made several improvements to the Chat Sessions view and the experience of delegating tasks to remote coding agents:
 
-#### Chat Sessions view enhancements
+#### Chat Sessions view enhancements {#chat-sessions-view-enhancements}
 
 **Setting**: `setting(chat.agentSessionsViewLocation)`
 
@@ -157,7 +157,7 @@ In this release, we made several UI refinements and performance improvements to 
 
     ![Screenshot of the Chat Sessions view with a new session open via the + button.](https://code.visualstudio.com/assets/updates/1_105/chat-sessions.png)
 
-### Delegating to remote coding agents
+### Delegating to remote coding agents {#delegating-to-remote-coding-agents}
 
 A typical scenario for working with remote coding agents is to first discuss and plan a task in a local chat session, where you have access to the full context of your codebase, and then delegate the implementation work to a remote coding agent. The remote agent can then work on the task in the background and create a pull request with the solution.
 
@@ -167,7 +167,7 @@ If you're working in a repository that has [Copilot coding agent enabled](https:
 
 When you use the delegate action, all context from your chat conversation, including file references, is forwarded to the coding agent. If your conversation exceeds the coding agent's context window, VS Code automatically summarizes and condenses the information to fit the window.
 
-### Chat terminal profiles
+### Chat terminal profiles {#chat-terminal-profiles}
 
 We added platform-specific settings `setting(chat.tools.terminal.terminalProfile.windows)`, `setting(chat.tools.terminal.terminalProfile.osx)` and `setting(chat.tools.terminal.terminalProfile.linux)` for configuring the shell that is launched by the run-in-terminal tool.
 
@@ -183,19 +183,19 @@ Having a chat-specific shell is useful to simplify or remove interactive element
 }
 ```
 
-### Terminal commands
+### Terminal commands {#terminal-commands}
 
-#### Auto-reply to terminal prompts (Experimental)
+#### Auto-reply to terminal prompts (Experimental) {#auto-reply-to-terminal-prompts-experimental}
 
 **Setting**: `setting(chat.tools.terminal.autoReplyToPrompts)`
 
 We introduced an opt-in setting, `setting(chat.tools.terminal.autoReplyToPrompts)`, which enables the agent to respond to prompts for input in the terminal automatically, like `Confirm? y/n`.
 
-#### Terminal free-form input request detection
+#### Terminal free-form input request detection {#terminal-free-form-input-request-detection}
 
 When the terminal requires free-form input, we now display a confirmation prompt. This lets you stay focused on your current work and only shift attention when input is needed.
 
-### Sign in with Apple accounts
+### Sign in with Apple accounts {#sign-in-with-apple-accounts}
 
 In addition to signing in with a GitHub or Google account, you can now also sign in or set up a GitHub Copilot account by using an Apple account. This functionality will be rolling out to VS Code users.
 
@@ -203,7 +203,7 @@ In addition to signing in with a GitHub or Google account, you can now also sign
 
 You can find more information about this in the announcement [GitHub blog post](https://github.blog/changelog/2025-10-07-github-now-supports-social-login-with-apple/).
 
-### Model availability
+### Model availability {#model-availability}
 
 This milestone, we added support for the following models in chat. The available models depend on your Copilot plan and configuration.
 
@@ -213,9 +213,9 @@ This milestone, we added support for the following models in chat. The available
 
 You can choose between different models with the model picker in chat. Learn more about [language models in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
 
-## MCP
+## MCP {#mcp}
 
-### MCP marketplace (Preview)
+### MCP marketplace (Preview) {#mcp-marketplace-preview}
 
 **Setting**: `setting(chat.mcp.gallery.enabled)`
 
@@ -235,7 +235,7 @@ To browse the MCP servers from the Extensions view:
 
 ![Screenshot showing the GitHub MCP server details from the MCP server marketplace inside VS Code.](https://code.visualstudio.com/assets/updates/1_105/mcp-server-editor.png)
 
-### Autostart MCP servers
+### Autostart MCP servers {#autostart-mcp-servers}
 
 **Setting**: `setting(chat.mcp.autostart)`
 
@@ -247,11 +247,11 @@ With MCP autostart on by default, we no longer eagerly activate extensions and i
 
 For extension developers, we also added support for the `when` clause on the `mcpServerDefinitionProviders` contribution point, so you can avoid activation when it's not relevant.
 
-### Improved representation of MCP resources returned from tools
+### Improved representation of MCP resources returned from tools {#improved-representation-of-mcp-resources-returned-from-tools}
 
 Previously, our implementation of tool results that contain resources left it up to the model to retrieve those resources, without clear instructions on how to do so. In this version of VS Code, by default, we include a preview of the resource content and add instructions to retrieve the complete contents. This should lead to better model performance when using such tools.
 
-### MCP specification updates
+### MCP specification updates {#mcp-specification-updates}
 
 This milestone, we adopted the following updates to the MCP specification:
 
@@ -263,13 +263,13 @@ This milestone, we adopted the following updates to the MCP specification:
 
 * [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1035), which lets MCP servers provide `default` values when using elicitation.
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Shell integration for pwsh on Windows support for screen readers
+### Shell integration for pwsh on Windows support for screen readers {#shell-integration-for-pwsh-on-windows-support-for-screen-readers}
 
 PSReadLine has historically been disabled when a screen reader is detected to avoid overwhelming users with excessive auditory feedback. Since our terminal's shell integration relies on PSReadLine support, we now activate a streamlined version of PSReadLine in screen reader mode. This ensures shell integration and its features work for screen reader users.
 
-### Chat improvements
+### Chat improvements {#chat-improvements}
 
 **Setting**: `setting(accessibility.verboseChatProgressUpdates)`
 
@@ -277,27 +277,27 @@ A new setting, `setting(accessibility.verboseChatProgressUpdates)`, enables more
 
 From the chat input, users can focus the last focused chat response item `kb(workbench.chat.action.focusLastFocused)`.
 
-### Accessible view persistence
+### Accessible view persistence {#accessible-view-persistence}
 
 When switching between VS Code and other windows, we now maintain the user's position in the Accessible view for a seamless workflow.
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Override default shortcuts for Quick Input
+### Override default shortcuts for Quick Input {#override-default-shortcuts-for-quick-input}
 
 The Quick Input controls, like the ones used in the Command Palette (Quick Pick, Input Box), used to hard-code keyboard shortcuts for navigation, such as moving up or down the list, accepting (`kbstyle(Enter)`), and a few other interactions.
 
 These actions are now moved to commands, which enables you to override their keyboard shortcuts. For example, if you want `kbstyle(Tab)` to be used to accept something in the Quick Pick, this is now possible. To see all keyboard shortcuts that you can override, open the Keyboard Shortcuts editor `(kb(workbench.action.openGlobalKeybindings))` and search for `quickInput.`
 
-### Disallow whitespace-only next edit suggestions
+### Disallow whitespace-only next edit suggestions {#disallow-whitespace-only-next-edit-suggestions}
 
 **Setting**: `setting(github.copilot.nextEditSuggestions.allowWhitespaceOnlyChanges)`
 
 It is now possible to disallow next edit suggestions (NES) to propose whitespace-only changes such as code formatting.
 
-## Source Control
+## Source Control {#source-control}
 
-### Resolve merge conflicts with AI
+### Resolve merge conflicts with AI {#resolve-merge-conflicts-with-ai}
 
 When opening a file with git merge conflict markers, you are now able to resolve merge conflicts with AI. We added a new action in the lower right-hand corner of the editor. Selecting this new action opens the Chat view and starts an agentic flow with the merge base and changes from each branch as context.
 
@@ -305,7 +305,7 @@ When opening a file with git merge conflict markers, you are now able to resolve
 
 You can review the proposed merge conflict resolution in the editor and follow up with additional context if needed. You can customize the merge conflict resolution by using an `AGENTS.md` file.
 
-### Add file commit to chat context
+### Add file commit to chat context {#add-file-commit-to-chat-context}
 
 A couple of milestones ago, we added the capability to view the files in each history item shown in the Source Control Graph view. You can now add a file from a history item as context to a chat request. This can be useful when you want to provide the contents of a specific version of a file as context to your chat prompt.
 
@@ -313,23 +313,23 @@ To add a file from a past commit to chat, select a commit to view the list of fi
 
 ![Screenshot of the Source Control Graph view showing the context menu for a file in a history item with the Add to Chat option highlighted.](https://code.visualstudio.com/assets/updates/1_105/add-history-item-to-chat.png)
 
-## Testing
+## Testing {#testing}
 
-### Run tests with code coverage
+### Run tests with code coverage {#run-tests-with-code-coverage}
 
 If you have a testing extension installed for your code, the `runTests` tool in chat enables the agent to run tests in your codebase by using the [VS Code testing integration](https://code.visualstudio.com/docs/debugtest/testing) rather than running them from the command line.
 
 In this release, the `runTests` tool now also reports test code coverage to the agent. This enables the agent to generate and verify tests that cover the entirety of your code.
 
-### Swap test result column
+### Swap test result column {#swap-test-result-column}
 
 You can change the side on which the result tree is displayed in the Test Results view by using the new swap ↔️ button in the view's title menu.
 
 ![Screenshot of the Test Results view with the swap button highlighted.](https://code.visualstudio.com/assets/updates/1_105/swap-test-result-column.png)
 
-## Tasks
+## Tasks {#tasks}
 
-### OS notification for long-running task completion
+### OS notification for long-running task completion {#os-notification-for-long-running-task-completion}
 
 **Setting**: `setting(task.notifyWindowOnTaskCompletion)`
 
@@ -337,7 +337,7 @@ When a user-initiated, long-running task completes while the VS Code window is n
 
 ![Screenshot of an OS notification that shows a task completion message saying Task "build" completed in 1 minute 21 seconds.](https://code.visualstudio.com/assets/updates/1_105/task-notification.png)
 
-### Task terminal title persistence
+### Task terminal title persistence {#task-terminal-title-persistence}
 
 **Setting**: `setting(terminal.integrated.tabs.title)`
 
@@ -345,18 +345,18 @@ You can configure the title of terminal tabs with the `setting(terminal.integrat
 
 For tasks, this means that the terminal title might change when the task starts a different process, which can be confusing. To address this, we now persist the task's name as the terminal title when a task is started.
 
-## Terminal
+## Terminal {#terminal}
 
-### Start dictation exposed
+### Start dictation exposed {#start-dictation-exposed}
 
 We added the **Start dictation** action to the terminal overflow menu. This action enables you to use voice dictation to input text into the terminal.
 A corresponding **Stop dictation** action appears when relevant.
 
 ![Screenshot of the terminal overflow menu with a Start Dictation option.](https://code.visualstudio.com/assets/updates/1_105/start-dictation-terminal.png)
 
-## Authentication
+## Authentication {#authentication}
 
-### macOS native broker support for Microsoft Authentication
+### macOS native broker support for Microsoft Authentication {#macos-native-broker-support-for-microsoft-authentication}
 
 **Setting**: `setting(microsoft-authentication.implementation)`
 
@@ -373,23 +373,23 @@ This enables nice single sign-on flows and is the recommended way of acquiring a
 
 > NOTE: If you have trouble authenticating via the broker, you can change the `setting(microsoft-authentication.implementation)` to `msal-no-broker`, which will use your browser to authenticate instead.
 
-### PKCE support for GitHub Authentication
+### PKCE support for GitHub Authentication {#pkce-support-for-github-authentication}
 
 [GitHub recently enabled](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/) PKCE ([Proof Key for Code Exchange](https://www.rfc-editor.org/rfc/rfc7636)) support in their authentication flows. We have adopted this in the flow that VS Code uses to authenticate to GitHub.
 
-## Languages
+## Languages {#languages}
 
-### Python
+### Python {#python}
 
-#### Copy test ID action
+#### Copy test ID action {#copy-test-id-action}
 
 The run gutter icon context menu now includes a **Copy Test Id** command to copy the fully qualified pytest or unittest test identifier.
 
 <video src="https://code.visualstudio.com/assets/updates/1_105/py_copy_test_id.mp4" title="Video showing the Copy Test Id command in the run gutter context menu." autoplay loop controls muted></video>
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### GitHub Pull Requests
+### GitHub Pull Requests {#github-pull-requests}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
 
@@ -399,9 +399,9 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 Review the [changelog for the 0.120.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01200) release of the extension to learn about everything in the release.
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### Microsoft Authentication now supports WWW-Authenticate claims challenges
+### Microsoft Authentication now supports WWW-Authenticate claims challenges {#microsoft-authentication-now-supports-wwwauthenticate-claims-challenges}
 
 [Azure is now enforcing](https://learn.microsoft.com/entra/identity/authentication/concept-mandatory-multifactor-authentication) that all create/delete operations to Azure resources must be done using authenticated sessions that used MFA to sign in. While some organizations require MFA for any authentication reason, some organizations do not enforce this, and those are affected by this MFA enforcement.
 
@@ -432,7 +432,7 @@ We have worked with the Azure Tools team, who owns the Azure Resources extension
 
 > NOTE: Looking to support `WWW-Authenticate` challenges in _your_ `AuthenticationProvider`? Provide your thoughts on the proposed API in issue [#267992](https://github.com/microsoft/vscode/issues/267992).
 
-### Prompt and instructions file contributions
+### Prompt and instructions file contributions {#prompt-and-instructions-file-contributions}
 
 Extensions can now contribute prompt and instructions files.
 
@@ -457,7 +457,7 @@ Extensions can now contribute prompt and instructions files.
 
 Chat mode contributions (`chatModes`) are currently behind a proposed API flag.
 
-### List keys in SecretStorage
+### List keys in SecretStorage {#list-keys-in-secretstorage}
 
 This iteration, we have finalized the API to list all keys that your extension has stored in Secret Storage. This can be found in the `context.secrets` object:
 
@@ -471,9 +471,9 @@ export function activate(context: ExtensionContext) {
 
 One example where this can be used is on `deactivate`, where you might want to delete all secret storage data.
 
-## Engineering
+## Engineering {#engineering}
 
-### Playwright VS Code MCP server
+### Playwright VS Code MCP server {#playwright-vs-code-mcp-server}
 
 We further explored using an MCP server that can control a local build of VS Code to help in the development loop for VS Code. While we had mixed results on model comprehension for parsing screenshots, orchestration for subagents using the `#executePrompt` tool (which can be enabled with `setting(github.copilot.chat.executePrompt.enabled)`) was effective at not polluting context.
 
@@ -484,16 +484,16 @@ To try this MCP Server, you can find it [in the test/mcp folder](https://github.
 1. Follow the [Contribution Guidelines](https://github.com/microsoft/vscode/wiki/How-to-Contribute) for getting a local version of Code OSS running.
 2. Use [our trivial (for now) prompt file](https://github.com/microsoft/vscode/blob/cd7de11f65cd5ff6a491f04fc013e363780bde31/.github/prompts/playwright.prompt.md) in agent mode to ask a question: `/playwright <your question here>`.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [vscode#265842](https://github.com/microsoft/vscode/issues/265842) - Chat: fix a file corruption issue affecting Sonnet, Gemini, and Grok models
 * [vscode#221255](https://github.com/microsoft/vscode/issues/221255) - Fix terminal links opening regardless of confirmation of "Opening URIs can be insecure" warning.
 * [vscode#229374](https://github.com/microsoft/vscode/issues/229374) - Fix to open terminal OSC 8 hyperlink to a folder in VS Code's explorer instead of native file explorer.
 * [vscode#268443](https://github.com/microsoft/vscode/issues/268443) - Settings links in Release Notes do nothing.
 
-## Thank you
+## Thank you {#thank-you}
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -502,7 +502,7 @@ Contributions to our issue tracking:
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 
-### Pull Requests
+### Pull Requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_105.md
+++ b/docs/release-notes/v1_105.md
@@ -76,7 +76,7 @@ Tool names are now qualified by the MCP server, extension, or tool set they are 
 
 You can still use the previous notation, however a code action helps you migrate to the new names.
 
-![Screenshot of a prompt file showing a Code Action to update an unqualified tool name.](images/1_105/qualified_tool_names.png)
+![Screenshot of a prompt file showing a Code Action to update an unqualified tool name.](https://code.visualstudio.com/assets/updates/1_105/qualified_tool_names.png)
 
 ### Improved edit tools for custom models
 
@@ -104,7 +104,7 @@ Learn more about [customizing chat in VS Code](https://code.visualstudio.com/doc
 
 In VS Code 1.103, we introduced OS notifications for chat sessions that required a user confirmation when the VS Code window was not focused. In this release, we are expanding this functionality to show an OS badge and notification toast when a chat response is received. The notification includes a preview of the response, and selecting it brings focus to the chat input.
 
-![Screenshot showing an OS notification while the VS Code window is unfocused.](images/1_105/chat-notification.png)
+![Screenshot showing an OS notification while the VS Code window is unfocused.](https://code.visualstudio.com/assets/updates/1_105/chat-notification.png)
 
 You can control the notification behavior with the `setting(chat.notifyWindowOnResponseReceived)` setting.
 
@@ -114,7 +114,7 @@ You can control the notification behavior with the `setting(chat.notifyWindowOnR
 
 Chain of thought shows the model’s reasoning as it responds, which can be great for debugging or understanding suggestions the model provides. With the introduction of GPT-5-Codex, thinking tokens are now shown in chat as expandable sections in the response.
 
-![Screenshot of a chat response showing thinking tokens as expandable sections in the response.](images/1_105/chat-thinking-tokens.png)
+![Screenshot of a chat response showing thinking tokens as expandable sections in the response.](https://code.visualstudio.com/assets/updates/1_105/chat-thinking-tokens.png)
 
 You can configure how to display or hide chain of thought with the `setting(chat.agent.thinkingStyle)` setting. Thinking tokens will soon be available in more models as well!
 
@@ -124,7 +124,7 @@ You can configure how to display or hide chain of thought with the `setting(chat
 
 Last milestone, we introduced [prompt file suggestions](https://code.visualstudio.com/updates/v1_104#_configure-prompt-file-suggestions-experimental) to help you get started when creating a new chat session (`kb(workbench.action.chat.newChat)`). In this release, we are building on that by showing your recent local chat conversations. This helps you quickly pick up where you left off or revisit past conversations.
 
-![Screenshot of the Chat view showing recent local chat conversations when there are no active chat sessions.](images/1_105/chat-history-on-empty.png)
+![Screenshot of the Chat view showing recent local chat conversations when there are no active chat sessions.](https://code.visualstudio.com/assets/updates/1_105/chat-history-on-empty.png)
 
 By default, this functionality is off, but you can enable it with the `setting(chat.emptyState.history.enabled)` setting.
 
@@ -155,7 +155,7 @@ In this release, we made several UI refinements and performance improvements to 
 
 * Quickly initiate a new session by using the "+" button in the view header.
 
-    ![Screenshot of the Chat Sessions view with a new session open via the + button.](images/1_105/chat-sessions.png)
+    ![Screenshot of the Chat Sessions view with a new session open via the + button.](https://code.visualstudio.com/assets/updates/1_105/chat-sessions.png)
 
 ### Delegating to remote coding agents
 
@@ -163,7 +163,7 @@ A typical scenario for working with remote coding agents is to first discuss and
 
 If you're working in a repository that has [Copilot coding agent enabled](https://aka.ms/coding-agent-docs), the **Delegate to coding agent** button in the Chat view now appears by default.
 
-![Screenshot of the Chat view with the Delegate to coding agent button highlighted.](images/1_105/delegate-button.png)
+![Screenshot of the Chat view with the Delegate to coding agent button highlighted.](https://code.visualstudio.com/assets/updates/1_105/delegate-button.png)
 
 When you use the delegate action, all context from your chat conversation, including file references, is forwarded to the coding agent. If your conversation exceeds the coding agent's context window, VS Code automatically summarizes and condenses the information to fit the window.
 
@@ -199,7 +199,7 @@ When the terminal requires free-form input, we now display a confirmation prompt
 
 In addition to signing in with a GitHub or Google account, you can now also sign in or set up a GitHub Copilot account by using an Apple account. This functionality will be rolling out to VS Code users.
 
-![Screenshot showing the sign in dialog showing the option to use an Apple account.](images/1_105/apple-sign-in.png)
+![Screenshot showing the sign in dialog showing the option to use an Apple account.](https://code.visualstudio.com/assets/updates/1_105/apple-sign-in.png)
 
 You can find more information about this in the announcement [GitHub blog post](https://github.blog/changelog/2025-10-07-github-now-supports-social-login-with-apple/).
 
@@ -225,7 +225,7 @@ VS Code now includes a built-in MCP marketplace that enables users to browse and
 
 The MCP marketplace is disabled by default. When no MCP servers are installed, you see a welcome view in the Extensions view that provides easy access to enable the marketplace. You can also enable the MCP marketplace manually by using the `setting(chat.mcp.gallery.enabled)` setting.
 
-![Screenshot showing the MCP Servers welcome view with text describing how to browse and install Model Context Protocol servers, and an "Enable MCP Servers Marketplace" button.](images/1_105/mcp-servers-welcome.png)
+![Screenshot showing the MCP Servers welcome view with text describing how to browse and install Model Context Protocol servers, and an "Enable MCP Servers Marketplace" button.](https://code.visualstudio.com/assets/updates/1_105/mcp-servers-welcome.png)
 
 To browse the MCP servers from the Extensions view:
 
@@ -233,7 +233,7 @@ To browse the MCP servers from the Extensions view:
 * Select **MCP Servers** from the filter dropdown in the Extensions view
 * Search for specific MCP servers by name
 
-![Screenshot showing the GitHub MCP server details from the MCP server marketplace inside VS Code.](images/1_105/mcp-server-editor.png)
+![Screenshot showing the GitHub MCP server details from the MCP server marketplace inside VS Code.](https://code.visualstudio.com/assets/updates/1_105/mcp-server-editor.png)
 
 ### Autostart MCP servers
 
@@ -241,7 +241,7 @@ To browse the MCP servers from the Extensions view:
 
 In this release, new or outdated MCP servers are now started automatically when you send a chat message. VS Code also avoids triggering interactions such as dialogs when autostarting a server, and instead adds an indicator in chat to let you know that a server needs attention.
 
-![Screenshot of the Chat view, showing a notification message that the GitHub MCP requires restarting.](./images/1_105/mcp_autostart_prompt.png)
+![Screenshot of the Chat view, showing a notification message that the GitHub MCP requires restarting.](https://code.visualstudio.com/assets/updates/1_105/mcp_autostart_prompt.png)
 
 With MCP autostart on by default, we no longer eagerly activate extensions and instead only activate MCP-providing extensions when the first chat message is sent.
 
@@ -257,7 +257,7 @@ This milestone, we adopted the following updates to the MCP specification:
 
 * [SEP-973](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/955), which lets MCP servers specify `icons` to associate with their data. This can be used to give a custom icon to servers, resources, and tools.
 
-    ![Screenshot of the tools picker, showing one of the MCP servers in the list with a custom icon.](./images/1_105/mcp_icons.png)
+    ![Screenshot of the tools picker, showing one of the MCP servers in the list with a custom icon.](https://code.visualstudio.com/assets/updates/1_105/mcp_icons.png)
 
     HTTP MCP servers must provide icons from the same authority that the MCP server itself is listening on, while stdio servers are allowed to reference `file:///` URIs on disk.
 
@@ -301,7 +301,7 @@ It is now possible to disallow next edit suggestions (NES) to propose whitespace
 
 When opening a file with git merge conflict markers, you are now able to resolve merge conflicts with AI. We added a new action in the lower right-hand corner of the editor. Selecting this new action opens the Chat view and starts an agentic flow with the merge base and changes from each branch as context.
 
-![Screenshot of the proposed merge conflict resolution in the editor.](images/1_105/merge-conflict-resolution.png)
+![Screenshot of the proposed merge conflict resolution in the editor.](https://code.visualstudio.com/assets/updates/1_105/merge-conflict-resolution.png)
 
 You can review the proposed merge conflict resolution in the editor and follow up with additional context if needed. You can customize the merge conflict resolution by using an `AGENTS.md` file.
 
@@ -311,7 +311,7 @@ A couple of milestones ago, we added the capability to view the files in each hi
 
 To add a file from a past commit to chat, select a commit to view the list of files, right-click on a particular file, and then select **Add to Chat** from the context menu.
 
-![Screenshot of the Source Control Graph view showing the context menu for a file in a history item with the Add to Chat option highlighted.](images/1_105/add-history-item-to-chat.png)
+![Screenshot of the Source Control Graph view showing the context menu for a file in a history item with the Add to Chat option highlighted.](https://code.visualstudio.com/assets/updates/1_105/add-history-item-to-chat.png)
 
 ## Testing
 
@@ -325,7 +325,7 @@ In this release, the `runTests` tool now also reports test code coverage to the 
 
 You can change the side on which the result tree is displayed in the Test Results view by using the new swap ↔️ button in the view's title menu.
 
-![Screenshot of the Test Results view with the swap button highlighted.](images/1_105/swap-test-result-column.png)
+![Screenshot of the Test Results view with the swap button highlighted.](https://code.visualstudio.com/assets/updates/1_105/swap-test-result-column.png)
 
 ## Tasks
 
@@ -335,7 +335,7 @@ You can change the side on which the result tree is displayed in the Test Result
 
 When a user-initiated, long-running task completes while the VS Code window is not focused, an OS badge and notification toast are shown. Selecting the notification focuses the window where the task completed. You can configure this behavior with the `setting(task.notifyWindowOnTaskCompletion)` setting.
 
-![Screenshot of an OS notification that shows a task completion message saying Task "build" completed in 1 minute 21 seconds.](images/1_105/task-notification.png)
+![Screenshot of an OS notification that shows a task completion message saying Task "build" completed in 1 minute 21 seconds.](https://code.visualstudio.com/assets/updates/1_105/task-notification.png)
 
 ### Task terminal title persistence
 
@@ -352,7 +352,7 @@ For tasks, this means that the terminal title might change when the task starts 
 We added the **Start dictation** action to the terminal overflow menu. This action enables you to use voice dictation to input text into the terminal.
 A corresponding **Stop dictation** action appears when relevant.
 
-![Screenshot of the terminal overflow menu with a Start Dictation option.](images/1_105/start-dictation-terminal.png)
+![Screenshot of the terminal overflow menu with a Start Dictation option.](https://code.visualstudio.com/assets/updates/1_105/start-dictation-terminal.png)
 
 ## Authentication
 
@@ -362,7 +362,7 @@ A corresponding **Stop dictation** action appears when relevant.
 
 This milestone, we adopted the latest MSAL libraries and with that you are now able to sign in through a native experience on macOS (in addition to Windows):
 
-![Screenshot of a native broker dialog window asking to sign into VS Code.](images/1_105/macOS-auth-broker.png)
+![Screenshot of a native broker dialog window asking to sign into VS Code.](https://code.visualstudio.com/assets/updates/1_105/macOS-auth-broker.png)
 
 Native broker authentication is only available for:
 
@@ -385,7 +385,7 @@ This enables nice single sign-on flows and is the recommended way of acquiring a
 
 The run gutter icon context menu now includes a **Copy Test Id** command to copy the fully qualified pytest or unittest test identifier.
 
-<video src="images/1_105/py_copy_test_id.mp4" title="Video showing the Copy Test Id command in the run gutter context menu." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_105/py_copy_test_id.mp4" title="Video showing the Copy Test Id command in the run gutter context menu." autoplay loop controls muted></video>
 
 ## Contributions to extensions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_105.md
     - release-notes/v1_104.md
     - release-notes/v1_103.md
     - release-notes/v1_102.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/962bacc24114dabffde695bdbae3a6c77c40b4ca

For future reference ...

1. Checkout original file (CLI command)
   ```
   wget -O docs/release-notes/v1_105.md https://github.com/microsoft/vscode-docs/raw/962bacc24114dabffde695bdbae3a6c77c40b4ca/release-notes/v1_105.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Agent mode - GPT-5 mini)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edit mode - Gemini 2.5 Pro)
   ```
   Translate the Markdown into Japanese. Insert a half-width space between full-width and half-width characters.
   ```