### PR TITLE
Translate October 2025 (version 1.106)

### DIFF
--- a/docs/release-notes/v1_106.md
+++ b/docs/release-notes/v1_106.md
@@ -1,0 +1,1039 @@
+---
+Order: 115
+TOCTitle: October 2025
+PageTitle: Visual Studio Code October 2025
+MetaDescription: Learn what is new in the Visual Studio Code October 2025 Release (1.106).
+MetaSocialImage: 1_106/release-highlights.png
+Date: 2025-11-12
+DownloadVersion: 1.106.0
+---
+# October 2025 (version 1.106)
+
+_Release date: November 12, 2025_
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+Welcome to the October 2025 release of Visual Studio Code.
+
+![Graphic showing the key highlights of the October 2025 release: Agent HQ, Security and trust, and great editor experience.](images/1_106/release-highlights.png)
+
+This releases brings significant updates across three key areas:
+
+* **Agent HQ** is your single view to kick off, monitor, and review agent sessions, whether they're local or remote, from Copilot or OpenAI Codex
+* **Security and trust** help you stay in control and confidently delegate more tasks to AI
+* **A great editor experience** to make your day-to-day coding smoother and more enjoyable
+
+Happy Coding!
+
+<!--
+There are many updates in this version that we hope you'll like, some of the key highlights include:
+
+<table class="highlights-table">
+  <tr>
+    <th>AI</th>
+    <th>Productivity and UX</th>
+    <th>Enterprise</th>
+  </tr>
+  <tr>
+    <td>Plan complex coding tasks with the plan agent and monitor agent sessions across background agents <a href="#agents"><br>Show more</a></td>
+    <td>Select text from deleted code in the diff editor <a href="#code-editing"><br>Show more</a></td>
+    <td>Manage MCP server access with custom MCP registry <a href="#mcp-server-access-for-your-organization"><br>Show more</a></td>
+  </tr>
+  <tr>
+    <td>Inline suggestions are now open source <a href="#inline-suggestions-are-open-source"><br>Show more</a></td>
+    <td>Experience the more modern, refreshed product icons <a href="#editor-experience"><br>Show more</a></td>
+    <td>Manage Linux devices with JSON policies <a href="#linux-policy-support"><br>Show more</a></td>
+  </tr>
+</table>
+-->
+
+<br>
+
+>If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+
+> **Insiders: Want to try new features as soon as possible?**<br>
+> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> [Download Insiders](https://code.visualstudio.com/insiders)<br>
+
+<!-- TOC
+<div class="toc-nav-layout">
+  <nav id="toc-nav">
+    <div>In this update</div>
+    <ul>
+      <li><a href="#agents">Agents</a></li>
+      <li><a href="#code-editing">Code Editing</a></li>
+      <li><a href="#editor-experience">Editor Experience</a></li>
+      <li><a href="#chat">Chat</a></li>
+      <li><a href="#mcp">MCP</a></li>
+      <li><a href="#accessibility">Accessibility</a></li>
+      <li><a href="#notebooks">Notebooks</a></li>
+      <li><a href="#source-control">Source Control</a></li>
+      <li><a href="#debugging">Debugging</a></li>
+      <li><a href="#tasks">Tasks</a></li>
+      <li><a href="#terminal">Terminal</a></li>
+      <li><a href="#authentication">Authentication</a></li>
+      <li><a href="#languages">Languages</a></li>
+      <li><a href="#remote-development">Remote Development</a></li>
+      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
+      <li><a href="#extension-authoring">Extension Authoring</a></li>
+      <li><a href="#proposed-apis">Proposed APIs</a></li>
+      <li><a href="#engineering">Engineering</a></li>
+      <li><a href="#notable-fixes">Notable fixes</a></li>
+      <li><a href="#thank-you">Thank you</a></li>
+    </ul>
+  </nav>
+  <div class="notes-main">
+Navigation End -->
+
+## Agents
+
+### Agent Sessions view
+
+**Setting**: `setting(chat.agentSessionsViewLocation)`
+
+As you hand off tasks to various coding agents, it's important to have a clear overview of all your active sessions. The Agent Sessions view provides a centralized location for managing your active chat sessions. This includes both local sessions in VS Code and sessions created by background agents in other environments, such as [Copilot coding agent](https://code.visualstudio.com/docs/copilot/copilot-coding-agent), [GitHub Copilot CLI](https://github.com/features/copilot/cli/), or [OpenAI's Codex](https://marketplace.visualstudio.com/items?itemName=OpenAI.chatgpt). The Agent Sessions view is now enabled by default, and can be managed via the `setting(chat.agentSessionsViewLocation)` setting.
+
+By default, the Agent Sessions view lists all your active chat sessions organized by their source. The view is divided into sections for local chat sessions in VS Code and for background agent sessions:
+
+![Screenshot of the Agent Sessions view in the Primary Side Bar, showing a view for local chat sessions, and coding agents like Copilot coding agent, Copilot CLI and Codex.](images/1_106/agent-sessions-view.png)
+
+If you prefer to have one consolidated view of your sessions across all providers, you can enable the `single-view` option for the `setting(chat.agentSessionsViewLocation)` setting. This option also moves the Agent Sessions view next to the Chat view in the Secondary Side Bar, making it easier to switch between chat and managing your sessions.
+
+<video src="images/1_106/agent-sessions.mp4" title="Video showing new agent sessions view." autoplay loop controls muted></video>
+
+Note that not all functionality is available in the consolidated view yet. We are actively working on making this view the default in the near future.
+
+The Agent Sessions view now also supports search (`kb(list.find)`) to help you easily find your sessions in the list.
+
+<video src="images/1_106/sessionsPaneSearch.mp4" title="Video showing search in the Agent Sessions view to find sessions that match your query." autoplay loop controls muted></video>
+
+Learn more about the [Agent Sessions view](https://code.visualstudio.com/docs/copilot/chat/chat-sessions/#_agent-sessions-view) in the VS Code documentation.
+
+### Plan agent
+
+A new plan agent helps developers break down complex tasks step-by-step before any code is written. Select **Plan** from the agents dropdown in the Chat view to get started. When tackling a multi-step implementation, VS Code prompts you with clarifying questions and generates a detailed implementation plan that you approve first, ensuring all requirements and context are captured upfront.
+
+<video src="images/1_106/plan-mode.mp4" title="Video showing the plan agent in action." autoplay loop controls muted></video>
+
+We recommend spending time iterating on the plan before implementation. You can refine requirements, adjust scope, and address open questions multiple times to build a solid foundation. Once you approve the plan, Copilot implements it either locally in VS Code or via [cloud agents](https://code.visualstudio.com/docs/copilot/copilot-coding-agent), giving you greater control and visibility into the development process. This helps you catch gaps or missing decisions early, reducing rework and improving code quality.
+
+You can also create your own custom plan agent tailored to your team's specific workflow and tools. Use the **Configure Custom Agent** menu to copy the built-in plan agent as a starting point, then customize the planning style, tools, and prompts to match your development process. Learn more about [planning in VS Code chat](https://code.visualstudio.com/docs/copilot/chat/chat-planning) and [creating custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents).
+
+### Cloud agents
+
+In this release, we have made quite a few updates to cloud agent sessions in the editor.
+
+We migrated the Copilot coding agent integration from the GitHub Pull Request extension into the Copilot Chat extension to provide a more native cloud agent experience in VS Code. This integration paves the way for smoother transitions and interactions between VS Code and [GitHub Mission Control](https://github.com/copilot/agents), such as opening a cloud agent session directly from the Agent Sessions view in the browser and vice versa.
+
+<video src="images/1_106/deeplink.mp4" title="Video showing GitHub Mission Control integration with VS Code." autoplay loop controls muted></video>
+
+### CLI agents
+
+In this release, we have also shipped an initial integration with the [Copilot CLI](https://github.com/features/copilot/cli/). You can create new and resume existing CLI agent sessions in a chat editor or an integrated terminal.
+
+![Screenshot of the CLI dropdown menu showing options to create a new CLI agent session or resume an existing one.](images/1_106/cli-dropdown.png)
+
+In a CLI agent editor, you can send messages to the Copilot CLI just as you would in a terminal, switch models, and attach context.
+
+![Screenshot showing a CLI agent editor and an integrated terminal with Copilot CLI sessions.](images/1_106/cli-editor-and-terminal.png)
+
+### Agent delegation
+
+We continue to improve the experience for delegating to cloud agents.
+
+When you use the cloud button to delegate to an agent from the chat panel, you'll be provided a set of available agents to which you can delegate. You can also delegate to the Copilot coding agent from the CLI, via the `/delegate` command in a CLI editor or terminal instance.
+
+![Screenshot showing delegating from a CLI agent editor.](images/1_106/cli-delegate-editor.png)
+
+### CLI agent edit tracking
+
+Chat edit sessions now track edits made by background agents, such as the Copilot CLI. When you create sessions from the Agent Sessions view, you can see edits tracked through both inline edit pills and the working set view, making it easier to understand what changes agents are making to your workspace.
+
+### Chat modes renamed to custom agents
+
+Chat modes have been renamed to custom agents throughout VS Code to better align with terminology used in other environments.
+
+![Screenshot of the agent picker control.](images/1_106/agent-picker.png)
+
+When you create custom agents, the definition files are now located in `.github/agents` in your workspace. These files can use the `.agents.md` suffix and can also be used as Github Copilot Cloud Agents and CLI Agent.
+
+Use **Chat: New Custom Agent...** to create a new agent and **Chat: Configure Custom Agents...** to manage them.
+
+If you have existing custom chat modes (`.chatmode.md` files in `.github/chatmodes`), they continue to work and are automatically treated as custom agents. When you open a chat agent file in the editor, a info marker appears on the first line with a quick fix to migrate it to a custom agent file.
+
+### Custom agent metadata
+
+Custom agent `.agent.md` files now accept an additional `target` frontmatter property to describe how an agent should run across environments:
+
+* `target: vscode`: optimizes the agent for local chat and unlocks `name`, `description`, `argument-hint`, `model`, `tools`, and `handoffs` properties. Any tool installed in VS Code can be used.
+* `target: github-copilot`: prepares the agent for Copilot cloud agents or the GitHub CLI with support for `name`, `description`, `tools`, `mcp-servers`, and `target`. Tools can be `edit`, `search`, `shell`, `custom-agent`, and tools from MCP servers
+
+All agents can be run in all environments. Each environment ignores unknown attributes and tools.
+
+* `name`: lets you override the agent label without renaming the file.
+* `argument-hint`: surfaces guidance in the chat input so teammates know how to prompt the agent.
+* `handoffs`: wires guided transitions to other agents, letting you chain multi-step workflows.
+
+The agent file editor provides validation, code completions, hovers and code actions.
+
+![GIF of validation while editing custom agent files.](images/1_106/agent-file-editing.gif)
+
+Learn more about [custom agents and agent handoffs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
+
+## Code Editing
+
+### Deleted code in diff editor is now selectable
+
+Previously, when you deleted code and viewed the changes in the diff editor, you couldn't copy those deleted lines. In this release, you can now select and copy text from deleted lines in the diff editor when using the inline diff view.
+
+<video src="images/1_106/diff-editor-select-deleted-lines-text.mp4" title="Video showing selecting text in deleted lines in the diff editor." autoplay loop controls muted></video>
+
+### Inline suggestions are open source
+
+This release continues our journey to make VS Code an open source AI editor. Following our first milestone of open sourcing GitHub Copilot Chat, we've now open sourced inline suggestions by merging them into the vscode-copilot-chat repository.
+
+As part of this milestone, we're consolidating the GitHub Copilot extension and GitHub Copilot Chat extension into a single extension experience. The Chat extension now serves all inline suggestions, providing the same intelligent code suggestions you're used to while maintaining all chat and agent functionality. The change should be transparent, you'll continue getting the same code suggestions as you type. If you encounter any issues, you can temporarily revert using the `setting(chat.extensionUnification.enabled)` setting.
+
+The GitHub Copilot extension will be deprecated by early 2026. Learn more about this milestone and explore the open source code in our [blog post](https://code.visualstudio.com/blogs/2025/11/04/openSourceAIEditorSecondMilestone).
+
+### Snooze inline suggestions from gutter
+
+You can now snooze inline suggestions directly from the gutter icon. When you hover over the gutter icon, a control appears with a **Snooze** option. Select it and choose a duration to pause suggestions.
+
+![Screenshot showing the Snooze button in the gutter context menu for inline suggestions.](images/1_106/nes-snooze.png)
+
+### Go to line improvements
+
+This iteration, we've made several enhancements to the **Go to Line** command (`kb(workbench.action.gotoLine)`), improving navigation within files.
+
+The **Go to Line** command now supports navigating to a specific character position in a file by using the `::` syntax. This is useful when tools report errors at specific character offsets, such as "error at position 599".
+
+To navigate to a character offset, type `::` followed by the character number in the **Go to Line** input box. For example:
+
+* `::599` - Navigate to character 599 in the file
+* `::-100` - Navigate 100 characters from the end of the file
+
+Use the toggle in the input box to switch between 1-based (default) and 0-based offset calculations.
+
+<video src="images/1_106/go-to-line.mp4" title="Video showing editor navigation using Go To Line command." autoplay loop controls muted></video>
+
+In addition, the **Go to Line** command also handles out-of-range values more gracefully and makes it easier to navigate to the start or end of files and lines:
+
+* **Line numbers**: Typing a line number larger than the file's line count navigates to the last line.
+* **Column numbers**: Using negative column numbers navigates from the end of a line. For example, `:12:-1` takes you to the last character on line 12. Typing a column number larger than the length of the line takes you to the end of the line.
+
+## Editor Experience
+
+### Refreshed iconography
+
+In this release, the codicon icon set has had a facelift. The new icons have been refined with curves, new modifier designs, and more accurate metaphors to make them feel modern, friendly and more legible.
+
+![Screenshot of updated product icons showing a more modern appearance and increased legibility.](images/1_106/refreshed-iconography.png)
+
+### Linux policy support
+
+We've introduced support for managing VS Code policies on Linux systems using JSON files. This allows administrators to enforce specific settings and configurations across all users on a Linux machine.
+
+For more details, see [JSON Policies on Linux](https://code.visualstudio.com/docs/setup/enterprise#_json-policies-on-linux).
+
+### Navigate changes in multi file diff editor
+
+Just like you can navigate to next or previous changes in a diff editor for a single file, you can now do so across files in the multi-file diff editor. Use keybindings or the navigation up and down arrow keys to review your changes across files.
+
+<video src="images/1_106/multiFileDiffNav.mp4" title="Video showing navigating changes in multi-file diff editor." autoplay loop controls muted></video>
+
+### Copy diagnostic hover text
+
+A copy button now appears in diagnostic hovers (errors, warnings, info, and hints) to make copying error messages easier. When you hover over a diagnostic marker, move your mouse over the hover message to reveal a copy button in the top-right corner.
+
+![Screenshot of hovering over a diagnostic hover revealing a copy button in the top-right corner.](images/1_106/hover-copy-button.png)
+
+### Accent-insensitive command filtering
+
+The Command Palette now ignores character accents when searching for commands, making it easier to find what you need regardless of your keyboard layout or language preferences. For example, when searching for a command containing the word `Générer` (French for `Generate`), type `generer` without accents and matching commands appear in the results.
+
+This is helpful when using different keyboard layouts or when mistyping while looking for a command. The filtering is based on [Unicode Normalization Form D](https://www.unicode.org/reports/tr15/#Norm_Forms) and supports all Unicode languages.
+
+<video src="images/1_106/filtering.mp4" title="Video showing filtering in Command Palette." autoplay loop controls muted></video>
+
+### Advanced VS Code settings
+
+VS Code now supports the concept of advanced settings. These settings are meant for configuring specialized scenarios and are intended for advanced users who need fine-grained control over their environment. By default, advanced settings are hidden in the Settings editor, keeping the interface streamlined while making these powerful options available when needed.
+
+To view and configure advanced settings, select **Advanced** from the filter dropdown menu in the Settings editor, or type `@tag:advanced` in the search box:
+
+![Screenshot showing the Settings editor with the Advanced filter applied, displaying advanced settings with the Advanced tag badge](images/1_106/advanced-settings.png)
+
+When you search for a specific setting by its exact name or use the `@id:` filter, advanced settings appear in the results without having to apply the **Advanced** filter. This ensures you can always find the settings you're looking for.
+
+Advanced settings can be combined with other filters such as `@modified` or `@feature:` to help you find exactly what you need. For example, `@tag:advanced @feature:terminal` shows only advanced settings related to the terminal.
+
+>**Note:** Extension authors can mark their settings as advanced by adding the `advanced` tag to the setting configuration.
+
+## Chat
+
+### Embeddings-based tool selection
+
+In this release we've significantly improved how we filter and group tools for users that have many (over 100) tools enabled in chat. You should see the "Optimizing tool selection..." loading state less often and for a shorter period of time. We also improved tool selection with a lower probability of agent confusion to make sure the right tools are chosen.
+
+### Tool approvals and trust
+
+#### Post-approval for external data
+
+Agent tools that pull in external data now support post-approval. This helps protect against potential prompt injection attacks by letting you review the data before it's used in your chat session.
+
+<video src="images/1_106/post-approval.mp4" autoplay loop controls muted></video>
+
+Post-approval is enabled for the `#fetch` tool and for Model Context Protocol (MCP) tools that declare `openWorldHint`.
+
+#### Trust all tools for a server or extension
+
+You can now trust MCP servers and extension tools at the source level through the **Allow** button dropdown. This means that you can approve all tools from a specific MCP server or extension at once, rather than having to approve each tool individually.
+
+We have also updated the **Chat: Manage Tool Approval** command experience to let you manage both pre- and post-approval of tools.
+
+![Screenshot of the Manage Tool Approval command experience, enabling tools to skip approval and skipping content review.](images/1_106/manage-tool-approvals.png)
+
+#### Tool auto approval status moved
+
+Auto approval status has moved from being inline inside the chat view to the tool call status/tick icon:
+
+![Screenshot of hovering a tool's tick icon will reveal why it was auto approved](images/1_106/tool-auto-approve-hover.png)
+
+### Terminal tool
+
+#### Auto approve parser improvements
+
+Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned paranthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
+
+This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter/) into the feature and use a [PowerShell grammar](https://github.com/airbus-cert/tree-sitter-powershell) or a [bash grammar](https://github.com/tree-sitter/tree-sitter-bash) for everything else\*. So, even really complex cases should be correctly extracted:
+
+![Screenshot of detecting "$()" inside echo calls.](images/1_106/tool-terminal-parser.png)
+
+\* _Note that this means it can fail to catch subcommands when the shell syntax differs from bash, such as `;` in zsh_
+
+#### File write/redirection detection (Experimental)
+
+Thanks to the new parser, we're able to fairly reliably extract files being written to via redirection. There's the new experimental setting `setting(chat.tools.terminal.blockDetectedFileWrites)` that will prevent auto approval conditionally.
+
+![Screenshot showing that writing outside the workspace by default will block auto approval.](images/1_106/tool-terminal-redirection.png)
+
+#### Disable default auto approve rules (Experimental)
+
+The new experimental setting `setting(chat.tools.terminal.ignoreDefaultAutoApproveRules)` allows disabling the default rules (both allow and deny rules). This is useful if you want more control without needing to look up the defaults.
+
+#### Shell specific prompts and command rewriting
+
+The terminal tool now has shell-specific descriptions for PowerShell, bash, zsh and fish. This should make commands suggested by the agent more reliable and less likely to fail, especially for PowerShell.
+
+In addition to this, for PowerShell we also re-write `&&` to `;` since the `&&` chain operator is not supported in Windows PowerShell (v5). Note that this is temporarily also happening for PowerShell 7 until [vscode#274548](https://github.com/microsoft/vscode/issues/274548) is actioned.
+
+#### Attach terminal commands to chat
+
+You can now attach a terminal command to chat as context from the command decoration's context menu. The attachment shares the command line, captured output, and exit code so the agent understands precisely what happened. This applies to any command tracked by shell integration, making it easy to escalate troubleshooting without copying and pasting text.
+
+<video src="images/1_106/terminal-attachment.mp4" title="Video showing attaching terminal commands to chat." autoplay loop controls muted></video>
+
+#### View terminal output inside chat (Experimental)
+
+The new `setting(chat.tools.terminal.outputLocation)` setting controls where the output is displayed. The default `none` value prevents the terminals from cluttering the panel.
+
+Every chat terminal invocation now surfaces two actions on the progress element:
+
+* **Show Terminal** reveals and focuses hidden sessions, and with rich shell integration, scrolls directly to the relevant command. With basic or no shell integration, the action still focuses the correct terminal tab.
+* **Show Output** opens the terminal's final output inline within the chat view. The output view expands automatically when a command exits with a non-zero code.
+
+When `npm i` fails, the output is automatically expanded. The terminal is revealed with the **Show Terminal** inline action.
+
+<video src="images/1_106/terminal-chat-output.mp4" title="Video showing terminal output showing inline in the Chat view and the option to open it in the terminal." autoplay loop controls muted></video>
+
+#### Discover hidden chat terminals (Experimental)
+
+When `setting(chat.tools.terminal.outputLocation):none`, a new **X hidden terminal(s)** button appears in the terminal tabs view when there is at least one hidden chat terminal. It opens a quick pick that lists each chat terminal alongside its chat session so you can immediately focus the right process. The same picker is available from the terminal overflow menu under **View Hidden Chat Terminals**, and it disappears once all chat terminals are visible again.
+
+The agent runs `ls -la`, which succeeds, so the output is collapsed. The **hidden terminal** action is taken from the tabs view and the terminal is selected, revealed, and scrolled to highlight the command.
+
+<video src="images/1_106/terminal-chat-hidden.mp4" title="Video showing discovering hidden chat terminals." autoplay loop controls muted></video>
+
+### Save conversation as prompt
+
+You can now save your chat conversations as reusable prompts with the `/savePrompt` command. When you invoke `/savePrompt` in an active chat session, VS Code generates a prompt file containing a generalized prompt based on your conversation. The editor displays a blue button that lets you save this prompt to a valid location, either at the user or workspace level.
+
+![Screenshot of the Save prompt button in the editor.](images/1_106/save-prompt-prompt.png)
+
+This feature replaces the previous `/save` command and provides a more streamlined workflow for capturing and sharing useful conversation patterns. The generated prompts can be easily reused in future chat sessions or shared with your team. Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
+
+### Edit welcome prompts
+
+You can now right-click on suggested prompts in the Chat welcome view to access additional actions. When you right-click a prompt (or press `kbstyle(Shift+F10)`), a context menu appears with an **Edit Prompt File** option to open the corresponding prompt file directly in the editor.
+
+Editing a prompt file works for prompts that have an associated file, including user-defined prompts and project-specific prompts configured through the `setting(chat.promptFilesRecommendations)` setting.
+
+![Screenshot of a context menu for a suggested prompt.](images/1_106/welcome-prompt-context.png)
+
+Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
+
+### Automatically open edited files
+
+**Setting**: `setting(chat.openEditedFilesAutomatically)`
+
+We changed the default behavior of the agent to no longer automatically open edited files in an editor. If you prefer the previous behavior, you can enable the setting `setting(accessibility.openChatEditedFiles)`.
+
+### Reasoning (Experimental)
+
+**Setting**: `setting(chat.agent.thinkingStyle)`, `setting(chat.agent.thinking.collapsedTools)`
+
+Last iteration, we added the `setting(chat.agent.thinkingStyle)` setting which enabled displaying thinking tokens in chat. This is now available in more models! As of this release, GPT-5-Codex, GPT-5, GPT-5 mini, and Gemini 2.5 Pro support this.
+
+The `setting(chat.agent.thinkingStyle)` was adjusted to three more common styles, with `fixedScrolling` as the default to show the most recent chain of thoughts.
+
+An additional setting, `setting(chat.agent.thinking.collapsedTools)`, adds tool calls into the collapsible thinking UI.
+
+![Screenshot showing reasoning tokens displayed in chat with interweaved tool cals and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](images/1_106/reasoning.png)
+
+### Inline chat v2 (Preview)
+
+**Setting**: `setting(inlineChat.enableV2:true)`
+
+We have ramped up our efforts to modernize inline chat. It's built to be
+
+* single prompt,
+* single file,
+* and for code changes only
+
+This makes the overall experience much lighter and allows for a simplified UI. For tasks it cannot handle, you'll be automatically upgraded to the Chat view.
+
+<video src="images/1_106/inline-chat.mp4" title="Showing Inline chat in action" autoplay loop controls muted></video>
+
+### Chat view UX improvements
+
+We tweaked some parts of the Chat view to make it feel more pleasant to use:
+
+* The action to create a new Chat is now a dropdown with options to create a chat session in the editor or in a new window
+* The tools and MCP server actions moved right next to the model picker
+* The configuration dropdown is cleaned up
+
+![Screenshot of the action to create a new chat dropdown menu.](images/1_106/chat-view.png)
+
+It is now also possible to copy math source by right-clicking math expressions in the chat view.
+
+## MCP
+
+### MCP server access for your organization
+
+**Settings**: `setting(chat.mcp.gallery.serviceUrl)`, `setting(chat.mcp.access)`
+
+VS Code now supports MCP registry configured through GitHub organization policies. This enables organizations to set up a custom MCP registry and control which MCP servers can be installed and started.
+
+When an MCP registry endpoint is configured in your organization's policies, VS Code will:
+
+* Provide browsing and installing of MCP servers from the configured registry
+* Restrict starting MCP servers to only those available in the registry when access restriction is enabled
+
+When your organization has configured these policies, the `setting(chat.mcp.gallery.serviceUrl)` setting specifies the MCP registry endpoint URL, and the `setting(chat.mcp.access)` setting controls whether access is restricted to only the servers in that registry. These settings will be marked as "(Managed by organization)" in the Settings editor:
+
+![Screenshot showing MCP settings managed by organization policy, including the Gallery Service URL and Access control settings](images/1_106/mcp-registry-policies.png)
+
+To learn more about configuring MCP server access for your organization or enterprise, see [Configure MCP server access](https://docs.github.com/en/copilot/how-tos/administer-copilot/configure-mcp-server-access).
+
+### Install MCP servers to workspace configuration
+
+When installing an MCP server, you can now choose whether to install it globally or to the workspace configuration. Right-click on an MCP server in the extensions view and select **Install (Workspace)** from the context menu, or use the **Install (Workspace)** action directly in the MCP server editor. This adds the MCP server to the `.vscode/mcp.json` file in your current workspace, making it easier to share MCP servers with your team.
+
+![Screenshot showing the context menu for an MCP server with the Install (Workspace) option highlighted](images/1_106/mcp-install-workspace.png)
+
+### Authentication: Client ID Metadata Document authentication flow
+
+Authentication support for remote MCPs now supports the [Client ID Metadata Document (CIMD)](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html) authentication flow, which is the future standard for OAuth in MCP. This flow enables a more secure and scaleable solution to authentication over [Dynamic Client Registiration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591) because now authorization servers do not have to worry about issuing client IDs per-client.
+
+When connecting to an MCP server that uses an authorization server that supports CIMD, VS Code will automatically use that flow over DCR.
+
+_For more information about CIMD, take a look at [the resources on oauth.net](https://oauth.net/2/client-id-metadata-document/)._
+
+### Authentication: `WWW-Authenticate` scope step up
+
+Authentication support for remote MCPs now supports dynamic scope escalation through the `WWW-Authenticate` header for remote MCP servers. This is called out in [the OAuth 2.0 specification](https://datatracker.ietf.org/doc/html/rfc6750#section-3). This allows MCP servers to request additional permissions when needed, rather than requiring all scopes upfront. For example, connecting to a server might require a minimal set of scopes, but specific tool calls can request broader permissions only when necessary. This provides better security by following the principle of least privilege.
+
+_This is currently called out in the [latest draft of the MCP specification](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy) which is expected to be finalized soon._
+
+## Accessibility
+
+### Speech timeout is disabled by default
+
+The configuration `setting(accessibility.voice.speechTimeout)` has changed to be `0` by default. This means, a voice session no longer ends automatically after a certain delay (e.g. a Chat request would not be triggered automatically if you pause). We feel this is a better default experience, but you can always change back to the previous default (`2500`).
+
+### Chat input improvements
+
+The chat input now announces the active agent and model in a clearer order so screen reader users hear the most relevant context first. The chat accessibility help also calls out that you can press **Delete** to remove attached context items, making attachment management fully keyboard-accessible.
+
+## Notebooks
+
+### Notebook search
+
+Notebooks now supports searching across cells. Use key bindings (`kb(notebook.findNext.fromWidget)` and `kb(notebook.findPrevious.fromWidget)`) to navigate to the next and previous match, just like you would in the editor.
+
+<video src="images/1_106/notebookSearch.mp4" title="Video showing search in notebook cells." autoplay loop controls muted></video>
+
+## Source Control
+
+### Folding support in git commit messages
+
+**Settings**: `setting(git.verboseCommit)`, `setting(git.useEditorAsCommitInput)`
+
+When writing git commit messages in the editor, you can now fold sections of the commit message to keep things organized. To use this feature, enable the `setting(git.verboseCommit)` and `setting(git.useEditorAsCommitInput)` settings.
+
+![Screenshot showing folding nodes in the gutter and a partially collapsed commit message in the editor.](images/1_106/commit-folding.png)
+
+### Graph incoming/outgoing changes
+
+**Settings**: `setting(scm.graph.showIncomingChanges)`, `setting(scm.graph.showOutgoingChanges)`
+
+This milestone, we are adding the capability to easily view incoming and outgoing changes in the Source Control Graph view. For active branches that have incoming or outgoing changes, the graph displays an "Incoming Changes" and "Outgoing Changes" node. Selecting each node displays the list of incoming or outgoing files.
+
+![Screenshot showing incoming and outgoing changes nodes in the Source Control Graph view.](images/1_106/graph-incoming-outgoing.png)
+
+You can hide this information from the Graph view by using the `setting(scm.graph.showIncomingChanges:false)` and `setting(scm.graph.showOutgoingChanges:false)` settings.
+
+### Graph compare references
+
+We have added a new command to the Source Control Graph context menu, **Compare with...**, that enables you to compare a history item in the graph with an arbitrary branch or tag. This feature lets you view changes that are in the history item but not in the branch or tag.
+
+In the context menu, there are shortcuts commands, **Compare with Remote** and **Compare with Merge Base** for comparing a history item with the remote branch and merge base respectively.
+
+### Repositories selection mode
+
+**Setting**: `setting(scm.repositories.selectionMode)`
+
+The Source Control Repositories view shows the list of opened repositories in the workspace and is used to control the repositories shown in the Source Control Changes view.
+
+We are looking to expand the functionality of the Repositories view and in preparation for that, we are introducing a setting, `setting(scm.repositories.selectionMode)`, to control the selection mode in the Repositories view to either a single repository or multiple repositories.
+
+Apart from the new functionality in the Repositories view, this also allows us to remove the repository picker in the Graph view's title and have a global repository picker across all source control views. You can toggle the selection mode using the setting, or from the "..." menu of the Repositories view.
+
+![Screenshot showing the Repositories view with single selection mode enabled and the context menu to toggle selection mode.](images/1_106/repositories-selection-mode.png)
+
+### Repositories explorer (experimental)
+
+**Settings**: `setting(scm.repositories.explorer:true)`, `setting(scm.repositories.selectionMode:single)`
+
+We are looking at enhancing the Repositories view and showing additional information for each repository. To try out this experimental feature, set `setting(scm.repositories.selectionMode:single)` and `setting(scm.repositories.explorer:true)`.
+
+In this first iteration, we have focused on branches and tags. You can create new branches, tags, view the list of branches and tags, and take various actions of each branch/tag (ex: checkout, etc.). In the upcoming milestone, we will add more information (ex: stashes, remotes, etc). Give this experimental feature a try and let us know what you think.
+
+![Screenshot showing the Repositories explorer with branches and tags for a single selected repository.](images/1_106/repositories-explorer.png)
+
+## Testing
+
+### Navigate uncovered lines in test coverage
+
+When reviewing test coverage, you can now easily navigate between uncovered lines using new navigation commands. Two commands are available in the editor toolbar when viewing coverage information:
+
+* **Go to Next Uncovered Line** - Jumps to the next line that is not covered by tests
+* **Go to Previous Uncovered Line** - Jumps to the previous line that is not covered by tests
+
+These commands help you quickly identify coverage gaps and focus on areas that need additional test coverage, making it easier to improve the overall test quality of your codebase.
+
+## Terminal
+
+### Terminal IntelliSense
+
+Terminal IntelliSense has been in the product as an experimental/preview feature [for around 1.5 years](https://code.visualstudio.com/updates/v1_89#_vs-codenative-intellisense-for-powershell)! This release we're removing the preview tag and will be doing a staged roll out as the default to all users on stable.
+
+When enabled, typing in the terminal will bring up IntelliSense similar to the editor for PowerShell, bash, zsh and fish:
+
+![Screenshot of typing "write" in PowerShell will bring up completions starting with the word write.](images/1_106/terminal-suggest-write.png)
+
+The completions have various sources, paths for example are all handled by core:
+
+<video src="images/1_106/terminal-suggest-cd.mp4" title="cd presents directories, pressing tab will refresh the entries" autoplay loop controls muted></video>
+
+Some commands feature advanced specifications, like git which has the ability to pull in branch names:
+
+<video src="images/1_106/terminal-suggest-git.mp4" title="git completions support sub-commands, branch names, tags and so on" autoplay loop controls muted></video>
+
+If we learned anything when building this feature it's that no one size fits all, so there are many options to tweak the behavior to get what you're after:
+
+- `setting(terminal.integrated.suggest.quickSuggestions)` - Show automatically depending on the content of the command line, as opposed to manually via `kbstyle(Ctrl+Space)`.
+- `setting(terminal.integrated.suggest.suggestOnTriggerCharacters)` - Show automatically after a "trigger character" such as `-` or `/`.
+- `setting(terminal.integrated.suggest.runOnEnter)` - Optionally run the command when `kbstyle(Enter)` is used (not `kbstyle(Tab)`).
+- `setting(terminal.integrated.suggest.windowsExecutableExtensions)` - The list of extensions that are treated as executables on Windows.
+- `setting(terminal.integrated.suggest.providers)` - Provides the ability to disable specific providers, for example extensions may contribute completions you don't want.
+- `setting(terminal.integrated.suggest.showStatusBar)` - Whether to show the status bar at the bottom of the IntelliSense popup.
+- `setting(terminal.integrated.suggest.cdPath)` - Whether to enable `$CDPATH` integration.
+- `setting(terminal.integrated.suggest.inlineSuggestion)` - Whether to integrate with shell "ghost text" and how to present it.
+- `setting(terminal.integrated.suggest.upArrowNavigatesHistory)` - Whether up arrow is sent to the shell instead of browsing completions, this is particularly useful on zsh where you can filter and then press up to do a history search with that prefix.
+- `setting(terminal.integrated.suggest.selectionMode)` - How the Intellisense popup is focused which determines what `kbstyle(Enter)` and `kbstyle(Tab)` do.
+- (New!) `setting(terminal.integrated.suggest.insertTrailingSpace)` - Insert a trailing space and re-trigger completions after accepting.
+
+If you are don't see the feature yet, make sure you have [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) enabled and enable IntelliSense explicitly in settings via `setting(terminal.integrated.suggest.enabled)`.
+
+Apart from overall polish, this is what is coming to the feature this release:
+
+- `copilot` and `azd` CLIs now have completions
+- The extension API is close to finalization
+- Git commit completions show the commit message
+
+![Screenshot of git commit completions showing branch names and their associated commit messages in the terminal suggest details view.](images/1_106/terminal-suggest-commit.png)
+
+### Consolidated shell integration timeout setting
+
+We now have one unified configurable setting, `setting(terminal.integrated.shellIntegration.timeout)`, that controls how long VS Code waits for shell integration to become ready before executing commands in the terminal, including those triggered through the executeCommand API and by Copilot terminal tool.
+
+`setting(chat.tools.terminal.shellIntegrationTimeout)` has been deprecated in favor of this consolidation.
+
+## Authentication
+
+### Manage extension account preferences discoverability
+
+The **Manage Extension Account Preferences** command is now more discoverable. In addition to being available in the Command Palette and extension context menus, it now appears in the Account Menu alongside **Manage Language Model Access**. This makes it easier to find and configure which accounts extensions can access.
+
+![Screenshot of Manage Extension Account Preferences in the Account menu.](images/1_106/manageExtensionAccountPref.png)
+
+### Last version of `classic` Microsoft authentication - use `msal-no-broker` if you experience issues
+
+We will be removing the `classic` option for `setting(microsoft-authentication.implementation)`. This means that VS Code release 1.106 is the final version that has the `classic` option.
+
+The `setting(microsoft-authentication.implementation)` setting has been around to let users opt-out of native brokered authentication for Microsoft accounts if they experienced issues. The values for this setting are:
+
+* `msal` - Use MSAL with brokered authentication when available (default)
+* `msal-no-broker` - Use MSAL without brokered authentication (introduced recently)
+* `classic` - Use the classic Microsoft authentication flow without MSAL
+
+We will remove the `classic` option since it's usage is very low and most issues with the `msal` option are due to the brokering, which is remedied with `msal-no-broker`.
+
+### Device code flow for Microsoft authentication
+
+Microsoft authentication now supports the device code flow in non-brokered scenarios, particularly useful for remote development environments. When other authentication methods fail, VS Code automatically falls back to device code flow, which displays a code that you can enter on another device to complete authentication.
+
+### Manage accounts command
+
+Manage your authentication accounts directly from the Command Palette using the **Accounts: Manage Accounts** command. This command provides access to account management features when the Account menu is hidden or not easily accessible.
+
+![Screenshot of the Manage Accounts menu.](images/1_106/manage-accounts-menu.png)
+
+When you run the **Manage Accounts** command, you'll see a quick pick menu listing all your active accounts. You can select an account to view available actions, including:
+
+* **Manage Trusted Extensions** - Control which extensions can access the selected account
+* **Manage Trusted MCP Servers** - Manage MCP server access permissions for accounts that support this capability
+* **Sign Out** - Sign out of the account
+
+## Languages
+
+### Python
+
+#### Python Environments Extension: Support for python.poetryPath setting
+
+The Python Environments Extension now respects the existing `python.poetryPath` user setting. This allows you to specify which Poetry executable to use. The provided path will be searched for and selected when managing Poetry environments.
+
+#### Python Environments Extension: Improved venv creation: dev-requirements.txt detection
+
+When creating a new virtual environment, the extension now detects both requirements.txt and dev-requirements.txt files and installs dependencies automatically.
+
+#### Add Copilot Hover Summaries as docstring
+
+You can now add your AI-generated documentation directly into your code as a docstring using the new **Add as docstring** command in Copilot Hover Summaries. When you generate a summary for a function or class, navigate to the symbol definition and hover over it to access the **Add as docstring** command, which inserts the summary below your cursor formatted as a proper docstring.
+
+This streamlines the process of documenting your code, allowing you to quickly enhance readability and maintainability without retyping.
+
+<video src="images/1_106/pylance-add-hover-summaries-as-docstring.mp4" title="Add as docstring command in Copilot Hover Summaries." autoplay loop controls muted></video>
+
+#### Localized Copilot Hover Summaries
+
+GitHub Copilot Hover Summaries inside Pylance now respect your display language within VS Code. When you invoke an AI-generated summary, you'll get strings in the language you've set for your editor, making it easier to understand the generated documentation.
+
+![Screenshot of a Copilot Hover Summary generated in Portuguese.](images/1_106/hover-summaries-in-portuguese.png)
+
+#### Convert wildcard imports Code Action
+
+Wildcard imports (from module import *) are often discouraged in Python because they can clutter your namespace and make it unclear where names come from, reducing code clarity and maintainability.
+Pylance now helps you clean up modules that still rely on `from module import *` via a new Code Action. It replaces the wildcard with the explicit symbols, preserving aliases and keeping the import to a single statement. To try it out, you can click on the line with the wildcard import and press `kbstyle(Ctrl+.)` (or `kbstyle(Cmd+.)` on macOS) to select the **Convert to explicit imports** Code Action.
+
+![Screenshot of the Convert wildcard imports Code Action.](images/1_106/wildcard-import.png)
+
+### dotenv
+
+There is built in basic support for dotenv files (`.env`), which are commonly used to define environment variables for applications.
+
+## Contributions to extensions
+
+### GitHub Pull Requests
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+
+* AI-generated PR descriptions (via `setting(githubPullRequests.pullRequestDescription:copilot)`) will respect the repository PR template if there is one.
+* Drafts in the Pull Requests view now render in italics instead of having a `[DRAFT]` prefix.
+* Pull requests can be opened from from a url, for example: `vscode-insiders://github.vscode-pull-request-github/checkout-pull-request?uri=https://github.com/microsoft/vscode-css-languageservice/pull/460`
+
+Review the [changelog for the 0.122.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01220) release of the extension to learn about everything in the release.
+
+## Preview Features
+
+### Language Models editor
+
+A new **Language Models** editor provides a centralized place to view and manage all available language models for GitHub Copilot Chat. You can open it from the chat model picker or via the command **Chat: Manage Language Models**.
+
+>**Note:** This feature is only available in [VS Code Insiders](https://code.visualstudio.com/insiders/).
+
+![Screenshot showing the Language Models editor with a list of models organized by provider.](images/1_106/language-models-editor.png)
+
+The editor displays:
+
+* All available models organized by provider
+* Model capabilities (tools, vision, agent)
+* Context size and multiplier information
+* Model visibility status
+
+You can search and filter models using:
+
+* Text search with highlighting
+* Provider filter: `@provider:"OpenAI"`
+* Capability filters: `@capability:tools`, `@capability:vision`, `@capability:agent`
+* Visibility filter: `@visible:true/false`
+
+Hover over model names or context sizes to see detailed information including model ID, version, status, and token breakdown.
+
+#### Manage model visibility
+
+Control which models appear in the chat model picker by toggling their visibility with the eye icon next to each model. When a model is visible, it appears in the model picker dropdown when you're using GitHub Copilot Chat, making it available for selection. Hidden models remain in the Language Models editor but won't appear in the model picker, helping you keep your model selection focused on the ones you use most frequently.
+
+![Screenshot showing the eye icon to toggle model visibility with a tooltip displaying "Show in the chat model picker"](images/1_106/toggle-language-model-visibility.png)
+
+This is particularly useful when you have access to many models and want to streamline your workflow by showing only your preferred models in the picker.
+
+#### Add models from installed providers
+
+Use the **Add Models...** button to configure and add models from language model providers you've already installed. When you select this button, you'll see a dropdown list of all installed model providers, such as Copilot, Anthropic, Azure, Google, Groq, Ollama, OpenAI, and others. Select a provider from the list to configure it and start using its models in GitHub Copilot Chat.
+
+![Screenshot showing the Add Models dropdown with a list of installed language model providers including Copilot, Anthropic, Azure, Google, and more](images/1_106/add-language-models-dropdown.png)
+
+This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
+
+## Extension Authoring
+
+### ID token in authentication sessions
+
+The `AuthenticationSession` interface now includes an optional `idToken` property. This allows authentication providers to return ID tokens in addition to access tokens, which is particularly useful for scenarios that require user identity information. The Microsoft authentication provider returns this field, while other providers like GitHub may not.
+
+ID tokens contain claims about the authenticated user and are signed by the identity provider, making them useful for verifying user identity. For more information about the difference between ID tokens and access tokens, see <https://oauth.net/id-tokens-vs-access-tokens/>.
+
+```typescript
+export interface AuthenticationSession {
+  /**
+   * The ID token.
+   */
+  readonly idToken?: string;
+}
+```
+
+### Git extension `getRepositoryWorkspace` API
+
+The build in Git extension offers new API for getting a folder that's known to be associated with a git repository remote. This works by caching a repository-remote to folder mapping when the user opens a folder with a git remote.
+
+### View containers in Secondary Side Bar
+
+Extension authors can now register view containers in the Secondary Side Bar by using the new `secondarySidebar` contribution point. This lets extensions place their custom views alongside built-in views like Chat in the Secondary Side Bar and provide a better integration with VS Code's dual side bar layout.
+
+```json
+{
+  "contributes": {
+    "viewsContainers": {
+      "secondarySidebar": [
+        {
+          "id": "myExtensionViews",
+          "title": "My Extension",
+          "icon": "$(extensions)"
+        }
+      ]
+    },
+    "views": {
+      "myExtensionViews": [
+        {
+          "id": "myCustomView",
+          "name": "Custom View",
+          "when": "true"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Proposed APIs
+
+### Quick Pick and Quick Input improvements
+
+The Quick Pick and Quick Input APIs include several new capabilities that give extension developers more flexibility in creating interactive user interfaces.
+
+<video src="images/1_106/quick-pick-api.mp4" title="Video showing quick pick with prompt, toggle and file icons." autoplay loop controls muted></video>
+
+#### Proposed API: Toggle button support
+
+Extensions can add toggle buttons to Quick Pick and Quick Input interfaces through the `toggles` property on `QuickInput`. This enables scenarios like a password visibility toggle in the input box area, allowing users to interact with controls without leaving the quick pick interface.
+
+Your comments and feedback on this API proposal are appreciated (please refer to the [GitHub issue](https://github.com/microsoft/vscode/issues/144956)).
+
+```typescript
+export enum QuickInputButtonLocation {
+  ...
+
+  /**
+   * The button is rendered at the far end inside the input box.
+   */
+  Input = 3
+}
+
+export interface QuickInputButton {
+  ...
+
+  /**
+   * When present, indicates that the button is a toggle button that can be checked or unchecked.
+   *
+   * **Note:** This property is currently only applicable to buttons with {@link QuickInputButtonLocation.Input} location.
+   * It must be set for such buttons, and the state will be updated when the button is toggled.
+   * It cannot be set for buttons with other location values.
+   */
+  readonly toggle?: { checked: boolean };
+}
+```
+
+#### Proposed API: Prompt support for Quick Pick
+
+Quick Pick supports a `prompt` property, similar to the one available in Input Box. The prompt displays persistent text beneath the input box that remains visible while users type, providing helpful guidance or instructions that doesn't disappear when the user starts entering text.
+
+Your comments and feedback on this API proposal are appreciated (please refer to the [GitHub issue](https://github.com/microsoft/vscode/issues/78335)).
+
+```typescript
+export interface QuickPick<T extends QuickPickItem> extends QuickInput {
+  /**
+   * Optional text that provides instructions or context to the user.
+   *
+   * The prompt is displayed below the input box and above the list of items.
+   */
+  prompt: string | undefined;
+}
+
+export interface QuickPickOptions {
+  /**
+   * Optional text that provides instructions or context to the user.
+   *
+   * The prompt is displayed below the input box and above the list of items.
+   */
+  prompt?: string;
+}
+```
+
+#### Proposed API: File icons for Quick Pick items
+
+Quick Pick items can display file-type-specific icons through the `resourceUri` property on `QuickPickItem`. When you provide a resource URI, VS Code automatically derives the appropriate label, description, and icon based on the resource type, matching your current theme's file icon set. This is particularly useful when building file or folder selection interfaces, as users can quickly identify items by their familiar file type icons.
+
+Your comments and feedback on this API proposal are appreciated (please refer to the [GitHub issue](https://github.com/microsoft/vscode/issues/59826)).
+
+```typescript
+export interface QuickPickItem {
+  /**
+   * A {@link Uri} representing the resource associated with this item.
+   *
+   * When set, this property is used to automatically derive several item properties if they are not explicitly provided:
+   * - **Label**: Derived from the resource's file name when {@link QuickPickItem.label label} is not provided or is empty.
+   * - **Description**: Derived from the resource's path when {@link QuickPickItem.description description} is not provided or is empty.
+   * - **Icon**: Derived from the current file icon theme when {@link QuickPickItem.iconPath iconPath} is set to
+   *   {@link ThemeIcon.File} or {@link ThemeIcon.Folder}.
+   */
+  resourceUri?: Uri;
+}
+```
+
+### GitHub-style alerts in MarkdownStrings ([#209652](https://github.com/microsoft/vscode/issues/209652))
+
+We have added support for rendering [GitHub-style alert syntax](https://github.com/orgs/community/discussions/16925) in `MarkdownString` by setting a new property `supportAlertSyntax`.
+
+```typescript
+const markdown = new vscode.MarkdownString();
+markdown.supportAlertSyntax = true;
+markdown.value = `
+> [!NOTE]
+> Useful information that users should know, even when skimming content.
+
+> [!TIP]
+> Helpful advice for doing things better or more easily.
+
+> [!IMPORTANT]
+> Key information users need to know to achieve their goal.
+
+> [!WARNING]
+> Urgent info that needs immediate user attention to avoid problems.
+
+> [!CAUTION]
+> Advises about risks or negative outcomes of certain actions.
+`;
+```
+
+This enables extensions to render alerts in various places in the UI, such as comments:
+
+![Screenshot showing GitHub-style alerts displayed in a comment thread showing each alert type with their respective icons and styling.](images/1_106/markdown-alerts.png)
+
+### MarkdownString support in TreeItem labels ([#115365](https://github.com/microsoft/vscode/issues/115365))
+
+Extension authors can now use `MarkdownString` in tree view item labels, enabling a subset of Markdown syntax including codicons and text formatting. This allows extensions to create more visually rich tree views.
+
+```typescript
+// Codicons
+const itemWithIcon = new vscode.TreeItem({ label: new vscode.MarkdownString('$(star) Starred item', true) });
+
+// Text formatting (must surround the entire string)
+const italicItem = new vscode.TreeItem({ label: new vscode.MarkdownString('_Italic item_') });
+
+// Formatting and codicons can be combined
+const combined = new vscode.TreeItem({ label: new vscode.MarkdownString('_~~**$(check) Done $(star)**~~_', true) });
+```
+
+The above items render as:
+![Screenshot of a tree view showing three items: a starred item with an icon, an italic item, and a combined item with check and star icons plus bold, italic, and strikethrough formatting.](images/1_106/markdown-labels.png)
+
+## Engineering
+
+### Exploration of automated UX PR testing
+
+We've introduced a new automation workflow that helps reviewers understand UI changes in pull requests without manually checking out and running the code. By adding the `~copilot-video-please` label to a pull request with UI changes, an automated process kicks off that:
+
+* Builds VS Code from the PR branch
+* Uses GitHub Copilot CLI to interact with the changes and record a video along the way - leveraging [playwright-mcp](https://github.com/microsoft/playwright-mcp)
+* Generates a Playwright trace for detailed inspection
+* Posts the results as a comment on the PR
+
+While it's still early, this workflow can reduce the manual effort required for code review, especially for small UI changes. The videos and traces help reviewers quickly verify that changes work as expected. Currently, the videos are only accessible to team members.
+
+For more details about this automation, see <https://github.com/microsoft/vscode/issues/272529>.
+
+### macOS 11.0 support has ended
+
+VS Code `1.106` is the last release that supports macOS 11.0 (macOS Big Sur). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
+
+## Notable fixes
+
+* [vscode#258236](https://github.com/microsoft/vscode/issues/258236) - Add setting for extensions request timeout used when installing extensions
+* [vscode#272945](https://github.com/microsoft/vscode/issues/272945) - Tasks do not trigger `onDidStartTerminalShellExecution`
+* [vscode#273372](https://github.com/microsoft/vscode/issues/273372) - `/**` is automatically closed with `*/` in .gitignore files
+* [vscode#243584](https://github.com/microsoft/vscode/issues/243584) - First input gets ignored on pwsh/conpty
+* [vscode#271952](https://github.com/microsoft/vscode/pull/271952) - Copilot 'configure instructions' quickpick doesn't show workspace-level agent instruction files (copilot-instructions.md, AGENTS.md)
+* [vscode#274631](https://github.com/microsoft/vscode/pull/274631) - Network: Load intermediate certification authorities on Windows
+
+## Thank you
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+* [@Accurio (Accurio)](https://github.com/Accurio)
+
+### Pull Requests
+
+Contributions to `vscode`:
+
+* [@AminSajedian (Amin Sajedian)](https://github.com/AminSajedian): Issue #210694 add hoverforeground and hoverbackground to activity bars [PR #263146](https://github.com/microsoft/vscode/pull/263146)
+* [@avarayr (avarayr)](https://github.com/avarayr): fix: Increase workbench border radius on macos tahoe [PR #270236](https://github.com/microsoft/vscode/pull/270236)
+* [@baptiste0928 (Baptiste Girardeau)](https://github.com/baptiste0928): fix: resolve renamed paths on merge editor [PR #254677](https://github.com/microsoft/vscode/pull/254677)
+* [@barroit (barroit)](https://github.com/barroit): Fix tabstop calc in tokenizeLineToHTML() [PR #263387](https://github.com/microsoft/vscode/pull/263387)
+* [@Benimautner](https://github.com/Benimautner): Fix: don't apply inertial scrolling if input device is a mouse. [PR #268284](https://github.com/microsoft/vscode/pull/268284)
+* [@danielbayley (Daniel Bayley)](https://github.com/danielbayley): Add `TM_DIRECTORY_BASE` snippets variable [PR #270262](https://github.com/microsoft/vscode/pull/270262)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): Hookup semantic tokens range refresh notification to the viewport contribution [PR #271419](https://github.com/microsoft/vscode/pull/271419)
+* [@dnicolson (Dave Nicolson)](https://github.com/dnicolson): Update activation event linter message [PR #269156](https://github.com/microsoft/vscode/pull/269156)
+* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): Fix disassembly view [PR #270361](https://github.com/microsoft/vscode/pull/270361)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Show the `Learn How to Hide AI Features` in more situations (fix #268450) [PR #268462](https://github.com/microsoft/vscode/pull/268462)
+* [@imbant (imbant)](https://github.com/imbant): fix(chat): correct file icon rendering in Files & Folders picker [PR #255384](https://github.com/microsoft/vscode/pull/255384)
+* [@JeffreyCA](https://github.com/JeffreyCA): Add Fig spec for Azure Developer CLI (azd) [PR #272348](https://github.com/microsoft/vscode/pull/272348)
+* [@jlelong (Jerome Lelong)](https://github.com/jlelong)
+  * Make pair colorizer ignore \@ifnextchar [PR #272329](https://github.com/microsoft/vscode/pull/272329)
+  * Exclude trailing underscore from bracket pairs in LaTeX [PR #272758](https://github.com/microsoft/vscode/pull/272758)
+* [@jmg-duarte (José Duarte)](https://github.com/jmg-duarte): Fix localization for terminal.hoverHighlightBackground [PR #264228](https://github.com/microsoft/vscode/pull/264228)
+* [@Mingpan](https://github.com/Mingpan): Copy selection for deleted chunk in inline diff [PR #267991](https://github.com/microsoft/vscode/pull/267991)
+* [@obrobrio2000 (Giovanni Magliocchetti)](https://github.com/obrobrio2000)
+  * Add "Go to Next/Previous Uncovered Line" navigation for Test Coverage [PR #269505](https://github.com/microsoft/vscode/pull/269505)
+  * html: add setting to disable end tag suggestions [PR #269605](https://github.com/microsoft/vscode/pull/269605)
+* [@ohah (ohah)](https://github.com/ohah): fix: file-found Badge vertical (#235159)  [PR #238757](https://github.com/microsoft/vscode/pull/238757)
+* [@rajniszp (Piotr Rajnisz)](https://github.com/rajniszp): i18n: add missing localizations for monaco-editor [PR #268038](https://github.com/microsoft/vscode/pull/268038)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): Fix soft wrapping on \n [PR #258407](https://github.com/microsoft/vscode/pull/258407)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Add dotenv support [PR #273074](https://github.com/microsoft/vscode/pull/273074)
+* [@ritesh006 (Ritesh Kudkelwar)](https://github.com/ritesh006): feat(ts-codeLens): show "implementations" CodeLens for overridden methods #263749 [PR #264546](https://github.com/microsoft/vscode/pull/264546)
+* [@Selva-Ganesh-M (Selva Ganesh M)](https://github.com/Selva-Ganesh-M): fix(editor)(#261780): transform UPPER_CASE to PascalCase [PR #262959](https://github.com/microsoft/vscode/pull/262959)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
+  * fix: memory leak in gettingStarted [PR #216876](https://github.com/microsoft/vscode/pull/216876)
+  * fix: memory leak in output view [PR #221605](https://github.com/microsoft/vscode/pull/221605)
+  * fix: memory leak in notebook text model [PR #265013](https://github.com/microsoft/vscode/pull/265013)
+  * fix: memory leak in InlayHints [PR #265185](https://github.com/microsoft/vscode/pull/265185)
+  * fix: memory leak in chat session tracker [PR #269027](https://github.com/microsoft/vscode/pull/269027)
+  * fix: memory leak in getTerminalActionBarArgs [PR #269516](https://github.com/microsoft/vscode/pull/269516)
+  * fix: memory leak in sticky scroll [PR #271102](https://github.com/microsoft/vscode/pull/271102)
+  * fix: memory leak in chat welcome [PR #271121](https://github.com/microsoft/vscode/pull/271121)
+* [@sinsincp](https://github.com/sinsincp): Fix AppUserModelID for code-workspace association [PR #272753](https://github.com/microsoft/vscode/pull/272753)
+* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): Testing - Uncompleted result should be marked as skipped [PR #273742](https://github.com/microsoft/vscode/pull/273742)
+* [@subin-chella (subin)](https://github.com/subin-chella): fix the bug #209943 [PR #216662](https://github.com/microsoft/vscode/pull/216662)
+* [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
+  * chat: always apply prompt file and auto-attach instructions. Fix #271624 [PR #272020](https://github.com/microsoft/vscode/pull/272020)
+  * fix(chat): guard against undefined customModes.custom Fix #272223 and #272236 [PR #272263](https://github.com/microsoft/vscode/pull/272263)
+* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): Fix memory leak in InlineEditsGutterIndicator (#273549) [PR #273550](https://github.com/microsoft/vscode/pull/273550)
+
+Contributions to `vscode-copilot-chat`:
+
+* [@24anisha](https://github.com/24anisha): Built-in toolsets for default tools [PR #1139](https://github.com/microsoft/vscode-copilot-chat/pull/1139)
+* [@AbdelrahmanAbouelenin (ababouelenin)](https://github.com/AbdelrahmanAbouelenin): Custom vsc model prompt  [PR #1504](https://github.com/microsoft/vscode-copilot-chat/pull/1504)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): Update repo URL in @vscode/chat-lib package [PR #1255](https://github.com/microsoft/vscode-copilot-chat/pull/1255)
+* [@DGideas (Wanlin Wang 王万霖)](https://github.com/DGideas): Improve error handling for Copilot Chat when 404 [PR #1073](https://github.com/microsoft/vscode-copilot-chat/pull/1073)
+* [@IanMatthewHuff (Ian Huff)](https://github.com/IanMatthewHuff): Fix issue with internal git repo telemetry collection [PR #1408](https://github.com/microsoft/vscode-copilot-chat/pull/1408)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Allow latest server.json schema in assisted NuGet MCP install flow [PR #1268](https://github.com/microsoft/vscode-copilot-chat/pull/1268)
+* [@phawrylak (Paweł Hawrylak)](https://github.com/phawrylak): Add security-sensitive file extensions to workspace indexing exclusion list [PR #1157](https://github.com/microsoft/vscode-copilot-chat/pull/1157)
+
+Contributions to `vscode-html-languageservice`:
+
+* [@obrobrio2000 (Giovanni Magliocchetti)](https://github.com/obrobrio2000): Add setting to disable end tag suggestions [PR #219](https://github.com/microsoft/vscode-html-languageservice/pull/219)
+
+Contributions to `vscode-json-languageservice`:
+
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): Escape plain text description hover correctly [PR #283](https://github.com/microsoft/vscode-json-languageservice/pull/283)
+
+Contributions to `vscode-languageserver-node`:
+
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): Clear workspace pull state on document close to prevent stale diagnostics [PR #1674](https://github.com/microsoft/vscode-languageserver-node/pull/1674)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@bendrucker (Ben Drucker)](https://github.com/bendrucker): Enable all LLM tools in prompts (agent mode) [PR #6956](https://github.com/microsoft/vscode-pull-request-github/pull/6956)
+* [@gerardbalaoro (Gerard Balaoro)](https://github.com/gerardbalaoro): Make branch list timeout configurable (#2840) [PR #7927](https://github.com/microsoft/vscode-pull-request-github/pull/7927)
+* [@wankun-tcj](https://github.com/wankun-tcj): Fix avatar display issue in Pull Request tree view [PR #7851](https://github.com/microsoft/vscode-pull-request-github/pull/7851)
+
+Contributions to `vscode-test-cli`:
+
+* [@bwateratmsft (Brandon Waterloo [MSFT])](https://github.com/bwateratmsft): Bump version ahead of release [PR #86](https://github.com/microsoft/vscode-test-cli/pull/86)
+
+Contributions to `debug-adapter-protocol`:
+
+* [@rsubtil (Ricardo Subtil)](https://github.com/rsubtil): Add Godot to the list of DAP adapters [PR #568](https://github.com/microsoft/debug-adapter-protocol/pull/568)
+
+Contributions to `language-server-protocol`:
+
+* [@kristoff-it (Loris Cro)](https://github.com/kristoff-it): Update servers.md [PR #2192](https://github.com/microsoft/language-server-protocol/pull/2192)
+
+Contributions to `monaco-editor`:
+
+* [@flofriday (Florian Freitag)](https://github.com/flofriday): Fix Kotlin number literals [PR #4973](https://github.com/microsoft/monaco-editor/pull/4973)
+
+Contributions to `node-pty`:
+
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): Load native addons directly from prebuilds directory [PR #809](https://github.com/microsoft/node-pty/pull/809)
+
+Contributions to `python-environment-tools`:
+
+* [@VictorColomb (Victor Colomb)](https://github.com/VictorColomb): fix(poetry): pep503 normalize package name [PR #242](https://github.com/microsoft/python-environment-tools/pull/242)
+
+We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+
+>If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_106.md
+++ b/docs/release-notes/v1_106.md
@@ -1,739 +1,739 @@
 ---
 Order: 115
-TOCTitle: October 2025
-PageTitle: Visual Studio Code October 2025
-MetaDescription: Learn what is new in the Visual Studio Code October 2025 Release (1.106).
+TOCTitle: 2025 年 10 月
+PageTitle: Visual Studio Code 2025 年 10 月
+MetaDescription: Visual Studio Code 2025 年 10 月リリース (1.106) の新機能について説明します。
 MetaSocialImage: 1_106/release-highlights.png
 Date: 2025-11-12
 DownloadVersion: 1.106.0
 ---
-# October 2025 (version 1.106) {#october-2025-version-1106}
+# 2025 年 10 月 (バージョン 1.106) {#october-2025-version-1106}
 
-_Release date: November 12, 2025_
+_リリース日: 2025 年 11 月 12 日_
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-Welcome to the October 2025 release of Visual Studio Code.
+Visual Studio Code の 2025 年 10 月リリースへようこそ。
 
-![Graphic showing the key highlights of the October 2025 release: Agent HQ, Security and trust, and great editor experience.](https://code.visualstudio.com/assets/updates/1_106/release-highlights.png)
+![2025 年 10 月リリースの主なハイライトを示すグラフィック: Agent HQ、セキュリティと信頼、そして優れたエディター体験。](https://code.visualstudio.com/assets/updates/1_106/release-highlights.png)
 
-This releases brings significant updates across three key areas:
+このリリースでは、3 つの主要な分野で大幅なアップデートが行われました:
 
-* **Agent HQ** is your single view to kick off, monitor, and review agent sessions, whether they're local or remote, from Copilot or OpenAI Codex
-* **Security and trust** help you stay in control and confidently delegate more tasks to AI
-* **A great editor experience** to make your day-to-day coding smoother and more enjoyable
+* **Agent HQ** は、Copilot や OpenAI Codex からのローカルまたはリモートのエージェントセッションを開始、監視、レビューするための単一のビューです
+* **セキュリティと信頼** は、AI により多くのタスクを自信を持って委任し、制御を維持するのに役立ちます
+* **優れたエディター体験** は、日々のコーディングをよりスムーズで楽しいものにします
 
 Happy Coding!
 
 <!--
-There are many updates in this version that we hope you'll like, some of the key highlights include:
+このバージョンには多くのアップデートがあり、皆様に気に入っていただけることを願っています。主なハイライトは次のとおりです:
 
 <table class="highlights-table">
   <tr>
     <th>AI</th>
-    <th>Productivity and UX</th>
-    <th>Enterprise</th>
+    <th>生産性と UX</th>
+    <th>エンタープライズ</th>
   </tr>
   <tr>
-    <td>Plan complex coding tasks with the plan agent and monitor agent sessions across background agents <a href="#agents"><br>Show more</a></td>
-    <td>Select text from deleted code in the diff editor <a href="#code-editing"><br>Show more</a></td>
-    <td>Manage MCP server access with custom MCP registry <a href="#mcp-server-access-for-your-organization"><br>Show more</a></td>
+    <td>プランエージェントで複雑なコーディングタスクを計画し、バックグラウンドエージェント全体のエージェントセッションを監視します <a href="#agents"><br>詳細を表示</a></td>
+    <td>差分エディターで削除されたコードからテキストを選択します <a href="#code-editing"><br>詳細を表示</a></td>
+    <td>カスタム MCP レジストリで MCP サーバーアクセスを管理します <a href="#mcp-server-access-for-your-organization"><br>詳細を表示</a></td>
   </tr>
   <tr>
-    <td>Inline suggestions are now open source <a href="#inline-suggestions-are-open-source"><br>Show more</a></td>
-    <td>Experience the more modern, refreshed product icons <a href="#editor-experience"><br>Show more</a></td>
-    <td>Manage Linux devices with JSON policies <a href="#linux-policy-support"><br>Show more</a></td>
+    <td>インラインサジェストがオープンソースになりました <a href="#inline-suggestions-are-open-source"><br>詳細を表示</a></td>
+    <td>よりモダンで刷新された製品アイコンを体験してください <a href="#editor-experience"><br>詳細を表示</a></td>
+    <td>JSON ポリシーで Linux デバイスを管理します <a href="#linux-policy-support"><br>詳細を表示</a></td>
   </tr>
 </table>
 -->
 
 <br>
 
->If you'd like to read these release notes online, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+>これらのリリースノートをオンラインで読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。<br>
 
-> **Insiders: Want to try new features as soon as possible?**<br>
-> You can download the nightly Insiders build and try the latest updates as soon as they are available.<br>
+> **Insiders: 新機能をいち早く試したいですか？**<br>
+> 夜間の Insiders ビルドをダウンロードして、利用可能になり次第、最新のアップデートを試すことができます。<br>
 > [Download Insiders](https://code.visualstudio.com/insiders)<br>
 
 <!-- TOC
 <div class="toc-nav-layout">
   <nav id="toc-nav">
-    <div>In this update</div>
+    <div>このアップデートの内容</div>
     <ul>
-      <li><a href="#agents">Agents</a></li>
-      <li><a href="#code-editing">Code Editing</a></li>
-      <li><a href="#editor-experience">Editor Experience</a></li>
-      <li><a href="#chat">Chat</a></li>
+      <li><a href="#agents">エージェント</a></li>
+      <li><a href="#code-editing">コード編集</a></li>
+      <li><a href="#editor-experience">エディター体験</a></li>
+      <li><a href="#chat">チャット</a></li>
       <li><a href="#mcp">MCP</a></li>
-      <li><a href="#accessibility">Accessibility</a></li>
+      <li><a href="#accessibility">アクセシビリティ</a></li>
       <li><a href="#notebooks">Notebooks</a></li>
-      <li><a href="#source-control">Source Control</a></li>
-      <li><a href="#debugging">Debugging</a></li>
-      <li><a href="#tasks">Tasks</a></li>
-      <li><a href="#terminal">Terminal</a></li>
-      <li><a href="#authentication">Authentication</a></li>
-      <li><a href="#languages">Languages</a></li>
-      <li><a href="#remote-development">Remote Development</a></li>
-      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
-      <li><a href="#extension-authoring">Extension Authoring</a></li>
-      <li><a href="#proposed-apis">Proposed APIs</a></li>
-      <li><a href="#engineering">Engineering</a></li>
-      <li><a href="#notable-fixes">Notable fixes</a></li>
-      <li><a href="#thank-you">Thank you</a></li>
+      <li><a href="#source-control">ソース管理</a></li>
+      <li><a href="#debugging">デバッグ</a></li>
+      <li><a href="#tasks">タスク</a></li>
+      <li><a href="#terminal">ターミナル</a></li>
+      <li><a href="#authentication">認証</a></li>
+      <li><a href="#languages">言語</a></li>
+      <li><a href="#remote-development">リモート開発</a></li>
+      <li><a href="#contributions-to-extensions">拡張機能への貢献</a></li>
+      <li><a href="#extension-authoring">拡張機能のオーサリング</a></li>
+      <li><a href="#proposed-apis">提案中の API</a></li>
+      <li><a href="#engineering">エンジニアリング</a></li>
+      <li><a href="#notable-fixes">注目すべき修正</a></li>
+      <li><a href="#thank-you">謝辞</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
-## Agents {#agents}
+## エージェント {#agents}
 
-### Agent Sessions view {#agent-sessions-view}
+### エージェントセッションビュー {#agent-sessions-view}
 
-**Setting**: `setting(chat.agentSessionsViewLocation)`
+**設定**: `setting(chat.agentSessionsViewLocation)`
 
-As you hand off tasks to various coding agents, it's important to have a clear overview of all your active sessions. The Agent Sessions view provides a centralized location for managing your active chat sessions. This includes both local sessions in VS Code and sessions created by background agents in other environments, such as [Copilot coding agent](https://code.visualstudio.com/docs/copilot/copilot-coding-agent), [GitHub Copilot CLI](https://github.com/features/copilot/cli/), or [OpenAI's Codex](https://marketplace.visualstudio.com/items?itemName=OpenAI.chatgpt). The Agent Sessions view is now enabled by default, and can be managed via the `setting(chat.agentSessionsViewLocation)` setting.
+さまざまなコーディングエージェントにタスクを渡す際には、すべてのアクティブなセッションの明確な概要を把握することが重要です。エージェントセッションビューは、アクティブなチャットセッションを管理するための一元的な場所を提供します。これには、VS Code のローカルセッションと、[Copilot コーディングエージェント](https://code.visualstudio.com/docs/copilot/copilot-coding-agent)、[GitHub Copilot CLI](https://github.com/features/copilot/cli/)、または [OpenAI's Codex](https://marketplace.visualstudio.com/items?itemName=OpenAI.chatgpt) などの他の環境のバックグラウンドエージェントによって作成されたセッションが含まれます。エージェントセッションビューはデフォルトで有効になり、`setting(chat.agentSessionsViewLocation)` 設定で管理できます。
 
-By default, the Agent Sessions view lists all your active chat sessions organized by their source. The view is divided into sections for local chat sessions in VS Code and for background agent sessions:
+デフォルトでは、エージェントセッションビューには、ソースごとに整理されたすべてのアクティブなチャットセッションが一覧表示されます。ビューは、VS Code のローカルチャットセッションとバックグラウンドエージェントセッションのセクションに分かれています:
 
-![Screenshot of the Agent Sessions view in the Primary Side Bar, showing a view for local chat sessions, and coding agents like Copilot coding agent, Copilot CLI and Codex.](https://code.visualstudio.com/assets/updates/1_106/agent-sessions-view.png)
+![プライマリサイドバーのエージェントセッションビューのスクリーンショット。ローカルチャットセッションのビューと、Copilot コーディングエージェント、Copilot CLI、Codex などのコーディングエージェントが表示されています。](https://code.visualstudio.com/assets/updates/1_106/agent-sessions-view.png)
 
-If you prefer to have one consolidated view of your sessions across all providers, you can enable the `single-view` option for the `setting(chat.agentSessionsViewLocation)` setting. This option also moves the Agent Sessions view next to the Chat view in the Secondary Side Bar, making it easier to switch between chat and managing your sessions.
+すべてのプロバイダーにわたるセッションを 1 つの統合ビューで表示したい場合は、`setting(chat.agentSessionsViewLocation)` 設定の `single-view` オプションを有効にできます。このオプションは、エージェントセッションビューをセカンダリサイドバーのチャットビューの隣に移動させ、チャットとセッション管理の切り替えを容易にします。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/agent-sessions.mp4" title="Video showing new agent sessions view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/agent-sessions.mp4" title="新しいエージェントセッションビューを示す動画。" autoplay loop controls muted></video>
 
-Note that not all functionality is available in the consolidated view yet. We are actively working on making this view the default in the near future.
+統合ビューではまだすべての機能が利用できるわけではないことに注意してください。近い将来、このビューをデフォルトにするために積極的に取り組んでいます。
 
-The Agent Sessions view now also supports search (`kb(list.find)`) to help you easily find your sessions in the list.
+エージェントセッションビューは、リスト内のセッションを簡単に見つけるのに役立つ検索 (`kb(list.find)`) もサポートするようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/sessionsPaneSearch.mp4" title="Video showing search in the Agent Sessions view to find sessions that match your query." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/sessionsPaneSearch.mp4" title="エージェントセッションビューでの検索を示し、クエリに一致するセッションを見つける動画。" autoplay loop controls muted></video>
 
-Learn more about the [Agent Sessions view](https://code.visualstudio.com/docs/copilot/chat/chat-sessions/#_agent-sessions-view) in the VS Code documentation.
+VS Code ドキュメントの[エージェントセッションビュー](https://code.visualstudio.com/docs/copilot/chat/chat-sessions/#_agent-sessions-view)について詳しく学んでください。
 
-### Plan agent {#plan-agent}
+### プランエージェント {#plan-agent}
 
-A new plan agent helps developers break down complex tasks step-by-step before any code is written. Select **Plan** from the agents dropdown in the Chat view to get started. When tackling a multi-step implementation, VS Code prompts you with clarifying questions and generates a detailed implementation plan that you approve first, ensuring all requirements and context are captured upfront.
+新しいプランエージェントは、コードが書かれる前に、開発者が複雑なタスクを段階的に分解するのに役立ちます。チャットビューのエージェントドロップダウンから **Plan** を選択して開始します。複数ステップの実装に取り組む際、VS Code は明確化のための質問を促し、最初に承認する詳細な実装計画を生成し、すべての要件とコンテキストが事前に把握されるようにします。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/plan-mode.mp4" title="Video showing the plan agent in action." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/plan-mode.mp4" title="プランエージェントの動作を示す動画。" autoplay loop controls muted></video>
 
-We recommend spending time iterating on the plan before implementation. You can refine requirements, adjust scope, and address open questions multiple times to build a solid foundation. Once you approve the plan, Copilot implements it either locally in VS Code or via [cloud agents](https://code.visualstudio.com/docs/copilot/copilot-coding-agent), giving you greater control and visibility into the development process. This helps you catch gaps or missing decisions early, reducing rework and improving code quality.
+実装の前に、計画の反復に時間を費やすことをお勧めします。要件を洗練させ、スコープを調整し、未解決の質問に複数回対処して、強固な基盤を構築できます。計画を承認すると、Copilot は VS Code でローカルに、または[クラウドエージェント](https://code.visualstudio.com/docs/copilot/copilot-coding-agent)を介してそれを実装し、開発プロセスに対するより大きな制御と可視性を提供します。これにより、ギャップや欠落している決定を早期に発見し、手戻りを減らし、コードの品質を向上させることができます。
 
-You can also create your own custom plan agent tailored to your team's specific workflow and tools. Use the **Configure Custom Agent** menu to copy the built-in plan agent as a starting point, then customize the planning style, tools, and prompts to match your development process. Learn more about [planning in VS Code chat](https://code.visualstudio.com/docs/copilot/chat/chat-planning) and [creating custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents).
+また、チーム固有のワークフローやツールに合わせてカスタマイズされた独自のカスタムプランエージェントを作成することもできます。**Configure Custom Agent** メニューを使用して、組み込みのプランエージェントを開始点としてコピーし、計画スタイル、ツール、プロンプトを開発プロセスに合わせてカスタマイズします。[VS Code チャットでの計画](https://code.visualstudio.com/docs/copilot/chat/chat-planning)と[カスタムエージェントの作成](https://code.visualstudio.com/docs/copilot/customization/custom-agents)について詳しく学んでください。
 
-### Cloud agents {#cloud-agents}
+### クラウドエージェント {#cloud-agents}
 
-In this release, we have made quite a few updates to cloud agent sessions in the editor.
+このリリースでは、エディター内のクラウドエージェントセッションにかなりの数の更新を行いました。
 
-We migrated the Copilot coding agent integration from the GitHub Pull Request extension into the Copilot Chat extension to provide a more native cloud agent experience in VS Code. This integration paves the way for smoother transitions and interactions between VS Code and [GitHub Mission Control](https://github.com/copilot/agents), such as opening a cloud agent session directly from the Agent Sessions view in the browser and vice versa.
+GitHub Pull Request 拡張機能から Copilot Chat 拡張機能に Copilot コーディングエージェントの統合を移行し、VS Code でよりネイティブなクラウドエージェント体験を提供しました。この統合は、VS Code と [GitHub Mission Control](https://github.com/copilot/agents) の間のよりスムーズな移行と相互作用への道を開きます。たとえば、ブラウザーのエージェントセッションビューから直接クラウドエージェントセッションを開いたり、その逆を行ったりすることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/deeplink.mp4" title="Video showing GitHub Mission Control integration with VS Code." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/deeplink.mp4" title="VS Code との GitHub Mission Control 統合を示す動画。" autoplay loop controls muted></video>
 
-### CLI agents {#cli-agents}
+### CLI エージェント {#cli-agents}
 
-In this release, we have also shipped an initial integration with the [Copilot CLI](https://github.com/features/copilot/cli/). You can create new and resume existing CLI agent sessions in a chat editor or an integrated terminal.
+このリリースでは、[Copilot CLI](https://github.com/features/copilot/cli/) との初期統合も出荷しました。チャットエディターまたは統合ターミナルで、新しい CLI エージェントセッションを作成したり、既存のセッションを再開したりできます。
 
-![Screenshot of the CLI dropdown menu showing options to create a new CLI agent session or resume an existing one.](https://code.visualstudio.com/assets/updates/1_106/cli-dropdown.png)
+![新しい CLI エージェントセッションを作成するか、既存のセッションを再開するオプションを示す CLI ドロップダウンメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/cli-dropdown.png)
 
-In a CLI agent editor, you can send messages to the Copilot CLI just as you would in a terminal, switch models, and attach context.
+CLI エージェントエディターでは、ターミナルで行うのと同じように Copilot CLI にメッセージを送信したり、モデルを切り替えたり、コンテキストを添付したりできます。
 
-![Screenshot showing a CLI agent editor and an integrated terminal with Copilot CLI sessions.](https://code.visualstudio.com/assets/updates/1_106/cli-editor-and-terminal.png)
+![CLI エージェントエディターと Copilot CLI セッションを持つ統合ターミナルを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/cli-editor-and-terminal.png)
 
-### Agent delegation {#agent-delegation}
+### エージェントの委任 {#agent-delegation}
 
-We continue to improve the experience for delegating to cloud agents.
+クラウドエージェントへの委任体験を引き続き改善しています。
 
-When you use the cloud button to delegate to an agent from the chat panel, you'll be provided a set of available agents to which you can delegate. You can also delegate to the Copilot coding agent from the CLI, via the `/delegate` command in a CLI editor or terminal instance.
+チャットパネルからクラウドボタンを使用してエージェントに委任すると、委任可能な利用可能なエージェントのセットが提供されます。CLI から Copilot コーディングエージェントに委任することもできます。これは、CLI エディターまたはターミナルインスタンスで `/delegate` コマンドを介して行います。
 
-![Screenshot showing delegating from a CLI agent editor.](https://code.visualstudio.com/assets/updates/1_106/cli-delegate-editor.png)
+![CLI エージェントエディターからの委任を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/cli-delegate-editor.png)
 
-### CLI agent edit tracking {#cli-agent-edit-tracking}
+### CLI エージェントの編集追跡 {#cli-agent-edit-tracking}
 
-Chat edit sessions now track edits made by background agents, such as the Copilot CLI. When you create sessions from the Agent Sessions view, you can see edits tracked through both inline edit pills and the working set view, making it easier to understand what changes agents are making to your workspace.
+チャット編集セッションは、Copilot CLI などのバックグラウンドエージェントによって行われた編集を追跡するようになりました。エージェントセッションビューからセッションを作成すると、インライン編集ピルとワーキングセットビューの両方を通じて追跡された編集を確認でき、エージェントがワークスペースにどのような変更を加えているかを理解しやすくなります。
 
-### Chat modes renamed to custom agents {#chat-modes-renamed-to-custom-agents}
+### チャットモードがカスタムエージェントに改名 {#chat-modes-renamed-to-custom-agents}
 
-Chat modes have been renamed to custom agents throughout VS Code to better align with terminology used in other environments.
+他の環境で使用される用語とよりよく整合させるため、VS Code 全体でチャットモードはカスタムエージェントに改名されました。
 
-![Screenshot of the agent picker control.](https://code.visualstudio.com/assets/updates/1_106/agent-picker.png)
+![エージェントピッカーコントロールのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/agent-picker.png)
 
-When you create custom agents, the definition files are now located in `.github/agents` in your workspace. These files can use the `.agents.md` suffix and can also be used as Github Copilot Cloud Agents and CLI Agent.
+カスタムエージェントを作成すると、定義ファイルはワークスペースの `.github/agents` に配置されるようになりました。これらのファイルは `.agents.md` サフィックスを使用でき、GitHub Copilot クラウドエージェントおよび CLI エージェントとしても使用できます。
 
-Use **Chat: New Custom Agent...** to create a new agent and **Chat: Configure Custom Agents...** to manage them.
+新しいエージェントを作成するには **Chat: New Custom Agent...** を、それらを管理するには **Chat: Configure Custom Agents...** を使用します。
 
-If you have existing custom chat modes (`.chatmode.md` files in `.github/chatmodes`), they continue to work and are automatically treated as custom agents. When you open a chat agent file in the editor, a info marker appears on the first line with a quick fix to migrate it to a custom agent file.
+既存のカスタムチャットモード (`.github/chatmodes` 内の `.chatmode.md` ファイル) がある場合、それらは引き続き機能し、自動的にカスタムエージェントとして扱われます。エディターでチャットエージェントファイルを開くと、最初の行に情報マーカーが表示され、カスタムエージェントファイルに移行するためのクイックフィックスが表示されます。
 
-### Custom agent metadata {#custom-agent-metadata}
+### カスタムエージェントのメタデータ {#custom-agent-metadata}
 
-Custom agent `.agent.md` files now accept an additional `target` frontmatter property to describe how an agent should run across environments:
+カスタムエージェントの `.agent.md` ファイルは、エージェントが環境間でどのように実行されるべきかを記述するための追加の `target` frontmatter プロパティを受け入れるようになりました:
 
-* `target: vscode`: optimizes the agent for local chat and unlocks `name`, `description`, `argument-hint`, `model`, `tools`, and `handoffs` properties. Any tool installed in VS Code can be used.
-* `target: github-copilot`: prepares the agent for Copilot cloud agents or the GitHub CLI with support for `name`, `description`, `tools`, `mcp-servers`, and `target`. Tools can be `edit`, `search`, `shell`, `custom-agent`, and tools from MCP servers
+* `target: vscode`: エージェントをローカルチャット用に最適化し、`name`、`description`、`argument-hint`、`model`、`tools`、`handoffs` プロパティをアンロックします。VS Code にインストールされている任意のツールを使用できます。
+* `target: github-copilot`: エージェントを Copilot クラウドエージェントまたは GitHub CLI 用に準備し、`name`、`description`、`tools`、`mcp-servers`、`target` をサポートします。ツールは `edit`、`search`、`shell`、`custom-agent`、および MCP サーバーからのツールにすることができます。
 
-All agents can be run in all environments. Each environment ignores unknown attributes and tools.
+すべてのエージェントはすべての環境で実行できます。各環境は不明な属性とツールを無視します。
 
-* `name`: lets you override the agent label without renaming the file.
-* `argument-hint`: surfaces guidance in the chat input so teammates know how to prompt the agent.
-* `handoffs`: wires guided transitions to other agents, letting you chain multi-step workflows.
+* `name`: ファイル名を変更せずにエージェントのラベルを上書きできます。
+* `argument-hint`: チャット入力にガイダンスを表示し、チームメイトがエージェントにどのようにプロンプトを出すかを知ることができます。
+* `handoffs`: 他のエージェントへのガイド付き移行を接続し、複数ステップのワークフローを連鎖させることができます。
 
-The agent file editor provides validation, code completions, hovers and code actions.
+エージェントファイルエディターは、検証、コード補完、ホバー、およびコードアクションを提供します。
 
-![GIF of validation while editing custom agent files.](https://code.visualstudio.com/assets/updates/1_106/agent-file-editing.gif)
+![カスタムエージェントファイルの編集中に検証が行われる GIF。](https://code.visualstudio.com/assets/updates/1_106/agent-file-editing.gif)
 
-Learn more about [custom agents and agent handoffs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
+ドキュメントで[カスタムエージェントとエージェントのハンドオフ](https://code.visualstudio.com/docs/copilot/customization/custom-agents)について詳しく学んでください。
 
-## Code Editing {#code-editing}
+## コード編集 {#code-editing}
 
-### Deleted code in diff editor is now selectable {#deleted-code-in-diff-editor-is-now-selectable}
+### 差分エディターの削除されたコードが選択可能に {#deleted-code-in-diff-editor-is-now-selectable}
 
-Previously, when you deleted code and viewed the changes in the diff editor, you couldn't copy those deleted lines. In this release, you can now select and copy text from deleted lines in the diff editor when using the inline diff view.
+以前は、コードを削除して差分エディターで変更を表示したとき、それらの削除された行をコピーすることはできませんでした。このリリースでは、インライン差分ビューを使用している場合、差分エディターで削除された行からテキストを選択してコピーできるようになりました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/diff-editor-select-deleted-lines-text.mp4" title="Video showing selecting text in deleted lines in the diff editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/diff-editor-select-deleted-lines-text.mp4" title="差分エディターで削除された行のテキストを選択する様子を示す動画。" autoplay loop controls muted></video>
 
-### Inline suggestions are open source {#inline-suggestions-are-open-source}
+### インラインサジェストがオープンソースに {#inline-suggestions-are-open-source}
 
-This release continues our journey to make VS Code an open source AI editor. Following our first milestone of open sourcing GitHub Copilot Chat, we've now open sourced inline suggestions by merging them into the vscode-copilot-chat repository.
+このリリースは、VS Code をオープンソースの AI エディターにするための私たちの旅を続けます。GitHub Copilot Chat をオープンソース化するという最初のマイルストーンに続き、インラインサジェストを vscode-copilot-chat リポジトリにマージすることでオープンソース化しました。
 
-As part of this milestone, we're consolidating the GitHub Copilot extension and GitHub Copilot Chat extension into a single extension experience. The Chat extension now serves all inline suggestions, providing the same intelligent code suggestions you're used to while maintaining all chat and agent functionality. The change should be transparent, you'll continue getting the same code suggestions as you type. If you encounter any issues, you can temporarily revert using the `setting(chat.extensionUnification.enabled)` setting.
+このマイルストーンの一環として、GitHub Copilot 拡張機能と GitHub Copilot Chat 拡張機能を単一の拡張機能体験に統合しています。Chat 拡張機能はすべてのインラインサジェストを提供するようになり、すべてのチャットおよびエージェント機能を維持しながら、慣れ親しんだインテリジェントなコードサジェストを提供します。この変更は透過的であるべきで、入力中に同じコードサジェストを引き続き受け取ることができます。問題が発生した場合は、`setting(chat.extensionUnification.enabled)` 設定を使用して一時的に元に戻すことができます。
 
-The GitHub Copilot extension will be deprecated by early 2026. Learn more about this milestone and explore the open source code in our [blog post](https://code.visualstudio.com/blogs/2025/11/04/openSourceAIEditorSecondMilestone).
+GitHub Copilot 拡張機能は 2026 年初頭までに非推奨となります。このマイルストーンの詳細については、[ブログ投稿](https://code.visualstudio.com/blogs/2025/11/04/openSourceAIEditorSecondMilestone)でオープンソースコードを探索してください。
 
-### Snooze inline suggestions from gutter {#snooze-inline-suggestions-from-gutter}
+### ガターからインラインサジェストをスヌーズ {#snooze-inline-suggestions-from-gutter}
 
-You can now snooze inline suggestions directly from the gutter icon. When you hover over the gutter icon, a control appears with a **Snooze** option. Select it and choose a duration to pause suggestions.
+ガターアイコンから直接インラインサジェストをスヌーズできるようになりました。ガターアイコンにホバーすると、**Snooze** オプション付きのコントロールが表示されます。それを選択し、サジェストを一時停止する期間を選択します。
 
-![Screenshot showing the Snooze button in the gutter context menu for inline suggestions.](https://code.visualstudio.com/assets/updates/1_106/nes-snooze.png)
+![インラインサジェストのガターコンテキストメニューにあるスヌーズボタンのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/nes-snooze.png)
 
-### Go to line improvements {#go-to-line-improvements}
+### Go to Line の改善 {#go-to-line-improvements}
 
-This iteration, we've made several enhancements to the **Go to Line** command (`kb(workbench.action.gotoLine)`), improving navigation within files.
+このイテレーションでは、**Go to Line** コマンド (`kb(workbench.action.gotoLine)`) にいくつかの機能強化を行い、ファイル内のナビゲーションを改善しました。
 
-The **Go to Line** command now supports navigating to a specific character position in a file by using the `::` syntax. This is useful when tools report errors at specific character offsets, such as "error at position 599".
+**Go to Line** コマンドは、`::` 構文を使用してファイル内の特定の文字位置に移動することをサポートするようになりました。これは、ツールが「error at position 599」のように特定の文字オフセットでエラーを報告する場合に便利です。
 
-To navigate to a character offset, type `::` followed by the character number in the **Go to Line** input box. For example:
+文字オフセットに移動するには、**Go to Line** 入力ボックスに `::` に続けて文字番号を入力します。例:
 
-* `::599` - Navigate to character 599 in the file
-* `::-100` - Navigate 100 characters from the end of the file
+* `::599` - ファイル内の文字 599 に移動
+* `::-100` - ファイルの末尾から 100 文字前に移動
 
-Use the toggle in the input box to switch between 1-based (default) and 0-based offset calculations.
+入力ボックスのトグルを使用して、1 ベース (デフォルト) と 0 ベースのオフセット計算を切り替えます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/go-to-line.mp4" title="Video showing editor navigation using Go To Line command." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/go-to-line.mp4" title="Go To Line コマンドを使用したエディターナビゲーションを示す動画。" autoplay loop controls muted></video>
 
-In addition, the **Go to Line** command also handles out-of-range values more gracefully and makes it easier to navigate to the start or end of files and lines:
+さらに、**Go to Line** コマンドは、範囲外の値をより適切に処理し、ファイルや行の先頭または末尾への移動を容易にします:
 
-* **Line numbers**: Typing a line number larger than the file's line count navigates to the last line.
-* **Column numbers**: Using negative column numbers navigates from the end of a line. For example, `:12:-1` takes you to the last character on line 12. Typing a column number larger than the length of the line takes you to the end of the line.
+* **行番号**: ファイルの行数より大きい行番号を入力すると、最終行に移動します。
+* **列番号**: 負の列番号を使用すると、行の末尾から移動します。たとえば、`:12:-1` は 12 行目の最後の文字に移動します。行の長さより大きい列番号を入力すると、行の末尾に移動します。
 
-## Editor Experience {#editor-experience}
+## エディター体験 {#editor-experience}
 
-### Refreshed iconography {#refreshed-iconography}
+### 刷新されたアイコン {#refreshed-iconography}
 
-In this release, the codicon icon set has had a facelift. The new icons have been refined with curves, new modifier designs, and more accurate metaphors to make them feel modern, friendly and more legible.
+このリリースでは、codicon アイコンセットが刷新されました。新しいアイコンは、曲線、新しい修飾子のデザイン、より正確なメタファーで洗練され、モダンで親しみやすく、より読みやすくなりました。
 
-![Screenshot of updated product icons showing a more modern appearance and increased legibility.](https://code.visualstudio.com/assets/updates/1_106/refreshed-iconography.png)
+![更新された製品アイコンのスクリーンショット。よりモダンな外観と向上した可読性を示しています。](https://code.visualstudio.com/assets/updates/1_106/refreshed-iconography.png)
 
-### Linux policy support {#linux-policy-support}
+### Linux ポリシーのサポート {#linux-policy-support}
 
-We've introduced support for managing VS Code policies on Linux systems using JSON files. This allows administrators to enforce specific settings and configurations across all users on a Linux machine.
+JSON ファイルを使用して Linux システム上の VS Code ポリシーを管理するためのサポートを導入しました。これにより、管理者は Linux マシン上のすべてのユーザーに対して特定の設定と構成を強制できます。
 
-For more details, see [JSON Policies on Linux](https://code.visualstudio.com/docs/setup/enterprise#_json-policies-on-linux).
+詳細については、[Linux での JSON ポリシー](https://code.visualstudio.com/docs/setup/enterprise#_json-policies-on-linux)を参照してください。
 
-### Navigate changes in multi file diff editor {#navigate-changes-in-multi-file-diff-editor}
+### 複数ファイル差分エディターでの変更のナビゲート {#navigate-changes-in-multi-file-diff-editor}
 
-Just like you can navigate to next or previous changes in a diff editor for a single file, you can now do so across files in the multi-file diff editor. Use keybindings or the navigation up and down arrow keys to review your changes across files.
+単一ファイルの差分エディターで次または前の変更にナビゲートできるように、複数ファイル差分エディターでもファイル間でナビゲートできるようになりました。キーバインディングまたはナビゲーションの上下矢印キーを使用して、ファイル間の変更を確認します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/multiFileDiffNav.mp4" title="Video showing navigating changes in multi-file diff editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/multiFileDiffNav.mp4" title="複数ファイル差分エディターでの変更のナビゲートを示す動画。" autoplay loop controls muted></video>
 
-### Copy diagnostic hover text {#copy-diagnostic-hover-text}
+### 診断ホバーテキストのコピー {#copy-diagnostic-hover-text}
 
-A copy button now appears in diagnostic hovers (errors, warnings, info, and hints) to make copying error messages easier. When you hover over a diagnostic marker, move your mouse over the hover message to reveal a copy button in the top-right corner.
+診断ホバー (エラー、警告、情報、ヒント) にコピーボタンが表示されるようになり、エラーメッセージのコピーが容易になりました。診断マーカーにホバーし、マウスをホバーメッセージの上に移動すると、右上にコピーボタンが表示されます。
 
-![Screenshot of hovering over a diagnostic hover revealing a copy button in the top-right corner.](https://code.visualstudio.com/assets/updates/1_106/hover-copy-button.png)
+![診断ホバーにホバーすると右上にコピーボタンが表示されるスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/hover-copy-button.png)
 
-### Accent-insensitive command filtering {#accentinsensitive-command-filtering}
+### アクセントを無視したコマンドフィルタリング {#accentinsensitive-command-filtering}
 
-The Command Palette now ignores character accents when searching for commands, making it easier to find what you need regardless of your keyboard layout or language preferences. For example, when searching for a command containing the word `Générer` (French for `Generate`), type `generer` without accents and matching commands appear in the results.
+コマンドパレットは、コマンドを検索する際に文字のアクセントを無視するようになり、キーボードレイアウトや言語設定に関係なく必要なものを見つけやすくなりました。たとえば、`Générer` (フランス語で `Generate`) という単語を含むコマンドを検索する場合、アクセントなしで `generer` と入力すると、一致するコマンドが結果に表示されます。
 
-This is helpful when using different keyboard layouts or when mistyping while looking for a command. The filtering is based on [Unicode Normalization Form D](https://www.unicode.org/reports/tr15/#Norm_Forms) and supports all Unicode languages.
+これは、異なるキーボードレイアウトを使用している場合や、コマンドを探しているときにタイプミスをした場合に役立ちます。フィルタリングは [Unicode 正規化形式 D](https://www.unicode.org/reports/tr15/#Norm_Forms) に基づいており、すべての Unicode 言語をサポートしています。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/filtering.mp4" title="Video showing filtering in Command Palette." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/filtering.mp4" title="コマンドパレットでのフィルタリングを示す動画。" autoplay loop controls muted></video>
 
-### Advanced VS Code settings {#advanced-vs-code-settings}
+### 高度な VS Code 設定 {#advanced-vs-code-settings}
 
-VS Code now supports the concept of advanced settings. These settings are meant for configuring specialized scenarios and are intended for advanced users who need fine-grained control over their environment. By default, advanced settings are hidden in the Settings editor, keeping the interface streamlined while making these powerful options available when needed.
+VS Code は、高度な設定の概念をサポートするようになりました。これらの設定は、特殊なシナリオを構成するためのものであり、環境を細かく制御する必要がある上級ユーザーを対象としています。デフォルトでは、高度な設定は設定エディターで非表示になっており、インターフェイスを合理化しながら、必要なときにこれらの強力なオプションを利用できるようにしています。
 
-To view and configure advanced settings, select **Advanced** from the filter dropdown menu in the Settings editor, or type `@tag:advanced` in the search box:
+高度な設定を表示および構成するには、設定エディターのフィルタードロップダウンメニューから **Advanced** を選択するか、検索ボックスに `@tag:advanced` と入力します:
 
-![Screenshot showing the Settings editor with the Advanced filter applied, displaying advanced settings with the Advanced tag badge](https://code.visualstudio.com/assets/updates/1_106/advanced-settings.png)
+![Advanced フィルターが適用された設定エディターのスクリーンショット。Advanced タグバッジ付きの高度な設定が表示されています。](https://code.visualstudio.com/assets/updates/1_106/advanced-settings.png)
 
-When you search for a specific setting by its exact name or use the `@id:` filter, advanced settings appear in the results without having to apply the **Advanced** filter. This ensures you can always find the settings you're looking for.
+特定の設定を正確な名前で検索したり、`@id:` フィルターを使用したりすると、**Advanced** フィルターを適用しなくても高度な設定が結果に表示されます。これにより、探している設定をいつでも見つけることができます。
 
-Advanced settings can be combined with other filters such as `@modified` or `@feature:` to help you find exactly what you need. For example, `@tag:advanced @feature:terminal` shows only advanced settings related to the terminal.
+高度な設定は、`@modified` や `@feature:` などの他のフィルターと組み合わせて、必要なものを正確に見つけるのに役立ちます。たとえば、`@tag:advanced @feature:terminal` は、ターミナルに関連する高度な設定のみを表示します。
 
->**Note:** Extension authors can mark their settings as advanced by adding the `advanced` tag to the setting configuration.
+>**注:** 拡張機能の作成者は、設定構成に `advanced` タグを追加することで、設定を高度なものとしてマークできます。
 
-## Chat {#chat}
+## チャット {#chat}
 
-### Embeddings-based tool selection {#embeddingsbased-tool-selection}
+### 埋め込みベースのツール選択 {#embeddingsbased-tool-selection}
 
-In this release we've significantly improved how we filter and group tools for users that have many (over 100) tools enabled in chat. You should see the "Optimizing tool selection..." loading state less often and for a shorter period of time. We also improved tool selection with a lower probability of agent confusion to make sure the right tools are chosen.
+このリリースでは、チャットで多数 (100 以上) のツールを有効にしているユーザー向けに、ツールのフィルタリングとグループ化の方法を大幅に改善しました。「Optimizing tool selection...」の読み込み状態が表示される頻度が減り、時間も短縮されるはずです。また、エージェントの混乱の可能性を低くして、適切なツールが選択されるようにツール選択を改善しました。
 
-### Tool approvals and trust {#tool-approvals-and-trust}
+### ツールの承認と信頼 {#tool-approvals-and-trust}
 
-#### Post-approval for external data {#postapproval-for-external-data}
+#### 外部データの事後承認 {#postapproval-for-external-data}
 
-Agent tools that pull in external data now support post-approval. This helps protect against potential prompt injection attacks by letting you review the data before it's used in your chat session.
+外部データを取得するエージェントツールが事後承認をサポートするようになりました。これにより、チャットセッションで使用される前にデータを確認できるため、潜在的なプロンプトインジェクション攻撃から保護するのに役立ちます。
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/post-approval.mp4" autoplay loop controls muted></video>
 
-Post-approval is enabled for the `#fetch` tool and for Model Context Protocol (MCP) tools that declare `openWorldHint`.
+事後承認は、`#fetch` ツールと `openWorldHint` を宣言する Model Context Protocol (MCP) ツールで有効になります。
 
-#### Trust all tools for a server or extension {#trust-all-tools-for-a-server-or-extension}
+#### サーバーまたは拡張機能のすべてのツールを信頼する {#trust-all-tools-for-a-server-or-extension}
 
-You can now trust MCP servers and extension tools at the source level through the **Allow** button dropdown. This means that you can approve all tools from a specific MCP server or extension at once, rather than having to approve each tool individually.
+**Allow** ボタンドロップダウンを介して、ソースレベルで MCP サーバーと拡張機能ツールを信頼できるようになりました。これにより、各ツールを個別に承認する必要なく、特定の MCP サーバーまたは拡張機能のすべてのツールを一度に承認できます。
 
-We have also updated the **Chat: Manage Tool Approval** command experience to let you manage both pre- and post-approval of tools.
+また、**Chat: Manage Tool Approval** コマンドエクスペリエンスを更新し、ツールの事前承認と事後承認の両方を管理できるようにしました。
 
-![Screenshot of the Manage Tool Approval command experience, enabling tools to skip approval and skipping content review.](https://code.visualstudio.com/assets/updates/1_106/manage-tool-approvals.png)
+![ツール承認管理コマンドエクスペリエンスのスクリーンショット。ツールの承認をスキップし、コンテンツレビューをスキップできます。](https://code.visualstudio.com/assets/updates/1_106/manage-tool-approvals.png)
 
-#### Tool auto approval status moved {#tool-auto-approval-status-moved}
+#### ツールの自動承認ステータスが移動 {#tool-auto-approval-status-moved}
 
-Auto approval status has moved from being inline inside the chat view to the tool call status/tick icon:
+自動承認ステータスは、チャットビュー内のインラインからツールコールステータス/チェックアイコンに移動しました:
 
-![Screenshot of hovering a tool's tick icon will reveal why it was auto approved](https://code.visualstudio.com/assets/updates/1_106/tool-auto-approve-hover.png)
+![ツールのチェックアイコンにホバーすると、なぜ自動承認されたかが表示されるスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/tool-auto-approve-hover.png)
 
-### Terminal tool {#terminal-tool}
+### ターミナルツール {#terminal-tool}
 
-#### Auto approve parser improvements {#auto-approve-parser-improvements}
+#### 自動承認パーサーの改善 {#auto-approve-parser-improvements}
 
-Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned paranthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
+以前は、ターミナルツールでのサブコマンド検出は、`|` や `&&` などの特定の文字列で分割するという単純なアプローチを使用していました。これはいくつかの点で失敗しましたが、大きなものは `echo "a|b|c"` のように文字列内でパイプが使用された場合で、サブコマンド `echo`、`b`、`c"` を検出してしまいました。もう 1 つの重要な点は、サブコマンドを確実に抽出できなかったため、より安全を期して偶発的な実行を防ぐために、括弧のペア、中括弧のペア、バッククォートを完全に禁止していたことです。
 
-This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter/) into the feature and use a [PowerShell grammar](https://github.com/airbus-cert/tree-sitter-powershell) or a [bash grammar](https://github.com/tree-sitter/tree-sitter-bash) for everything else\*. So, even really complex cases should be correctly extracted:
+このリリースでは、[パーサー](https://tree-sitter.github.io/tree-sitter/)を機能に統合し、[PowerShell 文法](https://github.com/airbus-cert/tree-sitter-powershell)またはその他すべてに[bash 文法](https://github.com/tree-sitter/tree-sitter-bash)を使用します*。したがって、非常に複雑なケースでも正しく抽出されるはずです:
 
-![Screenshot of detecting "$()" inside echo calls.](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-parser.png)
+![echo コール内の "$()" を検出するスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-parser.png)
 
-\* _Note that this means it can fail to catch subcommands when the shell syntax differs from bash, such as `;` in zsh_
+* _これは、zsh の `;` のようにシェル構文が bash と異なる場合にサブコマンドをキャッチできない可能性があることを意味します_
 
-#### File write/redirection detection (Experimental) {#file-writeredirection-detection-experimental}
+#### ファイル書き込み/リダイレクト検出 (実験的) {#file-writeredirection-detection-experimental}
 
-Thanks to the new parser, we're able to fairly reliably extract files being written to via redirection. There's the new experimental setting `setting(chat.tools.terminal.blockDetectedFileWrites)` that will prevent auto approval conditionally.
+新しいパーサーのおかげで、リダイレクトを介して書き込まれるファイルをかなり確実に抽出できるようになりました。新しい実験的な設定 `setting(chat.tools.terminal.blockDetectedFileWrites)` があり、条件付きで自動承認を防ぎます。
 
-![Screenshot showing that writing outside the workspace by default will block auto approval.](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-redirection.png)
+![デフォルトでワークスペース外に書き込むと自動承認がブロックされることを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-redirection.png)
 
-#### Disable default auto approve rules (Experimental) {#disable-default-auto-approve-rules-experimental}
+#### デフォルトの自動承認ルールを無効にする (実験的) {#disable-default-auto-approve-rules-experimental}
 
-The new experimental setting `setting(chat.tools.terminal.ignoreDefaultAutoApproveRules)` allows disabling the default rules (both allow and deny rules). This is useful if you want more control without needing to look up the defaults.
+新しい実験的な設定 `setting(chat.tools.terminal.ignoreDefaultAutoApproveRules)` を使用すると、デフォルトのルール (許可ルールと拒否ルールの両方) を無効にできます。これは、デフォルトを調べる必要なく、より多くの制御が必要な場合に便利です。
 
-#### Shell specific prompts and command rewriting {#shell-specific-prompts-and-command-rewriting}
+#### シェル固有のプロンプトとコマンドの書き換え {#shell-specific-prompts-and-command-rewriting}
 
-The terminal tool now has shell-specific descriptions for PowerShell, bash, zsh and fish. This should make commands suggested by the agent more reliable and less likely to fail, especially for PowerShell.
+ターミナルツールは、PowerShell、bash、zsh、fish 用のシェル固有の説明を持つようになりました。これにより、エージェントによって提案されるコマンドがより信頼性が高く、失敗しにくくなるはずです。特に PowerShell の場合です。
 
-In addition to this, for PowerShell we also re-write `&&` to `;` since the `&&` chain operator is not supported in Windows PowerShell (v5). Note that this is temporarily also happening for PowerShell 7 until [vscode#274548](https://github.com/microsoft/vscode/issues/274548) is actioned.
+これに加えて、PowerShell では `&&` を `;` に書き換えます。これは、`&&` チェーン演算子が Windows PowerShell (v5) でサポートされていないためです。[vscode#274548](https://github.com/microsoft/vscode/issues/274548) が対応されるまで、これは一時的に PowerShell 7 でも発生します。
 
-#### Attach terminal commands to chat {#attach-terminal-commands-to-chat}
+#### ターミナルコマンドをチャットに添付 {#attach-terminal-commands-to-chat}
 
-You can now attach a terminal command to chat as context from the command decoration's context menu. The attachment shares the command line, captured output, and exit code so the agent understands precisely what happened. This applies to any command tracked by shell integration, making it easy to escalate troubleshooting without copying and pasting text.
+コマンドデコレーションのコンテキストメニューから、ターミナルコマンドをコンテキストとしてチャットに添付できるようになりました。添付ファイルは、コマンドライン、キャプチャされた出力、および終了コードを共有するため、エージェントは何が起こったかを正確に理解します。これは、シェル統合によって追跡されるすべてのコマンドに適用され、テキストをコピーアンドペーストすることなく、トラブルシューティングを簡単にエスカレーションできます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-attachment.mp4" title="Video showing attaching terminal commands to chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-attachment.mp4" title="ターミナルコマンドをチャットに添付する様子を示す動画。" autoplay loop controls muted></video>
 
-#### View terminal output inside chat (Experimental) {#view-terminal-output-inside-chat-experimental}
+#### チャット内でターミナル出力を表示 (実験的) {#view-terminal-output-inside-chat-experimental}
 
-The new `setting(chat.tools.terminal.outputLocation)` setting controls where the output is displayed. The default `none` value prevents the terminals from cluttering the panel.
+新しい `setting(chat.tools.terminal.outputLocation)` 設定は、出力が表示される場所を制御します。デフォルトの `none` 値は、ターミナルがパネルを乱雑にすることを防ぎます。
 
-Every chat terminal invocation now surfaces two actions on the progress element:
+すべてのチャットターミナル呼び出しは、進行状況要素に 2 つのアクションを表示するようになりました:
 
-* **Show Terminal** reveals and focuses hidden sessions, and with rich shell integration, scrolls directly to the relevant command. With basic or no shell integration, the action still focuses the correct terminal tab.
-* **Show Output** opens the terminal's final output inline within the chat view. The output view expands automatically when a command exits with a non-zero code.
+* **Show Terminal** は、非表示のセッションを表示してフォーカスし、リッチシェル統合により、関連するコマンドに直接スクロールします。基本またはシェル統合なしの場合でも、アクションは正しいターミナルタブにフォーカスします。
+* **Show Output** は、チャットビュー内でターミナルの最終出力をインラインで開きます。コマンドがゼロ以外のコードで終了すると、出力ビューは自動的に展開されます。
 
-When `npm i` fails, the output is automatically expanded. The terminal is revealed with the **Show Terminal** inline action.
+`npm i` が失敗すると、出力は自動的に展開されます。ターミナルは **Show Terminal** インラインアクションで表示されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-output.mp4" title="Video showing terminal output showing inline in the Chat view and the option to open it in the terminal." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-output.mp4" title="チャットビューにインラインで表示されるターミナル出力と、ターミナルで開くオプションを示す動画。" autoplay loop controls muted></video>
 
-#### Discover hidden chat terminals (Experimental) {#discover-hidden-chat-terminals-experimental}
+#### 非表示のチャットターミナルを発見 (実験的) {#discover-hidden-chat-terminals-experimental}
 
-When `setting(chat.tools.terminal.outputLocation):none`, a new **X hidden terminal(s)** button appears in the terminal tabs view when there is at least one hidden chat terminal. It opens a quick pick that lists each chat terminal alongside its chat session so you can immediately focus the right process. The same picker is available from the terminal overflow menu under **View Hidden Chat Terminals**, and it disappears once all chat terminals are visible again.
+`setting(chat.tools.terminal.outputLocation):none` の場合、非表示のチャットターミナルが少なくとも 1 つあると、ターミナルタブビューに新しい **X hidden terminal(s)** ボタンが表示されます。これをクリックすると、各チャットターミナルとそのチャットセッションを一覧表示するクイックピックが開き、すぐに適切なプロセスにフォーカスできます。同じピッカーは、ターミナルのオーバーフローメニューの **View Hidden Chat Terminals** からも利用でき、すべてのチャットターミナルが再び表示されると消えます。
 
-The agent runs `ls -la`, which succeeds, so the output is collapsed. The **hidden terminal** action is taken from the tabs view and the terminal is selected, revealed, and scrolled to highlight the command.
+エージェントは `ls -la` を実行し、成功するため、出力は折りたたまれます。**hidden terminal** アクションがタブビューから実行され、ターミナルが選択、表示され、コマンドをハイライトするためにスクロールされます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-hidden.mp4" title="Video showing discovering hidden chat terminals." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-hidden.mp4" title="非表示のチャットターミナルを発見する様子を示す動画。" autoplay loop controls muted></video>
 
-### Save conversation as prompt {#save-conversation-as-prompt}
+### 会話をプロンプトとして保存 {#save-conversation-as-prompt}
 
-You can now save your chat conversations as reusable prompts with the `/savePrompt` command. When you invoke `/savePrompt` in an active chat session, VS Code generates a prompt file containing a generalized prompt based on your conversation. The editor displays a blue button that lets you save this prompt to a valid location, either at the user or workspace level.
+`/savePrompt` コマンドを使用して、チャットの会話を再利用可能なプロンプトとして保存できるようになりました。アクティブなチャットセッションで `/savePrompt` を呼び出すと、VS Code は会話に基づいて一般化されたプロンプトを含むプロンプトファイルを生成します。エディターには青いボタンが表示され、このプロンプトをユーザーレベルまたはワークスペースレベルの有効な場所に保存できます。
 
-![Screenshot of the Save prompt button in the editor.](https://code.visualstudio.com/assets/updates/1_106/save-prompt-prompt.png)
+![エディターのプロンプト保存ボタンのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/save-prompt-prompt.png)
 
-This feature replaces the previous `/save` command and provides a more streamlined workflow for capturing and sharing useful conversation patterns. The generated prompts can be easily reused in future chat sessions or shared with your team. Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
+この機能は、以前の `/save` コマンドを置き換え、役立つ会話パターンをキャプチャして共有するためのより合理化されたワークフローを提供します。生成されたプロンプトは、将来のチャットセッションで簡単に再利用したり、チームと共有したりできます。[カスタムプロンプトファイル](https://code.visualstudio.com/docs/copilot/customization/prompt-files)について詳しく学んでください。
 
-### Edit welcome prompts {#edit-welcome-prompts}
+### ウェルカムプロンプトの編集 {#edit-welcome-prompts}
 
-You can now right-click on suggested prompts in the Chat welcome view to access additional actions. When you right-click a prompt (or press `kbstyle(Shift+F10)`), a context menu appears with an **Edit Prompt File** option to open the corresponding prompt file directly in the editor.
+チャットのウェルカムビューで提案されたプロンプトを右クリックして、追加のアクションにアクセスできるようになりました。プロンプトを右クリック (または `kbstyle(Shift+F10)`) すると、コンテキストメニューが表示され、**Edit Prompt File** オプションを選択して、対応するプロンプトファイルをエディターで直接開くことができます。
 
-Editing a prompt file works for prompts that have an associated file, including user-defined prompts and project-specific prompts configured through the `setting(chat.promptFilesRecommendations)` setting.
+プロンプトファイルの編集は、ユーザー定義のプロンプトや `setting(chat.promptFilesRecommendations)` 設定を通じて構成されたプロジェクト固有のプロンプトなど、関連ファイルを持つプロンプトで機能します。
 
-![Screenshot of a context menu for a suggested prompt.](https://code.visualstudio.com/assets/updates/1_106/welcome-prompt-context.png)
+![提案されたプロンプトのコンテキストメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/welcome-prompt-context.png)
 
-Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
+[カスタムプロンプトファイル](https://code.visualstudio.com/docs/copilot/customization/prompt-files)について詳しく学んでください。
 
-### Automatically open edited files {#automatically-open-edited-files}
+### 編集されたファイルを自動的に開く {#automatically-open-edited-files}
 
-**Setting**: `setting(chat.openEditedFilesAutomatically)`
+**設定**: `setting(chat.openEditedFilesAutomatically)`
 
-We changed the default behavior of the agent to no longer automatically open edited files in an editor. If you prefer the previous behavior, you can enable the setting `setting(accessibility.openChatEditedFiles)`.
+エージェントのデフォルトの動作を変更し、編集されたファイルをエディターで自動的に開かないようにしました。以前の動作を好む場合は、`setting(accessibility.openChatEditedFiles)` 設定を有効にできます。
 
-### Reasoning (Experimental) {#reasoning-experimental}
+### 推論 (実験的) {#reasoning-experimental}
 
-**Setting**: `setting(chat.agent.thinkingStyle)`, `setting(chat.agent.thinking.collapsedTools)`
+**設定**: `setting(chat.agent.thinkingStyle)`、`setting(chat.agent.thinking.collapsedTools)`
 
-Last iteration, we added the `setting(chat.agent.thinkingStyle)` setting which enabled displaying thinking tokens in chat. This is now available in more models! As of this release, GPT-5-Codex, GPT-5, GPT-5 mini, and Gemini 2.5 Pro support this.
+前回のイテレーションで、チャットに思考トークンを表示する `setting(chat.agent.thinkingStyle)` 設定を追加しました。これがより多くのモデルで利用可能になりました！このリリース現在、GPT-5-Codex、GPT-5、GPT-5 mini、および Gemini 2.5 Pro がこれをサポートしています。
 
-The `setting(chat.agent.thinkingStyle)` was adjusted to three more common styles, with `fixedScrolling` as the default to show the most recent chain of thoughts.
+`setting(chat.agent.thinkingStyle)` は、より一般的な 3 つのスタイルに調整され、`fixedScrolling` がデフォルトで最新の思考の連鎖を表示するようになりました。
 
-An additional setting, `setting(chat.agent.thinking.collapsedTools)`, adds tool calls into the collapsible thinking UI.
+追加の設定 `setting(chat.agent.thinking.collapsedTools)` は、折りたたみ可能な思考 UI にツールコールを追加します。
 
-![Screenshot showing reasoning tokens displayed in chat with interweaved tool cals and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](https://code.visualstudio.com/assets/updates/1_106/reasoning.png)
+![チャットに表示される推論トークンと、織り交ぜられたツールコールと推論出力を示すスクリーンショット。これは、それぞれの思考設定に `fixedScrolling` と `readOnly` を使用した UI です。](https://code.visualstudio.com/assets/updates/1_106/reasoning.png)
 
-### Inline chat v2 (Preview) {#inline-chat-v2-preview}
+### インラインチャット v2 (プレビュー) {#inline-chat-v2-preview}
 
-**Setting**: `setting(inlineChat.enableV2:true)`
+**設定**: `setting(inlineChat.enableV2:true)`
 
-We have ramped up our efforts to modernize inline chat. It's built to be
+インラインチャットを近代化するための取り組みを強化しました。これは、
 
-* single prompt,
-* single file,
-* and for code changes only
+* 単一プロンプト、
+* 単一ファイル、
+* そしてコード変更のみ
 
-This makes the overall experience much lighter and allows for a simplified UI. For tasks it cannot handle, you'll be automatically upgraded to the Chat view.
+のために構築されています。これにより、全体的なエクスペリエンスがはるかに軽量になり、簡素化された UI が可能になります。処理できないタスクについては、自動的にチャットビューにアップグレードされます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/inline-chat.mp4" title="Showing Inline chat in action" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/inline-chat.mp4" title="インラインチャットの動作を示す動画" autoplay loop controls muted></video>
 
-### Chat view UX improvements {#chat-view-ux-improvements}
+### チャットビューの UX 改善 {#chat-view-ux-improvements}
 
-We tweaked some parts of the Chat view to make it feel more pleasant to use:
+チャットビューの一部を調整して、より快適に使用できるようにしました:
 
-* The action to create a new Chat is now a dropdown with options to create a chat session in the editor or in a new window
-* The tools and MCP server actions moved right next to the model picker
-* The configuration dropdown is cleaned up
+* 新しいチャットを作成するアクションが、エディターまたは新しいウィンドウでチャットセッションを作成するオプション付きのドロップダウンになりました
+* ツールと MCP サーバーのアクションがモデルピッカーのすぐ隣に移動しました
+* 構成ドロップダウンがクリーンアップされました
 
-![Screenshot of the action to create a new chat dropdown menu.](https://code.visualstudio.com/assets/updates/1_106/chat-view.png)
+![新しいチャットを作成するアクションのドロップダウンメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/chat-view.png)
 
-It is now also possible to copy math source by right-clicking math expressions in the chat view.
+チャットビューで数式を右クリックして、数式のソースをコピーすることも可能になりました。
 
 ## MCP {#mcp}
 
-### MCP server access for your organization {#mcp-server-access-for-your-organization}
+### 組織の MCP サーバーアクセス {#mcp-server-access-for-your-organization}
 
-**Settings**: `setting(chat.mcp.gallery.serviceUrl)`, `setting(chat.mcp.access)`
+**設定**: `setting(chat.mcp.gallery.serviceUrl)`、`setting(chat.mcp.access)`
 
-VS Code now supports MCP registry configured through GitHub organization policies. This enables organizations to set up a custom MCP registry and control which MCP servers can be installed and started.
+VS Code は、GitHub 組織ポリシーを通じて構成された MCP レジストリをサポートするようになりました。これにより、組織はカスタム MCP レジストリを設定し、どの MCP サーバーをインストールおよび起動できるかを制御できます。
 
-When an MCP registry endpoint is configured in your organization's policies, VS Code will:
+組織のポリシーで MCP レジストリエンドポイントが構成されている場合、VS Code は次のようになります:
 
-* Provide browsing and installing of MCP servers from the configured registry
-* Restrict starting MCP servers to only those available in the registry when access restriction is enabled
+* 構成されたレジストリから MCP サーバーの参照とインストールを提供します
+* アクセス制限が有効になっている場合、MCP サーバーの起動をレジストリで利用可能なもののみに制限します
 
-When your organization has configured these policies, the `setting(chat.mcp.gallery.serviceUrl)` setting specifies the MCP registry endpoint URL, and the `setting(chat.mcp.access)` setting controls whether access is restricted to only the servers in that registry. These settings will be marked as "(Managed by organization)" in the Settings editor:
+組織がこれらのポリシーを構成している場合、`setting(chat.mcp.gallery.serviceUrl)` 設定は MCP レジストリエンドポイント URL を指定し、`setting(chat.mcp.access)` 設定はアクセスがそのレジストリ内のサーバーのみに制限されるかどうかを制御します。これらの設定は、設定エディターで「(Managed by organization)」とマークされます:
 
-![Screenshot showing MCP settings managed by organization policy, including the Gallery Service URL and Access control settings](https://code.visualstudio.com/assets/updates/1_106/mcp-registry-policies.png)
+![組織ポリシーによって管理される MCP 設定のスクリーンショット。ギャラリーサービス URL とアクセス制御設定が含まれています。](https://code.visualstudio.com/assets/updates/1_106/mcp-registry-policies.png)
 
-To learn more about configuring MCP server access for your organization or enterprise, see [Configure MCP server access](https://docs.github.com/en/copilot/how-tos/administer-copilot/configure-mcp-server-access).
+組織またはエンタープライズの MCP サーバーアクセスを構成する方法の詳細については、[MCP サーバーアクセスの構成](https://docs.github.com/en/copilot/how-tos/administer-copilot/configure-mcp-server-access)を参照してください。
 
-### Install MCP servers to workspace configuration {#install-mcp-servers-to-workspace-configuration}
+### MCP サーバーをワークスペース構成にインストール {#install-mcp-servers-to-workspace-configuration}
 
-When installing an MCP server, you can now choose whether to install it globally or to the workspace configuration. Right-click on an MCP server in the extensions view and select **Install (Workspace)** from the context menu, or use the **Install (Workspace)** action directly in the MCP server editor. This adds the MCP server to the `.vscode/mcp.json` file in your current workspace, making it easier to share MCP servers with your team.
+MCP サーバーをインストールする際に、グローバルにインストールするか、ワークスペース構成にインストールするかを選択できるようになりました。拡張機能ビューで MCP サーバーを右クリックし、コンテキストメニューから **Install (Workspace)** を選択するか、MCP サーバーエディターで直接 **Install (Workspace)** アクションを使用します。これにより、MCP サーバーが現在のワークスペースの `.vscode/mcp.json` ファイルに追加され、チームと MCP サーバーを簡単に共有できるようになります。
 
-![Screenshot showing the context menu for an MCP server with the Install (Workspace) option highlighted](https://code.visualstudio.com/assets/updates/1_106/mcp-install-workspace.png)
+![Install (Workspace) オプションがハイライトされた MCP サーバーのコンテキストメニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/mcp-install-workspace.png)
 
-### Authentication: Client ID Metadata Document authentication flow {#authentication-client-id-metadata-document-authentication-flow}
+### 認証: クライアント ID メタデータドキュメント認証フロー {#authentication-client-id-metadata-document-authentication-flow}
 
-Authentication support for remote MCPs now supports the [Client ID Metadata Document (CIMD)](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html) authentication flow, which is the future standard for OAuth in MCP. This flow enables a more secure and scaleable solution to authentication over [Dynamic Client Registiration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591) because now authorization servers do not have to worry about issuing client IDs per-client.
+リモート MCP の認証サポートは、MCP の OAuth の将来の標準である [クライアント ID メタデータドキュメント (CIMD)](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html) 認証フローをサポートするようになりました。このフローは、認証サーバーがクライアントごとにクライアント ID を発行することを心配する必要がなくなったため、[動的クライアント登録 (DCR)](https://datatracker.ietf.org/doc/html/rfc7591) よりも安全でスケーラブルな認証ソリューションを可能にします。
 
-When connecting to an MCP server that uses an authorization server that supports CIMD, VS Code will automatically use that flow over DCR.
+CIMD をサポートする認証サーバーを使用する MCP サーバーに接続すると、VS Code は自動的に DCR よりもそのフローを使用します。
 
-_For more information about CIMD, take a look at [the resources on oauth.net](https://oauth.net/2/client-id-metadata-document/)._
+_CIMD の詳細については、[oauth.net のリソース](https://oauth.net/2/client-id-metadata-document/)をご覧ください。_
 
-### Authentication: `WWW-Authenticate` scope step up {#authentication-wwwauthenticate-scope-step-up}
+### 認証: `WWW-Authenticate` スコープステップアップ {#authentication-wwwauthenticate-scope-step-up}
 
-Authentication support for remote MCPs now supports dynamic scope escalation through the `WWW-Authenticate` header for remote MCP servers. This is called out in [the OAuth 2.0 specification](https://datatracker.ietf.org/doc/html/rfc6750#section-3). This allows MCP servers to request additional permissions when needed, rather than requiring all scopes upfront. For example, connecting to a server might require a minimal set of scopes, but specific tool calls can request broader permissions only when necessary. This provides better security by following the principle of least privilege.
+リモート MCP の認証サポートは、リモート MCP サーバーの `WWW-Authenticate` ヘッダーを介した動的スコープエスカレーションをサポートするようになりました。これは [OAuth 2.0 仕様](https://datatracker.ietf.org/doc/html/rfc6750#section-3)で言及されています。これにより、MCP サーバーはすべてのスコープを事前に要求するのではなく、必要なときに追加の権限を要求できます。たとえば、サーバーへの接続には最小限のスコープセットが必要ですが、特定のツールコールは必要な場合にのみより広範な権限を要求できます。これにより、最小権限の原則に従うことで、より優れたセキュリティが提供されます。
 
-_This is currently called out in the [latest draft of the MCP specification](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy) which is expected to be finalized soon._
+_これは現在、[MCP 仕様の最新ドラフト](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy)で言及されており、まもなく最終決定される予定です。_
 
-## Accessibility {#accessibility}
+## アクセシビリティ {#accessibility}
 
-### Speech timeout is disabled by default {#speech-timeout-is-disabled-by-default}
+### 音声タイムアウトはデフォルトで無効 {#speech-timeout-is-disabled-by-default}
 
-The configuration `setting(accessibility.voice.speechTimeout)` has changed to be `0` by default. This means, a voice session no longer ends automatically after a certain delay (e.g. a Chat request would not be triggered automatically if you pause). We feel this is a better default experience, but you can always change back to the previous default (`2500`).
+`setting(accessibility.voice.speechTimeout)` の構成は、デフォルトで `0` に変更されました。これは、音声セッションが一定の遅延後に自動的に終了しなくなったことを意味します (たとえば、一時停止した場合、チャットリクエストは自動的にトリガーされません)。これがより良いデフォルトのエクスペリエンスであると感じていますが、いつでも以前のデフォルト (`2500`) に戻すことができます。
 
-### Chat input improvements {#chat-input-improvements}
+### チャット入力の改善 {#chat-input-improvements}
 
-The chat input now announces the active agent and model in a clearer order so screen reader users hear the most relevant context first. The chat accessibility help also calls out that you can press **Delete** to remove attached context items, making attachment management fully keyboard-accessible.
+チャット入力は、アクティブなエージェントとモデルをより明確な順序でアナウンスするようになり、スクリーンリーダーユーザーが最も関連性の高いコンテキストを最初に聞くことができます。チャットのアクセシビリティヘルプでは、**Delete** を押して添付されたコンテキスト項目を削除できることも示しており、添付ファイルの管理が完全にキーボードでアクセス可能になります。
 
 ## Notebooks {#notebooks}
 
-### Notebook search {#notebook-search}
+### Notebook 検索 {#notebook-search}
 
-Notebooks now supports searching across cells. Use key bindings (`kb(notebook.findNext.fromWidget)` and `kb(notebook.findPrevious.fromWidget)`) to navigate to the next and previous match, just like you would in the editor.
+Notebooks は、セル間の検索をサポートするようになりました。キーバインディング (`kb(notebook.findNext.fromWidget)` と `kb(notebook.findPrevious.fromWidget)`) を使用して、エディターで行うのと同じように、次と前の一致に移動します。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/notebookSearch.mp4" title="Video showing search in notebook cells." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/notebookSearch.mp4" title="Notebook セルでの検索を示す動画。" autoplay loop controls muted></video>
 
-## Source Control {#source-control}
+## ソース管理 {#source-control}
 
-### Folding support in git commit messages {#folding-support-in-git-commit-messages}
+### git コミットメッセージでの折りたたみサポート {#folding-support-in-git-commit-messages}
 
-**Settings**: `setting(git.verboseCommit)`, `setting(git.useEditorAsCommitInput)`
+**設定**: `setting(git.verboseCommit)`、`setting(git.useEditorAsCommitInput)`
 
-When writing git commit messages in the editor, you can now fold sections of the commit message to keep things organized. To use this feature, enable the `setting(git.verboseCommit)` and `setting(git.useEditorAsCommitInput)` settings.
+エディターで git コミットメッセージを記述する際に、コミットメッセージのセクションを折りたたんで整理できるようになりました。この機能を使用するには、`setting(git.verboseCommit)` と `setting(git.useEditorAsCommitInput)` 設定を有効にします。
 
-![Screenshot showing folding nodes in the gutter and a partially collapsed commit message in the editor.](https://code.visualstudio.com/assets/updates/1_106/commit-folding.png)
+![ガターに折りたたみノードと、エディターで部分的に折りたたまれたコミットメッセージを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/commit-folding.png)
 
-### Graph incoming/outgoing changes {#graph-incomingoutgoing-changes}
+### グラフの受信/送信変更 {#graph-incomingoutgoing-changes}
 
-**Settings**: `setting(scm.graph.showIncomingChanges)`, `setting(scm.graph.showOutgoingChanges)`
+**設定**: `setting(scm.graph.showIncomingChanges)`、`setting(scm.graph.showOutgoingChanges)`
 
-This milestone, we are adding the capability to easily view incoming and outgoing changes in the Source Control Graph view. For active branches that have incoming or outgoing changes, the graph displays an "Incoming Changes" and "Outgoing Changes" node. Selecting each node displays the list of incoming or outgoing files.
+このマイルストーンでは、ソース管理グラフビューで受信および送信の変更を簡単に表示する機能を追加しています。受信または送信の変更があるアクティブなブランチの場合、グラフには「Incoming Changes」および「Outgoing Changes」ノードが表示されます。各ノードを選択すると、受信または送信ファイルのリストが表示されます。
 
-![Screenshot showing incoming and outgoing changes nodes in the Source Control Graph view.](https://code.visualstudio.com/assets/updates/1_106/graph-incoming-outgoing.png)
+![ソース管理グラフビューで受信および送信の変更ノードを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/graph-incoming-outgoing.png)
 
-You can hide this information from the Graph view by using the `setting(scm.graph.showIncomingChanges:false)` and `setting(scm.graph.showOutgoingChanges:false)` settings.
+`setting(scm.graph.showIncomingChanges:false)` と `setting(scm.graph.showOutgoingChanges:false)` 設定を使用して、この情報をグラフビューから非表示にできます。
 
-### Graph compare references {#graph-compare-references}
+### グラフ参照の比較 {#graph-compare-references}
 
-We have added a new command to the Source Control Graph context menu, **Compare with...**, that enables you to compare a history item in the graph with an arbitrary branch or tag. This feature lets you view changes that are in the history item but not in the branch or tag.
+ソース管理グラフのコンテキストメニューに新しいコマンド **Compare with...** を追加しました。これにより、グラフ内の履歴項目を任意のブランチまたはタグと比較できます。この機能を使用すると、履歴項目にはあるがブランチまたはタグにはない変更を表示できます。
 
-In the context menu, there are shortcuts commands, **Compare with Remote** and **Compare with Merge Base** for comparing a history item with the remote branch and merge base respectively.
+コンテキストメニューには、履歴項目をリモートブランチおよびマージベースとそれぞれ比較するためのショートカットコマンド **Compare with Remote** および **Compare with Merge Base** があります。
 
-### Repositories selection mode {#repositories-selection-mode}
+### リポジトリ選択モード {#repositories-selection-mode}
 
-**Setting**: `setting(scm.repositories.selectionMode)`
+**設定**: `setting(scm.repositories.selectionMode)`
 
-The Source Control Repositories view shows the list of opened repositories in the workspace and is used to control the repositories shown in the Source Control Changes view.
+ソース管理リポジトリビューには、ワークスペースで開かれているリポジトリのリストが表示され、ソース管理変更ビューに表示されるリポジトリを制御するために使用されます。
 
-We are looking to expand the functionality of the Repositories view and in preparation for that, we are introducing a setting, `setting(scm.repositories.selectionMode)`, to control the selection mode in the Repositories view to either a single repository or multiple repositories.
+リポジトリビューの機能を拡張する準備として、リポジトリビューの選択モードを単一リポジトリまたは複数リポジトリに制御するための設定 `setting(scm.repositories.selectionMode)` を導入しています。
 
-Apart from the new functionality in the Repositories view, this also allows us to remove the repository picker in the Graph view's title and have a global repository picker across all source control views. You can toggle the selection mode using the setting, or from the "..." menu of the Repositories view.
+リポジトリビューの新しい機能とは別に、これによりグラフビューのタイトルのリポジトリピッカーを削除し、すべてのソース管理ビューでグローバルなリポジトリピッカーを持つことができます。設定またはリポジトリビューの「...」メニューから選択モードを切り替えることができます。
 
-![Screenshot showing the Repositories view with single selection mode enabled and the context menu to toggle selection mode.](https://code.visualstudio.com/assets/updates/1_106/repositories-selection-mode.png)
+![単一選択モードが有効になっているリポジトリビューと、選択モードを切り替えるコンテキストメニューを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/repositories-selection-mode.png)
 
-### Repositories explorer (experimental) {#repositories-explorer-experimental}
+### リポジトリエクスプローラー (実験的) {#repositories-explorer-experimental}
 
-**Settings**: `setting(scm.repositories.explorer:true)`, `setting(scm.repositories.selectionMode:single)`
+**設定**: `setting(scm.repositories.explorer:true)`、`setting(scm.repositories.selectionMode:single)`
 
-We are looking at enhancing the Repositories view and showing additional information for each repository. To try out this experimental feature, set `setting(scm.repositories.selectionMode:single)` and `setting(scm.repositories.explorer:true)`.
+リポジトリビューを強化し、各リポジトリの追加情報を表示することを検討しています。この実験的な機能を試すには、`setting(scm.repositories.selectionMode:single)` と `setting(scm.repositories.explorer:true)` を設定します。
 
-In this first iteration, we have focused on branches and tags. You can create new branches, tags, view the list of branches and tags, and take various actions of each branch/tag (ex: checkout, etc.). In the upcoming milestone, we will add more information (ex: stashes, remotes, etc). Give this experimental feature a try and let us know what you think.
+この最初のイテレーションでは、ブランチとタグに焦点を当てました。新しいブランチ、タグを作成したり、ブランチとタグのリストを表示したり、各ブランチ/タグに対してさまざまなアクション (例: チェックアウトなど) を実行したりできます。今後のマイルストーンでは、さらに多くの情報 (例: スタッシュ、リモートなど) を追加します。この実験的な機能を試して、ご意見をお聞かせください。
 
-![Screenshot showing the Repositories explorer with branches and tags for a single selected repository.](https://code.visualstudio.com/assets/updates/1_106/repositories-explorer.png)
+![単一の選択されたリポジトリのブランチとタグを持つリポジトリエクスプローラーを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/repositories-explorer.png)
 
-## Testing {#testing}
+## テスト {#testing}
 
-### Navigate uncovered lines in test coverage {#navigate-uncovered-lines-in-test-coverage}
+### テストカバレッジでカバーされていない行に移動 {#navigate-uncovered-lines-in-test-coverage}
 
-When reviewing test coverage, you can now easily navigate between uncovered lines using new navigation commands. Two commands are available in the editor toolbar when viewing coverage information:
+テストカバレッジを確認する際に、新しいナビゲーションコマンドを使用して、カバーされていない行間を簡単に移動できるようになりました。カバレッジ情報を表示しているとき、エディターのツールバーで 2 つのコマンドが利用できます:
 
-* **Go to Next Uncovered Line** - Jumps to the next line that is not covered by tests
-* **Go to Previous Uncovered Line** - Jumps to the previous line that is not covered by tests
+* **Go to Next Uncovered Line** - テストでカバーされていない次の行にジャンプします
+* **Go to Previous Uncovered Line** - テストでカバーされていない前の行にジャンプします
 
-These commands help you quickly identify coverage gaps and focus on areas that need additional test coverage, making it easier to improve the overall test quality of your codebase.
+これらのコマンドは、カバレッジのギャップをすばやく特定し、追加のテストカバレッジが必要な領域に集中するのに役立ち、コードベース全体のテスト品質を向上させやすくします。
 
-## Terminal {#terminal}
+## ターミナル {#terminal}
 
-### Terminal IntelliSense {#terminal-intellisense}
+### ターミナル IntelliSense {#terminal-intellisense}
 
-Terminal IntelliSense has been in the product as an experimental/preview feature [for around 1.5 years](https://code.visualstudio.com/updates/v1_89#_vs-codenative-intellisense-for-powershell)! This release we're removing the preview tag and will be doing a staged roll out as the default to all users on stable.
+ターミナル IntelliSense は、実験的/プレビュー機能として製品に[約 1.5 年間](https://code.visualstudio.com/updates/v1_89#_vs-codenative-intellisense-for-powershell)搭載されていました！このリリースでは、プレビュータグを削除し、安定版のすべてのユーザーにデフォルトとして段階的に展開します。
 
-When enabled, typing in the terminal will bring up IntelliSense similar to the editor for PowerShell, bash, zsh and fish:
+有効にすると、ターミナルで入力すると、PowerShell、bash、zsh、fish のエディターと同様の IntelliSense が表示されます:
 
-![Screenshot of typing "write" in PowerShell will bring up completions starting with the word write.](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-write.png)
+![PowerShell で "write" と入力すると、write で始まる補完が表示されるスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-write.png)
 
-The completions have various sources, paths for example are all handled by core:
+補完にはさまざまなソースがあり、たとえばパスはすべてコアによって処理されます:
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-cd.mp4" title="cd presents directories, pressing tab will refresh the entries" autoplay loop controls muted></video>
 
-Some commands feature advanced specifications, like git which has the ability to pull in branch names:
+一部のコマンドには、ブランチ名を取り込む機能を持つ git のような高度な仕様があります:
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-git.mp4" title="git completions support sub-commands, branch names, tags and so on" autoplay loop controls muted></video>
 
-If we learned anything when building this feature it's that no one size fits all, so there are many options to tweak the behavior to get what you're after:
+この機能を構築する際に学んだことがあるとすれば、それは万能なものはないということです。そのため、目的の動作を得るために動作を調整するための多くのオプションがあります:
 
-- `setting(terminal.integrated.suggest.quickSuggestions)` - Show automatically depending on the content of the command line, as opposed to manually via `kbstyle(Ctrl+Space)`.
-- `setting(terminal.integrated.suggest.suggestOnTriggerCharacters)` - Show automatically after a "trigger character" such as `-` or `/`.
-- `setting(terminal.integrated.suggest.runOnEnter)` - Optionally run the command when `kbstyle(Enter)` is used (not `kbstyle(Tab)`).
-- `setting(terminal.integrated.suggest.windowsExecutableExtensions)` - The list of extensions that are treated as executables on Windows.
-- `setting(terminal.integrated.suggest.providers)` - Provides the ability to disable specific providers, for example extensions may contribute completions you don't want.
-- `setting(terminal.integrated.suggest.showStatusBar)` - Whether to show the status bar at the bottom of the IntelliSense popup.
-- `setting(terminal.integrated.suggest.cdPath)` - Whether to enable `$CDPATH` integration.
-- `setting(terminal.integrated.suggest.inlineSuggestion)` - Whether to integrate with shell "ghost text" and how to present it.
-- `setting(terminal.integrated.suggest.upArrowNavigatesHistory)` - Whether up arrow is sent to the shell instead of browsing completions, this is particularly useful on zsh where you can filter and then press up to do a history search with that prefix.
-- `setting(terminal.integrated.suggest.selectionMode)` - How the Intellisense popup is focused which determines what `kbstyle(Enter)` and `kbstyle(Tab)` do.
-- (New!) `setting(terminal.integrated.suggest.insertTrailingSpace)` - Insert a trailing space and re-trigger completions after accepting.
+- `setting(terminal.integrated.suggest.quickSuggestions)` - `kbstyle(Ctrl+Space)` を介して手動ではなく、コマンドラインの内容に応じて自動的に表示します。
+- `setting(terminal.integrated.suggest.suggestOnTriggerCharacters)` - `-` や `/` などの「トリガー文字」の後に自動的に表示します。
+- `setting(terminal.integrated.suggest.runOnEnter)` - オプションで、`kbstyle(Enter)` が使用されたときにコマンドを実行します (`kbstyle(Tab)` ではありません)。
+- `setting(terminal.integrated.suggest.windowsExecutableExtensions)` - Windows で実行可能ファイルとして扱われる拡張子のリスト。
+- `setting(terminal.integrated.suggest.providers)` - 特定のプロバイダーを無効にする機能を提供します。たとえば、拡張機能が不要な補完を提供する場合があります。
+- `setting(terminal.integrated.suggest.showStatusBar)` - IntelliSense ポップアップの下部にステータスバーを表示するかどうか。
+- `setting(terminal.integrated.suggest.cdPath)` - `$CDPATH` 統合を有効にするかどうか。
+- `setting(terminal.integrated.suggest.inlineSuggestion)` - シェルの「ゴーストテキスト」と統合するかどうか、およびそれをどのように表示するか。
+- `setting(terminal.integrated.suggest.upArrowNavigatesHistory)` - 上矢印が補完を閲覧する代わりにシェルに送信されるかどうか。これは、zsh でフィルターをかけてから上を押してそのプレフィックスで履歴検索を行う場合に特に便利です。
+- `setting(terminal.integrated.suggest.selectionMode)` - Intellisense ポップアップがどのようにフォーカスされるか。これにより、`kbstyle(Enter)` と `kbstyle(Tab)` が何をするかが決まります。
+- (新規!) `setting(terminal.integrated.suggest.insertTrailingSpace)` - 受け入れた後に末尾のスペースを挿入し、補完を再トリガーします。
 
-If you are don't see the feature yet, make sure you have [shell integration](https://code.visualstudio.com/docs/terminal/shell-integration) enabled and enable IntelliSense explicitly in settings via `setting(terminal.integrated.suggest.enabled)`.
+まだこの機能が表示されない場合は、[シェル統合](https://code.visualstudio.com/docs/terminal/shell-integration)が有効になっていることを確認し、設定で `setting(terminal.integrated.suggest.enabled)` を介して IntelliSense を明示的に有効にしてください。
 
-Apart from overall polish, this is what is coming to the feature this release:
+全体的な洗練とは別に、このリリースでこの機能に追加される内容は次のとおりです:
 
-- `copilot` and `azd` CLIs now have completions
-- The extension API is close to finalization
-- Git commit completions show the commit message
+- `copilot` と `azd` CLI に補完が追加されました
+- 拡張機能 API は最終決定に近づいています
+- Git コミット補完はコミットメッセージを表示します
 
-![Screenshot of git commit completions showing branch names and their associated commit messages in the terminal suggest details view.](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-commit.png)
+![ターミナルサジェスト詳細ビューでブランチ名とそれに関連するコミットメッセージを表示する git コミット補完のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-commit.png)
 
-### Consolidated shell integration timeout setting {#consolidated-shell-integration-timeout-setting}
+### 統合されたシェル統合タイムアウト設定 {#consolidated-shell-integration-timeout-setting}
 
-We now have one unified configurable setting, `setting(terminal.integrated.shellIntegration.timeout)`, that controls how long VS Code waits for shell integration to become ready before executing commands in the terminal, including those triggered through the executeCommand API and by Copilot terminal tool.
+VS Code がシェル統合の準備が整うまで待機する時間を制御する、統一された構成可能な設定 `setting(terminal.integrated.shellIntegration.timeout)` ができました。これには、executeCommand API や Copilot ターミナルツールを介してトリガーされるコマンドも含まれます。
 
-`setting(chat.tools.terminal.shellIntegrationTimeout)` has been deprecated in favor of this consolidation.
+`setting(chat.tools.terminal.shellIntegrationTimeout)` は、この統合を優先して非推奨になりました。
 
-## Authentication {#authentication}
+## 認証 {#authentication}
 
-### Manage extension account preferences discoverability {#manage-extension-account-preferences-discoverability}
+### 拡張機能アカウント設定の管理の発見可能性 {#manage-extension-account-preferences-discoverability}
 
-The **Manage Extension Account Preferences** command is now more discoverable. In addition to being available in the Command Palette and extension context menus, it now appears in the Account Menu alongside **Manage Language Model Access**. This makes it easier to find and configure which accounts extensions can access.
+**Manage Extension Account Preferences** コマンドがより見つけやすくなりました。コマンドパレットと拡張機能のコンテキストメニューで利用できるほか、アカウントメニューの **Manage Language Model Access** の横に表示されるようになりました。これにより、拡張機能がアクセスできるアカウントを見つけて構成するのが容易になります。
 
-![Screenshot of Manage Extension Account Preferences in the Account menu.](https://code.visualstudio.com/assets/updates/1_106/manageExtensionAccountPref.png)
+![アカウントメニューの Manage Extension Account Preferences のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/manageExtensionAccountPref.png)
 
-### Last version of `classic` Microsoft authentication - use `msal-no-broker` if you experience issues {#last-version-of-classic-microsoft-authentication-use-msalnobroker-if-you-experience-issues}
+### `classic` Microsoft 認証の最終バージョン - 問題が発生した場合は `msal-no-broker` を使用してください {#last-version-of-classic-microsoft-authentication-use-msalnobroker-if-you-experience-issues}
 
-We will be removing the `classic` option for `setting(microsoft-authentication.implementation)`. This means that VS Code release 1.106 is the final version that has the `classic` option.
+`setting(microsoft-authentication.implementation)` の `classic` オプションを削除します。これは、VS Code リリース 1.106 が `classic` オプションを持つ最後のバージョンであることを意味します。
 
-The `setting(microsoft-authentication.implementation)` setting has been around to let users opt-out of native brokered authentication for Microsoft accounts if they experienced issues. The values for this setting are:
+`setting(microsoft-authentication.implementation)` 設定は、問題が発生した場合にユーザーが Microsoft アカウントのネイティブブローカー認証をオプトアウトできるようにするために存在していました。この設定の値は次のとおりです:
 
-* `msal` - Use MSAL with brokered authentication when available (default)
-* `msal-no-broker` - Use MSAL without brokered authentication (introduced recently)
-* `classic` - Use the classic Microsoft authentication flow without MSAL
+* `msal` - 利用可能な場合はブローカー認証付きの MSAL を使用します (デフォルト)
+* `msal-no-broker` - ブローカー認証なしの MSAL を使用します (最近導入)
+* `classic` - MSAL なしのクラシックな Microsoft 認証フローを使用します
 
-We will remove the `classic` option since it's usage is very low and most issues with the `msal` option are due to the brokering, which is remedied with `msal-no-broker`.
+`classic` オプションの使用率は非常に低く、`msal` オプションの問題のほとんどはブローカリングによるものであり、これは `msal-no-broker` で解決されるため、`classic` オプションを削除します。
 
-### Device code flow for Microsoft authentication {#device-code-flow-for-microsoft-authentication}
+### Microsoft 認証のデバイスコードフロー {#device-code-flow-for-microsoft-authentication}
 
-Microsoft authentication now supports the device code flow in non-brokered scenarios, particularly useful for remote development environments. When other authentication methods fail, VS Code automatically falls back to device code flow, which displays a code that you can enter on another device to complete authentication.
+Microsoft 認証は、特にリモート開発環境で役立つ、非ブローカーシナリオでのデバイスコードフローをサポートするようになりました。他の認証方法が失敗した場合、VS Code は自動的にデバイスコードフローにフォールバックし、別のデバイスで入力して認証を完了できるコードを表示します。
 
-### Manage accounts command {#manage-accounts-command}
+### アカウント管理コマンド {#manage-accounts-command}
 
-Manage your authentication accounts directly from the Command Palette using the **Accounts: Manage Accounts** command. This command provides access to account management features when the Account menu is hidden or not easily accessible.
+コマンドパレットから **Accounts: Manage Accounts** コマンドを使用して、認証アカウントを直接管理します。このコマンドは、アカウントメニューが非表示または簡単にアクセスできない場合に、アカウント管理機能へのアクセスを提供します。
 
-![Screenshot of the Manage Accounts menu.](https://code.visualstudio.com/assets/updates/1_106/manage-accounts-menu.png)
+![アカウント管理メニューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/manage-accounts-menu.png)
 
-When you run the **Manage Accounts** command, you'll see a quick pick menu listing all your active accounts. You can select an account to view available actions, including:
+**Manage Accounts** コマンドを実行すると、すべてのアクティブなアカウントを一覧表示するクイックピックメニューが表示されます。アカウントを選択して、利用可能なアクションを表示できます。これには以下が含まれます:
 
-* **Manage Trusted Extensions** - Control which extensions can access the selected account
-* **Manage Trusted MCP Servers** - Manage MCP server access permissions for accounts that support this capability
-* **Sign Out** - Sign out of the account
+* **Manage Trusted Extensions** - 選択したアカウントにアクセスできる拡張機能を制御します
+* **Manage Trusted MCP Servers** - この機能をサポートするアカウントの MCP サーバーアクセス許可を管理します
+* **Sign Out** - アカウントからサインアウトします
 
-## Languages {#languages}
+## 言語 {#languages}
 
 ### Python {#python}
 
-#### Python Environments Extension: Support for python.poetryPath setting {#python-environments-extension-support-for-pythonpoetrypath-setting}
+#### Python Environments Extension: python.poetryPath 設定のサポート {#python-environments-extension-support-for-pythonpoetrypath-setting}
 
-The Python Environments Extension now respects the existing `python.poetryPath` user setting. This allows you to specify which Poetry executable to use. The provided path will be searched for and selected when managing Poetry environments.
+Python Environments Extension は、既存の `python.poetryPath` ユーザー設定を尊重するようになりました。これにより、使用する Poetry 実行可能ファイルを指定できます。提供されたパスは、Poetry 環境を管理する際に検索され、選択されます。
 
-#### Python Environments Extension: Improved venv creation: dev-requirements.txt detection {#python-environments-extension-improved-venv-creation-devrequirementstxt-detection}
+#### Python Environments Extension: 改善された venv 作成: dev-requirements.txt 検出 {#python-environments-extension-improved-venv-creation-devrequirementstxt-detection}
 
-When creating a new virtual environment, the extension now detects both requirements.txt and dev-requirements.txt files and installs dependencies automatically.
+新しい仮想環境を作成する際、拡張機能は requirements.txt と dev-requirements.txt の両方のファイルを検出し、依存関係を自動的にインストールするようになりました。
 
-#### Add Copilot Hover Summaries as docstring {#add-copilot-hover-summaries-as-docstring}
+#### Copilot ホバーサマリーを docstring として追加 {#add-copilot-hover-summaries-as-docstring}
 
-You can now add your AI-generated documentation directly into your code as a docstring using the new **Add as docstring** command in Copilot Hover Summaries. When you generate a summary for a function or class, navigate to the symbol definition and hover over it to access the **Add as docstring** command, which inserts the summary below your cursor formatted as a proper docstring.
+Copilot ホバーサマリーの新しい **Add as docstring** コマンドを使用して、AI が生成したドキュメントをコードに直接 docstring として追加できるようになりました。関数またはクラスのサマリーを生成したら、シンボル定義に移動してホバーすると、**Add as docstring** コマンドにアクセスでき、カーソルの下にサマリーが適切な docstring としてフォーマットされて挿入されます。
 
-This streamlines the process of documenting your code, allowing you to quickly enhance readability and maintainability without retyping.
+これにより、コードのドキュメント化プロセスが合理化され、再入力することなく読みやすさと保守性をすばやく向上させることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/pylance-add-hover-summaries-as-docstring.mp4" title="Add as docstring command in Copilot Hover Summaries." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/pylance-add-hover-summaries-as-docstring.mp4" title="Copilot ホバーサマリーの Add as docstring コマンド。" autoplay loop controls muted></video>
 
-#### Localized Copilot Hover Summaries {#localized-copilot-hover-summaries}
+#### ローカライズされた Copilot ホバーサマリー {#localized-copilot-hover-summaries}
 
-GitHub Copilot Hover Summaries inside Pylance now respect your display language within VS Code. When you invoke an AI-generated summary, you'll get strings in the language you've set for your editor, making it easier to understand the generated documentation.
+Pylance 内の GitHub Copilot ホバーサマリーは、VS Code 内の表示言語を尊重するようになりました。AI が生成したサマリーを呼び出すと、エディターに設定した言語で文字列が表示され、生成されたドキュメントを理解しやすくなります。
 
-![Screenshot of a Copilot Hover Summary generated in Portuguese.](https://code.visualstudio.com/assets/updates/1_106/hover-summaries-in-portuguese.png)
+![ポルトガル語で生成された Copilot ホバーサマリーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/hover-summaries-in-portuguese.png)
 
-#### Convert wildcard imports Code Action {#convert-wildcard-imports-code-action}
+#### ワイルドカードインポート変換コードアクション {#convert-wildcard-imports-code-action}
 
-Wildcard imports (from module import *) are often discouraged in Python because they can clutter your namespace and make it unclear where names come from, reducing code clarity and maintainability.
-Pylance now helps you clean up modules that still rely on `from module import *` via a new Code Action. It replaces the wildcard with the explicit symbols, preserving aliases and keeping the import to a single statement. To try it out, you can click on the line with the wildcard import and press `kbstyle(Ctrl+.)` (or `kbstyle(Cmd+.)` on macOS) to select the **Convert to explicit imports** Code Action.
+ワイルドカードインポート (`from module import *`) は、名前空間を乱雑にし、名前の由来を不明確にし、コードの明瞭性と保守性を低下させる可能性があるため、Python ではしばしば推奨されません。
+Pylance は、新しいコードアクションを介して、まだ `from module import *` に依存しているモジュールをクリーンアップするのに役立ちます。ワイルドカードを明示的なシンボルに置き換え、エイリアスを保持し、インポートを単一のステートメントに保ちます。試すには、ワイルドカードインポートのある行をクリックし、`kbstyle(Ctrl+.)` (macOS では `kbstyle(Cmd+.)`) を押して **Convert to explicit imports** コードアクションを選択します。
 
-![Screenshot of the Convert wildcard imports Code Action.](https://code.visualstudio.com/assets/updates/1_106/wildcard-import.png)
+![ワイルドカードインポート変換コードアクションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/wildcard-import.png)
 
 ### dotenv {#dotenv}
 
-There is built in basic support for dotenv files (`.env`), which are commonly used to define environment variables for applications.
+アプリケーションの環境変数を定義するために一般的に使用される dotenv ファイル (`.env`) の基本的なサポートが組み込まれています。
 
-## Contributions to extensions {#contributions-to-extensions}
+## 拡張機能への貢献 {#contributions-to-extensions}
 
 ### GitHub Pull Requests {#github-pull-requests}
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+プルリクエストと issue の作業、作成、管理を可能にする [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能でさらに進展がありました。新機能は次のとおりです:
 
-* AI-generated PR descriptions (via `setting(githubPullRequests.pullRequestDescription:copilot)`) will respect the repository PR template if there is one.
-* Drafts in the Pull Requests view now render in italics instead of having a `[DRAFT]` prefix.
-* Pull requests can be opened from from a url, for example: `vscode-insiders://github.vscode-pull-request-github/checkout-pull-request?uri=https://github.com/microsoft/vscode-css-languageservice/pull/460`
+* AI が生成した PR の説明 (`setting(githubPullRequests.pullRequestDescription:copilot)` 経由) は、リポジトリに PR テンプレートがある場合、それを尊重します。
+* プルリクエストビューのドラフトは、`[DRAFT]` プレフィックスを持つ代わりにイタリックでレンダリングされるようになりました。
+* プルリクエストは URL から開くことができます。例: `vscode-insiders://github.vscode-pull-request-github/checkout-pull-request?uri=https://github.com/microsoft/vscode-css-languageservice/pull/460`
 
-Review the [changelog for the 0.122.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01220) release of the extension to learn about everything in the release.
+拡張機能の [0.122.0 リリースの変更ログ](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01220) を確認して、リリースのすべてについて学んでください。
 
-## Preview Features {#preview-features}
+## プレビュー機能 {#preview-features}
 
-### Language Models editor {#language-models-editor}
+### 言語モデルエディター {#language-models-editor}
 
-A new **Language Models** editor provides a centralized place to view and manage all available language models for GitHub Copilot Chat. You can open it from the chat model picker or via the command **Chat: Manage Language Models**.
+新しい **Language Models** エディターは、GitHub Copilot Chat で利用可能なすべての言語モデルを表示および管理するための一元的な場所を提供します。チャットモデルピッカーから、またはコマンド **Chat: Manage Language Models** を介して開くことができます。
 
->**Note:** This feature is only available in [VS Code Insiders](https://code.visualstudio.com/insiders/).
+>**注:** この機能は [VS Code Insiders](https://code.visualstudio.com/insiders/) でのみ利用可能です。
 
-![Screenshot showing the Language Models editor with a list of models organized by provider.](https://code.visualstudio.com/assets/updates/1_106/language-models-editor.png)
+![プロバイダーごとに整理されたモデルのリストを持つ言語モデルエディターのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/language-models-editor.png)
 
-The editor displays:
+エディターには以下が表示されます:
 
-* All available models organized by provider
-* Model capabilities (tools, vision, agent)
-* Context size and multiplier information
-* Model visibility status
+* プロバイダーごとに整理されたすべての利用可能なモデル
+* モデルの機能 (ツール、ビジョン、エージェント)
+* コンテキストサイズと乗数情報
+* モデルの可視性ステータス
 
-You can search and filter models using:
+以下を使用してモデルを検索およびフィルタリングできます:
 
-* Text search with highlighting
-* Provider filter: `@provider:"OpenAI"`
-* Capability filters: `@capability:tools`, `@capability:vision`, `@capability:agent`
-* Visibility filter: `@visible:true/false`
+* ハイライト付きのテキスト検索
+* プロバイダーフィルター: `@provider:"OpenAI"`
+* 機能フィルター: `@capability:tools`、`@capability:vision`、`@capability:agent`
+* 可視性フィルター: `@visible:true/false`
 
-Hover over model names or context sizes to see detailed information including model ID, version, status, and token breakdown.
+モデル名またはコンテキストサイズにホバーすると、モデル ID、バージョン、ステータス、トークンの内訳などの詳細情報が表示されます。
 
-#### Manage model visibility {#manage-model-visibility}
+#### モデルの可視性を管理 {#manage-model-visibility}
 
-Control which models appear in the chat model picker by toggling their visibility with the eye icon next to each model. When a model is visible, it appears in the model picker dropdown when you're using GitHub Copilot Chat, making it available for selection. Hidden models remain in the Language Models editor but won't appear in the model picker, helping you keep your model selection focused on the ones you use most frequently.
+各モデルの横にある目のアイコンで可視性を切り替えることで、チャットモデルピッカーに表示されるモデルを制御します。モデルが表示されている場合、GitHub Copilot Chat を使用しているときにモデルピッカーのドロップダウンに表示され、選択可能になります。非表示のモデルは言語モデルエディターに残りますが、モデルピッカーには表示されず、最も頻繁に使用するモデルにモデル選択を集中させるのに役立ちます。
 
-![Screenshot showing the eye icon to toggle model visibility with a tooltip displaying "Show in the chat model picker"](https://code.visualstudio.com/assets/updates/1_106/toggle-language-model-visibility.png)
+!["Show in the chat model picker" と表示されたツールチップ付きのモデル可視性を切り替える目のアイコンのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/toggle-language-model-visibility.png)
 
-This is particularly useful when you have access to many models and want to streamline your workflow by showing only your preferred models in the picker.
+これは、多くのモデルにアクセスでき、ピッカーに好みのモデルのみを表示することでワークフローを合理化したい場合に特に便利です。
 
-#### Add models from installed providers {#add-models-from-installed-providers}
+#### インストール済みのプロバイダーからモデルを追加 {#add-models-from-installed-providers}
 
-Use the **Add Models...** button to configure and add models from language model providers you've already installed. When you select this button, you'll see a dropdown list of all installed model providers, such as Copilot, Anthropic, Azure, Google, Groq, Ollama, OpenAI, and others. Select a provider from the list to configure it and start using its models in GitHub Copilot Chat.
+**Add Models...** ボタンを使用して、既にインストールした言語モデルプロバイダーからモデルを構成および追加します。このボタンを選択すると、Copilot、Anthropic、Azure、Google、Groq、Ollama、OpenAI などのインストール済みのモデルプロバイダーのドロップダウンリストが表示されます。リストからプロバイダーを選択して構成し、GitHub Copilot Chat でそのモデルの使用を開始します。
 
-![Screenshot showing the Add Models dropdown with a list of installed language model providers including Copilot, Anthropic, Azure, Google, and more](https://code.visualstudio.com/assets/updates/1_106/add-language-models-dropdown.png)
+![Copilot、Anthropic、Azure、Google などを含むインストール済みの言語モデルプロバイダーのリストを持つ Add Models ドロップダウンのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_106/add-language-models-dropdown.png)
 
-This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
+これにより、言語モデルエディターから移動することなく、インストールした追加のモデルプロバイダーを簡単にアクティブ化できます。プロバイダー行の歯車アイコンを選択して、プロバイダー管理にアクセスします。
 
-## Extension Authoring {#extension-authoring}
+## 拡張機能のオーサリング {#extension-authoring}
 
-### ID token in authentication sessions {#id-token-in-authentication-sessions}
+### 認証セッションの ID トークン {#id-token-in-authentication-sessions}
 
-The `AuthenticationSession` interface now includes an optional `idToken` property. This allows authentication providers to return ID tokens in addition to access tokens, which is particularly useful for scenarios that require user identity information. The Microsoft authentication provider returns this field, while other providers like GitHub may not.
+`AuthenticationSession` インターフェイスに、オプションの `idToken` プロパティが含まれるようになりました。これにより、認証プロバイダーはアクセストークンに加えて ID トークンを返すことができ、ユーザー ID 情報を必要とするシナリオで特に役立ちます。Microsoft 認証プロバイダーはこのフィールドを返しますが、GitHub などの他のプロバイダーは返さない場合があります。
 
-ID tokens contain claims about the authenticated user and are signed by the identity provider, making them useful for verifying user identity. For more information about the difference between ID tokens and access tokens, see <https://oauth.net/id-tokens-vs-access-tokens/>.
+ID トークンには、認証されたユーザーに関するクレームが含まれ、ID プロバイダーによって署名されているため、ユーザー ID の検証に役立ちます。ID トークンとアクセストークンの違いの詳細については、<https://oauth.net/id-tokens-vs-access-tokens/> を参照してください。
 
 ```typescript
 export interface AuthenticationSession {
   /**
-   * The ID token.
+   * ID トークン。
    */
   readonly idToken?: string;
 }
 ```
 
-### Git extension `getRepositoryWorkspace` API {#git-extension-getrepositoryworkspace-api}
+### Git 拡張機能 `getRepositoryWorkspace` API {#git-extension-getrepositoryworkspace-api}
 
-The build in Git extension offers new API for getting a folder that's known to be associated with a git repository remote. This works by caching a repository-remote to folder mapping when the user opens a folder with a git remote.
+組み込みの Git 拡張機能は、git リポジトリリモートに関連付けられていることがわかっているフォルダーを取得するための新しい API を提供します。これは、ユーザーが git リモートを持つフォルダーを開いたときに、リポジトリリモートとフォルダーのマッピングをキャッシュすることで機能します。
 
-### View containers in Secondary Side Bar {#view-containers-in-secondary-side-bar}
+### セカンダリサイドバーのビューコンテナー {#view-containers-in-secondary-side-bar}
 
-Extension authors can now register view containers in the Secondary Side Bar by using the new `secondarySidebar` contribution point. This lets extensions place their custom views alongside built-in views like Chat in the Secondary Side Bar and provide a better integration with VS Code's dual side bar layout.
+拡張機能の作成者は、新しい `secondarySidebar` コントリビューションポイントを使用して、セカンダリサイドバーにビューコンテナーを登録できるようになりました。これにより、拡張機能はカスタムビューをセカンダリサイドバーのチャットなどの組み込みビューと並べて配置し、VS Code のデュアルサイドバーレイアウトとのより良い統合を提供できます。
 
 ```json
 {
@@ -760,26 +760,26 @@ Extension authors can now register view containers in the Secondary Side Bar by 
 }
 ```
 
-## Proposed APIs {#proposed-apis}
+## 提案中の API {#proposed-apis}
 
-### Quick Pick and Quick Input improvements {#quick-pick-and-quick-input-improvements}
+### Quick Pick と Quick Input の改善 {#quick-pick-and-quick-input-improvements}
 
-The Quick Pick and Quick Input APIs include several new capabilities that give extension developers more flexibility in creating interactive user interfaces.
+Quick Pick と Quick Input API には、拡張機能開発者がインタラクティブなユーザーインターフェイスを作成する際の柔軟性を高めるいくつかの新機能が含まれています。
 
-<video src="https://code.visualstudio.com/assets/updates/1_106/quick-pick-api.mp4" title="Video showing quick pick with prompt, toggle and file icons." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/quick-pick-api.mp4" title="プロンプト、トグル、ファイルアイコン付きのクイックピックを示す動画。" autoplay loop controls muted></video>
 
-#### Proposed API: Toggle button support {#proposed-api-toggle-button-support}
+#### 提案中の API: トグルボタンのサポート {#proposed-api-toggle-button-support}
 
-Extensions can add toggle buttons to Quick Pick and Quick Input interfaces through the `toggles` property on `QuickInput`. This enables scenarios like a password visibility toggle in the input box area, allowing users to interact with controls without leaving the quick pick interface.
+拡張機能は、`QuickInput` の `toggles` プロパティを介して、Quick Pick および Quick Input インターフェイスにトグルボタンを追加できます。これにより、入力ボックス領域にパスワード表示トグルなどのシナリオが可能になり、ユーザーはクイックピックインターフェイスを離れることなくコントロールを操作できます。
 
-Your comments and feedback on this API proposal are appreciated (please refer to the [GitHub issue](https://github.com/microsoft/vscode/issues/144956)).
+この API 提案に関するご意見やフィードバックをお待ちしております ([GitHub issue](https://github.com/microsoft/vscode/issues/144956) を参照してください)。
 
 ```typescript
 export enum QuickInputButtonLocation {
   ...
 
   /**
-   * The button is rendered at the far end inside the input box.
+   * ボタンは入力ボックス内の最も遠い端にレンダリングされます。
    */
   Input = 3
 }
@@ -788,142 +788,141 @@ export interface QuickInputButton {
   ...
 
   /**
-   * When present, indicates that the button is a toggle button that can be checked or unchecked.
+   * 存在する場合、ボタンがチェックまたはアンチェックできるトグルボタンであることを示します。
    *
-   * **Note:** This property is currently only applicable to buttons with {@link QuickInputButtonLocation.Input} location.
-   * It must be set for such buttons, and the state will be updated when the button is toggled.
-   * It cannot be set for buttons with other location values.
+   * **注:** このプロパティは現在、{@link QuickInputButtonLocation.Input} の場所を持つボタンにのみ適用可能です。
+   * このようなボタンには設定する必要があり、ボタンがトグルされると状態が更新されます。
+   * 他の場所の値を持つボタンには設定できません。
    */
   readonly toggle?: { checked: boolean };
 }
 ```
 
-#### Proposed API: Prompt support for Quick Pick {#proposed-api-prompt-support-for-quick-pick}
+#### 提案中の API: Quick Pick のプロンプトサポート {#proposed-api-prompt-support-for-quick-pick}
 
-Quick Pick supports a `prompt` property, similar to the one available in Input Box. The prompt displays persistent text beneath the input box that remains visible while users type, providing helpful guidance or instructions that doesn't disappear when the user starts entering text.
+Quick Pick は、Input Box で利用可能なものと同様の `prompt` プロパティをサポートします。プロンプトは、入力ボックスの下に永続的なテキストを表示し、ユーザーが入力している間も表示され続け、ユーザーがテキストの入力を開始しても消えない役立つガイダンスや指示を提供します。
 
-Your comments and feedback on this API proposal are appreciated (please refer to the [GitHub issue](https://github.com/microsoft/vscode/issues/78335)).
+この API 提案に関するご意見やフィードバックをお待ちしております ([GitHub issue](https://github.com/microsoft/vscode/issues/78335) を参照してください)。
 
 ```typescript
 export interface QuickPick<T extends QuickPickItem> extends QuickInput {
   /**
-   * Optional text that provides instructions or context to the user.
+   * ユーザーに指示やコンテキストを提供するオプションのテキスト。
    *
-   * The prompt is displayed below the input box and above the list of items.
+   * プロンプトは入力ボックスの下、アイテムのリストの上に表示されます。
    */
   prompt: string | undefined;
 }
 
 export interface QuickPickOptions {
   /**
-   * Optional text that provides instructions or context to the user.
+   * ユーザーに指示やコンテキストを提供するオプションのテキスト。
    *
-   * The prompt is displayed below the input box and above the list of items.
+   * プロンプトは入力ボックスの下、アイテムのリストの上に表示されます。
    */
   prompt?: string;
 }
 ```
 
-#### Proposed API: File icons for Quick Pick items {#proposed-api-file-icons-for-quick-pick-items}
+#### 提案中の API: Quick Pick アイテムのファイルアイコン {#proposed-api-file-icons-for-quick-pick-items}
 
-Quick Pick items can display file-type-specific icons through the `resourceUri` property on `QuickPickItem`. When you provide a resource URI, VS Code automatically derives the appropriate label, description, and icon based on the resource type, matching your current theme's file icon set. This is particularly useful when building file or folder selection interfaces, as users can quickly identify items by their familiar file type icons.
+Quick Pick アイテムは、`QuickPickItem` の `resourceUri` プロパティを介して、ファイルタイプ固有のアイコンを表示できます。リソース URI を提供すると、VS Code はリソースタイプに基づいて適切なラベル、説明、アイコンを自動的に導き出し、現在のテーマのファイルアイコンセットに一致させます。これは、ユーザーが使い慣れたファイルタイプのアイコンでアイテムをすばやく識別できるため、ファイルまたはフォルダー選択インターフェイスを構築する際に特に便利です。
 
-Your comments and feedback on this API proposal are appreciated (please refer to the [GitHub issue](https://github.com/microsoft/vscode/issues/59826)).
+この API 提案に関するご意見やフィードバックをお待ちしております ([GitHub issue](https://github.com/microsoft/vscode/issues/59826) を参照してください)。
 
 ```typescript
 export interface QuickPickItem {
   /**
-   * A {@link Uri} representing the resource associated with this item.
+   * このアイテムに関連付けられたリソースを表す {@link Uri}。
    *
-   * When set, this property is used to automatically derive several item properties if they are not explicitly provided:
-   * - **Label**: Derived from the resource's file name when {@link QuickPickItem.label label} is not provided or is empty.
-   * - **Description**: Derived from the resource's path when {@link QuickPickItem.description description} is not provided or is empty.
-   * - **Icon**: Derived from the current file icon theme when {@link QuickPickItem.iconPath iconPath} is set to
-   *   {@link ThemeIcon.File} or {@link ThemeIcon.Folder}.
+   * 設定されている場合、このプロパティは、明示的に提供されていない場合にいくつかのアイテムプロパティを自動的に導き出すために使用されます:
+   * - **Label**: {@link QuickPickItem.label label} が提供されていないか空の場合、リソースのファイル名から導き出されます。
+   * - **Description**: {@link QuickPickItem.description description} が提供されていないか空の場合、リソースのパスから導き出されます。
+   * - **Icon**: {@link QuickPickItem.iconPath iconPath} が {@link ThemeIcon.File} または {@link ThemeIcon.Folder} に設定されている場合、現在のファイルアイコンテーマから導き出されます。
    */
   resourceUri?: Uri;
 }
 ```
-### GitHub-style alerts in MarkdownStrings ([#209652](https://github.com/microsoft/vscode/issues/209652)) {#githubstyle-alerts-in-markdownstrings-hash209652httpsgithubcommicrosoftvscodeissues209652}
+### MarkdownStrings での GitHub スタイルのアラート ([#209652](https://github.com/microsoft/vscode/issues/209652)) {#githubstyle-alerts-in-markdownstrings-hash209652httpsgithubcommicrosoftvscodeissues209652}
 
-We have added support for rendering [GitHub-style alert syntax](https://github.com/orgs/community/discussions/16925) in `MarkdownString` by setting a new property `supportAlertSyntax`.
+新しいプロパティ `supportAlertSyntax` を設定することで、`MarkdownString` で [GitHub スタイルのアラート構文](https://github.com/orgs/community/discussions/16925)をレンダリングするためのサポートを追加しました。
 
 ```typescript
 const markdown = new vscode.MarkdownString();
 markdown.supportAlertSyntax = true;
 markdown.value = `
 > [!NOTE]
-> Useful information that users should know, even when skimming content.
+> コンテンツをざっと見ているときでも、ユーザーが知っておくべき役立つ情報。
 
 > [!TIP]
-> Helpful advice for doing things better or more easily.
+> 物事をより良く、またはより簡単に行うための役立つアドバイス。
 
 > [!IMPORTANT]
-> Key information users need to know to achieve their goal.
+> ユーザーが目標を達成するために知っておく必要がある重要な情報。
 
 > [!WARNING]
-> Urgent info that needs immediate user attention to avoid problems.
+> 問題を回避するためにユーザーの即時の注意が必要な緊急情報。
 
 > [!CAUTION]
-> Advises about risks or negative outcomes of certain actions.
+> 特定のアクションのリスクや否定的な結果についてのアドバイス。
 `;
 ```
 
-This enables extensions to render alerts in various places in the UI, such as comments:
+これにより、拡張機能はコメントなど、UI のさまざまな場所でアラートをレンダリングできます:
 
-![Screenshot showing GitHub-style alerts displayed in a comment thread showing each alert type with their respective icons and styling.](https://code.visualstudio.com/assets/updates/1_106/markdown-alerts.png)
+![スクリーンショットのコメントスレッドに表示される GitHub スタイルのアラート。各アラートタイプがそれぞれのアイコンとスタイルで表示されています。](https://code.visualstudio.com/assets/updates/1_106/markdown-alerts.png)
 
-### MarkdownString support in TreeItem labels ([#115365](https://github.com/microsoft/vscode/issues/115365)) {#markdownstring-support-in-treeitem-labels-hash115365httpsgithubcommicrosoftvscodeissues115365}
+### TreeItem ラベルでの MarkdownString サポート ([#115365](https://github.com/microsoft/vscode/issues/115365)) {#markdownstring-support-in-treeitem-labels-hash115365httpsgithubcommicrosoftvscodeissues115365}
 
-Extension authors can now use `MarkdownString` in tree view item labels, enabling a subset of Markdown syntax including codicons and text formatting. This allows extensions to create more visually rich tree views.
+拡張機能の作成者は、ツリービューアイテムのラベルで `MarkdownString` を使用できるようになり、codicon やテキストフォーマットを含む Markdown 構文のサブセットを有効にできます。これにより、拡張機能はより視覚的にリッチなツリービューを作成できます。
 
 ```typescript
 // Codicons
 const itemWithIcon = new vscode.TreeItem({ label: new vscode.MarkdownString('$(star) Starred item', true) });
 
-// Text formatting (must surround the entire string)
+// テキストフォーマット (文字列全体を囲む必要があります)
 const italicItem = new vscode.TreeItem({ label: new vscode.MarkdownString('_Italic item_') });
 
-// Formatting and codicons can be combined
+// フォーマットと codicon は組み合わせることができます
 const combined = new vscode.TreeItem({ label: new vscode.MarkdownString('_~~**$(check) Done $(star)**~~_', true) });
 ```
 
-The above items render as:
-![Screenshot of a tree view showing three items: a starred item with an icon, an italic item, and a combined item with check and star icons plus bold, italic, and strikethrough formatting.](https://code.visualstudio.com/assets/updates/1_106/markdown-labels.png)
+上記のアイテムは次のようにレンダリングされます:
+![3 つのアイテムを示すツリービューのスクリーンショット: アイコン付きのスター付きアイテム、イタリック体のアイテム、チェックとスターのアイコンに加えて太字、イタリック、取り消し線のフォーマットが施された結合アイテム。](https://code.visualstudio.com/assets/updates/1_106/markdown-labels.png)
 
-## Engineering {#engineering}
+## エンジニアリング {#engineering}
 
-### Exploration of automated UX PR testing {#exploration-of-automated-ux-pr-testing}
+### 自動化された UX PR テストの探求 {#exploration-of-automated-ux-pr-testing}
 
-We've introduced a new automation workflow that helps reviewers understand UI changes in pull requests without manually checking out and running the code. By adding the `~copilot-video-please` label to a pull request with UI changes, an automated process kicks off that:
+手動でコードをチェックアウトして実行することなく、レビュー担当者がプルリクエストの UI 変更を理解するのに役立つ新しい自動化ワークフローを導入しました。UI 変更のあるプルリクエストに `~copilot-video-please` ラベルを追加すると、自動化されたプロセスが開始されます:
 
-* Builds VS Code from the PR branch
-* Uses GitHub Copilot CLI to interact with the changes and record a video along the way - leveraging [playwright-mcp](https://github.com/microsoft/playwright-mcp)
-* Generates a Playwright trace for detailed inspection
-* Posts the results as a comment on the PR
+* PR ブランチから VS Code をビルドします
+* GitHub Copilot CLI を使用して変更と対話し、その過程でビデオを録画します - [playwright-mcp](https://github.com/microsoft/playwright-mcp) を活用
+* 詳細な検査のために Playwright トレースを生成します
+* 結果を PR のコメントとして投稿します
 
-While it's still early, this workflow can reduce the manual effort required for code review, especially for small UI changes. The videos and traces help reviewers quickly verify that changes work as expected. Currently, the videos are only accessible to team members.
+まだ初期段階ですが、このワークフローは、特に小さな UI 変更の場合、コードレビューに必要な手動の労力を削減できます。ビデオとトレースは、レビュー担当者が変更が期待どおりに機能することをすばやく確認するのに役立ちます。現在、ビデオはチームメンバーのみがアクセスできます。
 
-For more details about this automation, see <https://github.com/microsoft/vscode/issues/272529>.
+この自動化の詳細については、<https://github.com/microsoft/vscode/issues/272529> を参照してください。
 
-### macOS 11.0 support has ended {#macos-110-support-has-ended}
+### macOS 11.0 のサポートが終了しました {#macos-110-support-has-ended}
 
-VS Code `1.106` is the last release that supports macOS 11.0 (macOS Big Sur). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
+VS Code `1.106` は、macOS 11.0 (macOS Big Sur) をサポートする最後のリリースです。詳細については、[FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) を参照してください。
 
-## Notable fixes {#notable-fixes}
+## 注目すべき修正 {#notable-fixes}
 
-* [vscode#258236](https://github.com/microsoft/vscode/issues/258236) - Add setting for extensions request timeout used when installing extensions
-* [vscode#272945](https://github.com/microsoft/vscode/issues/272945) - Tasks do not trigger `onDidStartTerminalShellExecution`
-* [vscode#273372](https://github.com/microsoft/vscode/issues/273372) - `/**` is automatically closed with `*/` in .gitignore files
-* [vscode#243584](https://github.com/microsoft/vscode/issues/243584) - First input gets ignored on pwsh/conpty
-* [vscode#271952](https://github.com/microsoft/vscode/pull/271952) - Copilot 'configure instructions' quickpick doesn't show workspace-level agent instruction files (copilot-instructions.md, AGENTS.md)
-* [vscode#274631](https://github.com/microsoft/vscode/pull/274631) - Network: Load intermediate certification authorities on Windows
+* [vscode#258236](https://github.com/microsoft/vscode/issues/258236) - 拡張機能のインストール時に使用される拡張機能リクエストタイムアウトの設定を追加
+* [vscode#272945](https://github.com/microsoft/vscode/issues/272945) - タスクが `onDidStartTerminalShellExecution` をトリガーしない
+* [vscode#273372](https://github.com/microsoft/vscode/issues/273372) - .gitignore ファイルで `/**` が `*/` で自動的に閉じられる
+* [vscode#243584](https://github.com/microsoft/vscode/issues/243584) - pwsh/conpty で最初の入力が無視される
+* [vscode#271952](https://github.com/microsoft/vscode/pull/271952) - Copilot の 'configure instructions' クイックピックがワークスペースレベルのエージェント指示ファイル (copilot-instructions.md, AGENTS.md) を表示しない
+* [vscode#274631](https://github.com/microsoft/vscode/pull/274631) - ネットワーク: Windows で中間認証局をロードする
 
-## Thank you {#thank-you}
+## 謝辞 {#thank-you}
 
-### Issue tracking {#issue-tracking}
+### Issue トラッキング {#issue-tracking}
 
-Contributions to our issue tracking:
+Issue トラッキングへの貢献:
 
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
@@ -931,108 +930,108 @@ Contributions to our issue tracking:
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@Accurio (Accurio)](https://github.com/Accurio)
 
-### Pull Requests {#pull-requests}
+### プルリクエスト {#pull-requests}
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
-* [@AminSajedian (Amin Sajedian)](https://github.com/AminSajedian): Issue #210694 add hoverforeground and hoverbackground to activity bars [PR #263146](https://github.com/microsoft/vscode/pull/263146)
-* [@avarayr (avarayr)](https://github.com/avarayr): fix: Increase workbench border radius on macos tahoe [PR #270236](https://github.com/microsoft/vscode/pull/270236)
-* [@baptiste0928 (Baptiste Girardeau)](https://github.com/baptiste0928): fix: resolve renamed paths on merge editor [PR #254677](https://github.com/microsoft/vscode/pull/254677)
-* [@barroit (barroit)](https://github.com/barroit): Fix tabstop calc in tokenizeLineToHTML() [PR #263387](https://github.com/microsoft/vscode/pull/263387)
-* [@Benimautner](https://github.com/Benimautner): Fix: don't apply inertial scrolling if input device is a mouse. [PR #268284](https://github.com/microsoft/vscode/pull/268284)
-* [@danielbayley (Daniel Bayley)](https://github.com/danielbayley): Add `TM_DIRECTORY_BASE` snippets variable [PR #270262](https://github.com/microsoft/vscode/pull/270262)
-* [@dibarbet (David Barbet)](https://github.com/dibarbet): Hookup semantic tokens range refresh notification to the viewport contribution [PR #271419](https://github.com/microsoft/vscode/pull/271419)
-* [@dnicolson (Dave Nicolson)](https://github.com/dnicolson): Update activation event linter message [PR #269156](https://github.com/microsoft/vscode/pull/269156)
-* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): Fix disassembly view [PR #270361](https://github.com/microsoft/vscode/pull/270361)
-* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Show the `Learn How to Hide AI Features` in more situations (fix #268450) [PR #268462](https://github.com/microsoft/vscode/pull/268462)
-* [@imbant (imbant)](https://github.com/imbant): fix(chat): correct file icon rendering in Files & Folders picker [PR #255384](https://github.com/microsoft/vscode/pull/255384)
-* [@JeffreyCA](https://github.com/JeffreyCA): Add Fig spec for Azure Developer CLI (azd) [PR #272348](https://github.com/microsoft/vscode/pull/272348)
+* [@AminSajedian (Amin Sajedian)](https://github.com/AminSajedian): Issue #210694 アクティビティバーに hoverforeground と hoverbackground を追加 [PR #263146](https://github.com/microsoft/vscode/pull/263146)
+* [@avarayr (avarayr)](https://github.com/avarayr): 修正: macos tahoe でワークベンチの境界半径を増やす [PR #270236](https://github.com/microsoft/vscode/pull/270236)
+* [@baptiste0928 (Baptiste Girardeau)](https://github.com/baptiste0928): 修正: マージエディターで名前が変更されたパスを解決 [PR #254677](https://github.com/microsoft/vscode/pull/254677)
+* [@barroit (barroit)](https://github.com/barroit): tokenizeLineToHTML() のタブストップ計算を修正 [PR #263387](https://github.com/microsoft/vscode/pull/263387)
+* [@Benimautner](https://github.com/Benimautner): 修正: 入力デバイスがマウスの場合、慣性スクロールを適用しない [PR #268284](https://github.com/microsoft/vscode/pull/268284)
+* [@danielbayley (Daniel Bayley)](https://github.com/danielbayley): `TM_DIRECTORY_BASE` スニペット変数を追加 [PR #270262](https://github.com/microsoft/vscode/pull/270262)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): セマンティックトークンの範囲更新通知をビューポートコントリビューションにフック [PR #271419](https://github.com/microsoft/vscode/pull/271419)
+* [@dnicolson (Dave Nicolson)](https://github.com/dnicolson): アクティベーションイベントリンターメッセージを更新 [PR #269156](https://github.com/microsoft/vscode/pull/269156)
+* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): 逆アセンブリビューを修正 [PR #270361](https://github.com/microsoft/vscode/pull/270361)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): より多くの状況で `Learn How to Hide AI Features` を表示 (修正 #268450) [PR #268462](https://github.com/microsoft/vscode/pull/268462)
+* [@imbant (imbant)](https://github.com/imbant): 修正(chat): Files & Folders ピッカーでのファイルアイコンのレンダリングを修正 [PR #255384](https://github.com/microsoft/vscode/pull/255384)
+* [@JeffreyCA](https://github.com/JeffreyCA): Azure Developer CLI (azd) の Fig スペックを追加 [PR #272348](https://github.com/microsoft/vscode/pull/272348)
 * [@jlelong (Jerome Lelong)](https://github.com/jlelong)
-  * Make pair colorizer ignore \@ifnextchar [PR #272329](https://github.com/microsoft/vscode/pull/272329)
-  * Exclude trailing underscore from bracket pairs in LaTeX [PR #272758](https://github.com/microsoft/vscode/pull/272758)
-* [@jmg-duarte (José Duarte)](https://github.com/jmg-duarte): Fix localization for terminal.hoverHighlightBackground [PR #264228](https://github.com/microsoft/vscode/pull/264228)
-* [@Mingpan](https://github.com/Mingpan): Copy selection for deleted chunk in inline diff [PR #267991](https://github.com/microsoft/vscode/pull/267991)
+  * ペアカラーライザーが \@ifnextchar を無視するようにする [PR #272329](https://github.com/microsoft/vscode/pull/272329)
+  * LaTeX のブラケットペアから末尾のアンダースコアを除外 [PR #272758](https://github.com/microsoft/vscode/pull/272758)
+* [@jmg-duarte (José Duarte)](https://github.com/jmg-duarte): terminal.hoverHighlightBackground のローカライズを修正 [PR #264228](https://github.com/microsoft/vscode/pull/264228)
+* [@Mingpan](https://github.com/Mingpan): インライン差分で削除されたチャンクの選択をコピー [PR #267991](https://github.com/microsoft/vscode/pull/267991)
 * [@obrobrio2000 (Giovanni Magliocchetti)](https://github.com/obrobrio2000)
-  * Add "Go to Next/Previous Uncovered Line" navigation for Test Coverage [PR #269505](https://github.com/microsoft/vscode/pull/269505)
-  * html: add setting to disable end tag suggestions [PR #269605](https://github.com/microsoft/vscode/pull/269605)
-* [@ohah (ohah)](https://github.com/ohah): fix: file-found Badge vertical (#235159)  [PR #238757](https://github.com/microsoft/vscode/pull/238757)
-* [@rajniszp (Piotr Rajnisz)](https://github.com/rajniszp): i18n: add missing localizations for monaco-editor [PR #268038](https://github.com/microsoft/vscode/pull/268038)
-* [@RedCMD (RedCMD)](https://github.com/RedCMD): Fix soft wrapping on \n [PR #258407](https://github.com/microsoft/vscode/pull/258407)
-* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Add dotenv support [PR #273074](https://github.com/microsoft/vscode/pull/273074)
-* [@ritesh006 (Ritesh Kudkelwar)](https://github.com/ritesh006): feat(ts-codeLens): show "implementations" CodeLens for overridden methods #263749 [PR #264546](https://github.com/microsoft/vscode/pull/264546)
-* [@Selva-Ganesh-M (Selva Ganesh M)](https://github.com/Selva-Ganesh-M): fix(editor)(#261780): transform UPPER_CASE to PascalCase [PR #262959](https://github.com/microsoft/vscode/pull/262959)
+  * テストカバレッジに「Go to Next/Previous Uncovered Line」ナビゲーションを追加 [PR #269505](https://github.com/microsoft/vscode/pull/269505)
+  * html: 終了タグの提案を無効にする設定を追加 [PR #269605](https://github.com/microsoft/vscode/pull/269605)
+* [@ohah (ohah)](https://github.com/ohah): 修正: file-found Badge vertical (#235159) [PR #238757](https://github.com/microsoft/vscode/pull/238757)
+* [@rajniszp (Piotr Rajnisz)](https://github.com/rajniszp): i18n: monaco-editor の不足しているローカライズを追加 [PR #268038](https://github.com/microsoft/vscode/pull/268038)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD): \n でのソフトラップを修正 [PR #258407](https://github.com/microsoft/vscode/pull/258407)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): dotenv サポートを追加 [PR #273074](https://github.com/microsoft/vscode/pull/273074)
+* [@ritesh006 (Ritesh Kudkelwar)](https://github.com/ritesh006): feat(ts-codeLens): オーバーライドされたメソッドに "implementations" CodeLens を表示 #263749 [PR #264546](https://github.com/microsoft/vscode/pull/264546)
+* [@Selva-Ganesh-M (Selva Ganesh M)](https://github.com/Selva-Ganesh-M): 修正(editor)(#261780): UPPER_CASE を PascalCase に変換 [PR #262959](https://github.com/microsoft/vscode/pull/262959)
 * [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
-  * fix: memory leak in gettingStarted [PR #216876](https://github.com/microsoft/vscode/pull/216876)
-  * fix: memory leak in output view [PR #221605](https://github.com/microsoft/vscode/pull/221605)
-  * fix: memory leak in notebook text model [PR #265013](https://github.com/microsoft/vscode/pull/265013)
-  * fix: memory leak in InlayHints [PR #265185](https://github.com/microsoft/vscode/pull/265185)
-  * fix: memory leak in chat session tracker [PR #269027](https://github.com/microsoft/vscode/pull/269027)
-  * fix: memory leak in getTerminalActionBarArgs [PR #269516](https://github.com/microsoft/vscode/pull/269516)
-  * fix: memory leak in sticky scroll [PR #271102](https://github.com/microsoft/vscode/pull/271102)
-  * fix: memory leak in chat welcome [PR #271121](https://github.com/microsoft/vscode/pull/271121)
-* [@sinsincp](https://github.com/sinsincp): Fix AppUserModelID for code-workspace association [PR #272753](https://github.com/microsoft/vscode/pull/272753)
-* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): Testing - Uncompleted result should be marked as skipped [PR #273742](https://github.com/microsoft/vscode/pull/273742)
-* [@subin-chella (subin)](https://github.com/subin-chella): fix the bug #209943 [PR #216662](https://github.com/microsoft/vscode/pull/216662)
+  * 修正: gettingStarted のメモリリーク [PR #216876](https://github.com/microsoft/vscode/pull/216876)
+  * 修正: output view のメモリリーク [PR #221605](https://github.com/microsoft/vscode/pull/221605)
+  * 修正: notebook text model のメモリリーク [PR #265013](https://github.com/microsoft/vscode/pull/265013)
+  * 修正: InlayHints のメモリリーク [PR #265185](https://github.com/microsoft/vscode/pull/265185)
+  * 修正: chat session tracker のメモリリーク [PR #269027](https://github.com/microsoft/vscode/pull/269027)
+  * 修正: getTerminalActionBarArgs のメモリリーク [PR #269516](https://github.com/microsoft/vscode/pull/269516)
+  * 修正: sticky scroll のメモリリーク [PR #271102](https://github.com/microsoft/vscode/pull/271102)
+  * 修正: chat welcome のメモリリーク [PR #271121](https://github.com/microsoft/vscode/pull/271121)
+* [@sinsincp](https://github.com/sinsincp): code-workspace 関連付けの AppUserModelID を修正 [PR #272753](https://github.com/microsoft/vscode/pull/272753)
+* [@Skn0tt (Simon Knott)](https://github.com/Skn0tt): テスト - 未完了の結果はスキップとしてマークされるべき [PR #273742](https://github.com/microsoft/vscode/pull/273742)
+* [@subin-chella (subin)](https://github.com/subin-chella): バグ #209943 を修正 [PR #216662](https://github.com/microsoft/vscode/pull/216662)
 * [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
-  * chat: always apply prompt file and auto-attach instructions. Fix #271624 [PR #272020](https://github.com/microsoft/vscode/pull/272020)
-  * fix(chat): guard against undefined customModes.custom Fix #272223 and #272236 [PR #272263](https://github.com/microsoft/vscode/pull/272263)
-* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): Fix memory leak in InlineEditsGutterIndicator (#273549) [PR #273550](https://github.com/microsoft/vscode/pull/273550)
+  * chat: 常にプロンプトファイルと自動添付の指示を適用。修正 #271624 [PR #272020](https://github.com/microsoft/vscode/pull/272020)
+  * 修正(chat): 未定義の customModes.custom から保護。修正 #272223 と #272236 [PR #272263](https://github.com/microsoft/vscode/pull/272263)
+* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): InlineEditsGutterIndicator のメモリリークを修正 (#273549) [PR #273550](https://github.com/microsoft/vscode/pull/273550)
 
-Contributions to `vscode-copilot-chat`:
+`vscode-copilot-chat` への貢献:
 
-* [@24anisha](https://github.com/24anisha): Built-in toolsets for default tools [PR #1139](https://github.com/microsoft/vscode-copilot-chat/pull/1139)
-* [@AbdelrahmanAbouelenin (ababouelenin)](https://github.com/AbdelrahmanAbouelenin): Custom vsc model prompt  [PR #1504](https://github.com/microsoft/vscode-copilot-chat/pull/1504)
-* [@devm33 (Devraj Mehta)](https://github.com/devm33): Update repo URL in @vscode/chat-lib package [PR #1255](https://github.com/microsoft/vscode-copilot-chat/pull/1255)
-* [@DGideas (Wanlin Wang 王万霖)](https://github.com/DGideas): Improve error handling for Copilot Chat when 404 [PR #1073](https://github.com/microsoft/vscode-copilot-chat/pull/1073)
-* [@IanMatthewHuff (Ian Huff)](https://github.com/IanMatthewHuff): Fix issue with internal git repo telemetry collection [PR #1408](https://github.com/microsoft/vscode-copilot-chat/pull/1408)
-* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Allow latest server.json schema in assisted NuGet MCP install flow [PR #1268](https://github.com/microsoft/vscode-copilot-chat/pull/1268)
-* [@phawrylak (Paweł Hawrylak)](https://github.com/phawrylak): Add security-sensitive file extensions to workspace indexing exclusion list [PR #1157](https://github.com/microsoft/vscode-copilot-chat/pull/1157)
+* [@24anisha](https://github.com/24anisha): デフォルトツールのための組み込みツールセット [PR #1139](https://github.com/microsoft/vscode-copilot-chat/pull/1139)
+* [@AbdelrahmanAbouelenin (ababouelenin)](https://github.com/AbdelrahmanAbouelenin): カスタム vsc モデルプロンプト [PR #1504](https://github.com/microsoft/vscode-copilot-chat/pull/1504)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): @vscode/chat-lib パッケージのリポジトリ URL を更新 [PR #1255](https://github.com/microsoft/vscode-copilot-chat/pull/1255)
+* [@DGideas (Wanlin Wang 王万霖)](https://github.com/DGideas): Copilot Chat が 404 の場合のエラーハンドリングを改善 [PR #1073](https://github.com/microsoft/vscode-copilot-chat/pull/1073)
+* [@IanMatthewHuff (Ian Huff)](https://github.com/IanMatthewHuff): 内部 git リポジトリのテレメトリ収集に関する問題を修正 [PR #1408](https://github.com/microsoft/vscode-copilot-chat/pull/1408)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): アシスト付き NuGet MCP インストールフローで最新の server.json スキーマを許可 [PR #1268](https://github.com/microsoft/vscode-copilot-chat/pull/1268)
+* [@phawrylak (Paweł Hawrylak)](https://github.com/phawrylak): セキュリティに敏感なファイル拡張子をワークスペースインデックス除外リストに追加 [PR #1157](https://github.com/microsoft/vscode-copilot-chat/pull/1157)
 
-Contributions to `vscode-html-languageservice`:
+`vscode-html-languageservice` への貢献:
 
-* [@obrobrio2000 (Giovanni Magliocchetti)](https://github.com/obrobrio2000): Add setting to disable end tag suggestions [PR #219](https://github.com/microsoft/vscode-html-languageservice/pull/219)
+* [@obrobrio2000 (Giovanni Magliocchetti)](https://github.com/obrobrio2000): 終了タグの提案を無効にする設定を追加 [PR #219](https://github.com/microsoft/vscode-html-languageservice/pull/219)
 
-Contributions to `vscode-json-languageservice`:
+`vscode-json-languageservice` への貢献:
 
-* [@Legend-Master (Tony)](https://github.com/Legend-Master): Escape plain text description hover correctly [PR #283](https://github.com/microsoft/vscode-json-languageservice/pull/283)
+* [@Legend-Master (Tony)](https://github.com/Legend-Master): プレーンテキストの説明ホバーを正しくエスケープ [PR #283](https://github.com/microsoft/vscode-json-languageservice/pull/283)
 
-Contributions to `vscode-languageserver-node`:
+`vscode-languageserver-node` への貢献:
 
-* [@dibarbet (David Barbet)](https://github.com/dibarbet): Clear workspace pull state on document close to prevent stale diagnostics [PR #1674](https://github.com/microsoft/vscode-languageserver-node/pull/1674)
+* [@dibarbet (David Barbet)](https://github.com/dibarbet): 古い診断を防ぐためにドキュメントクローズ時にワークスペースプル状態をクリア [PR #1674](https://github.com/microsoft/vscode-languageserver-node/pull/1674)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
-* [@bendrucker (Ben Drucker)](https://github.com/bendrucker): Enable all LLM tools in prompts (agent mode) [PR #6956](https://github.com/microsoft/vscode-pull-request-github/pull/6956)
-* [@gerardbalaoro (Gerard Balaoro)](https://github.com/gerardbalaoro): Make branch list timeout configurable (#2840) [PR #7927](https://github.com/microsoft/vscode-pull-request-github/pull/7927)
-* [@wankun-tcj](https://github.com/wankun-tcj): Fix avatar display issue in Pull Request tree view [PR #7851](https://github.com/microsoft/vscode-pull-request-github/pull/7851)
+* [@bendrucker (Ben Drucker)](https://github.com/bendrucker): プロンプト (エージェントモード) で全ての LLM ツールを有効化 [PR #6956](https://github.com/microsoft/vscode-pull-request-github/pull/6956)
+* [@gerardbalaoro (Gerard Balaoro)](https://github.com/gerardbalaoro): ブランチリストのタイムアウトを設定可能にする (#2840) [PR #7927](https://github.com/microsoft/vscode-pull-request-github/pull/7927)
+* [@wankun-tcj](https://github.com/wankun-tcj): プルリクエストツリービューのアバター表示の問題を修正 [PR #7851](https://github.com/microsoft/vscode-pull-request-github/pull/7851)
 
-Contributions to `vscode-test-cli`:
+`vscode-test-cli` への貢献:
 
-* [@bwateratmsft (Brandon Waterloo [MSFT])](https://github.com/bwateratmsft): Bump version ahead of release [PR #86](https://github.com/microsoft/vscode-test-cli/pull/86)
+* [@bwateratmsft (Brandon Waterloo [MSFT])](https://github.com/bwateratmsft): リリース前にバージョンを上げる [PR #86](https://github.com/microsoft/vscode-test-cli/pull/86)
 
-Contributions to `debug-adapter-protocol`:
+`debug-adapter-protocol` への貢献:
 
-* [@rsubtil (Ricardo Subtil)](https://github.com/rsubtil): Add Godot to the list of DAP adapters [PR #568](https://github.com/microsoft/debug-adapter-protocol/pull/568)
+* [@rsubtil (Ricardo Subtil)](https://github.com/rsubtil): DAP アダプターのリストに Godot を追加 [PR #568](https://github.com/microsoft/debug-adapter-protocol/pull/568)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@kristoff-it (Loris Cro)](https://github.com/kristoff-it): Update servers.md [PR #2192](https://github.com/microsoft/language-server-protocol/pull/2192)
+* [@kristoff-it (Loris Cro)](https://github.com/kristoff-it): servers.md を更新 [PR #2192](https://github.com/microsoft/language-server-protocol/pull/2192)
 
-Contributions to `monaco-editor`:
+`monaco-editor` への貢献:
 
-* [@flofriday (Florian Freitag)](https://github.com/flofriday): Fix Kotlin number literals [PR #4973](https://github.com/microsoft/monaco-editor/pull/4973)
+* [@flofriday (Florian Freitag)](https://github.com/flofriday): Kotlin の数値リテラルを修正 [PR #4973](https://github.com/microsoft/monaco-editor/pull/4973)
 
-Contributions to `node-pty`:
+`node-pty` への貢献:
 
-* [@devm33 (Devraj Mehta)](https://github.com/devm33): Load native addons directly from prebuilds directory [PR #809](https://github.com/microsoft/node-pty/pull/809)
+* [@devm33 (Devraj Mehta)](https://github.com/devm33): prebuilds ディレクトリからネイティブアドオンを直接ロード [PR #809](https://github.com/microsoft/node-pty/pull/809)
 
-Contributions to `python-environment-tools`:
+`python-environment-tools` への貢献:
 
-* [@VictorColomb (Victor Colomb)](https://github.com/VictorColomb): fix(poetry): pep503 normalize package name [PR #242](https://github.com/microsoft/python-environment-tools/pull/242)
+* [@VictorColomb (Victor Colomb)](https://github.com/VictorColomb): 修正(poetry): pep503 パッケージ名を正規化 [PR #242](https://github.com/microsoft/python-environment-tools/pull/242)
 
-We really appreciate people trying our new features as soon as they are ready, so check back here often and learn what's new.
+新機能が準備でき次第、試してくださる皆様に心から感謝いたします。頻繁にこちらをチェックして、新機能について学んでください。
 
->If you'd like to read release notes for previous VS Code versions, go to [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).
+>以前の VS Code バージョンのリリースノートを読みたい場合は、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) にアクセスしてください。
 
-<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<a id="scroll-to-top" role="button" title="トップへスクロール" aria-label="トップへスクロール" href="#"><span class="icon"></span></a>
 <link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_106.md
+++ b/docs/release-notes/v1_106.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_106/release-highlights.png
 Date: 2025-11-12
 DownloadVersion: 1.106.0
 ---
-# October 2025 (version 1.106)
+# October 2025 (version 1.106) {#october-2025-version-1106}
 
 _Release date: November 12, 2025_
 
@@ -87,9 +87,9 @@ There are many updates in this version that we hope you'll like, some of the key
   <div class="notes-main">
 Navigation End -->
 
-## Agents
+## Agents {#agents}
 
-### Agent Sessions view
+### Agent Sessions view {#agent-sessions-view}
 
 **Setting**: `setting(chat.agentSessionsViewLocation)`
 
@@ -111,7 +111,7 @@ The Agent Sessions view now also supports search (`kb(list.find)`) to help you e
 
 Learn more about the [Agent Sessions view](https://code.visualstudio.com/docs/copilot/chat/chat-sessions/#_agent-sessions-view) in the VS Code documentation.
 
-### Plan agent
+### Plan agent {#plan-agent}
 
 A new plan agent helps developers break down complex tasks step-by-step before any code is written. Select **Plan** from the agents dropdown in the Chat view to get started. When tackling a multi-step implementation, VS Code prompts you with clarifying questions and generates a detailed implementation plan that you approve first, ensuring all requirements and context are captured upfront.
 
@@ -121,7 +121,7 @@ We recommend spending time iterating on the plan before implementation. You can 
 
 You can also create your own custom plan agent tailored to your team's specific workflow and tools. Use the **Configure Custom Agent** menu to copy the built-in plan agent as a starting point, then customize the planning style, tools, and prompts to match your development process. Learn more about [planning in VS Code chat](https://code.visualstudio.com/docs/copilot/chat/chat-planning) and [creating custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents).
 
-### Cloud agents
+### Cloud agents {#cloud-agents}
 
 In this release, we have made quite a few updates to cloud agent sessions in the editor.
 
@@ -129,7 +129,7 @@ We migrated the Copilot coding agent integration from the GitHub Pull Request ex
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/deeplink.mp4" title="Video showing GitHub Mission Control integration with VS Code." autoplay loop controls muted></video>
 
-### CLI agents
+### CLI agents {#cli-agents}
 
 In this release, we have also shipped an initial integration with the [Copilot CLI](https://github.com/features/copilot/cli/). You can create new and resume existing CLI agent sessions in a chat editor or an integrated terminal.
 
@@ -139,7 +139,7 @@ In a CLI agent editor, you can send messages to the Copilot CLI just as you woul
 
 ![Screenshot showing a CLI agent editor and an integrated terminal with Copilot CLI sessions.](https://code.visualstudio.com/assets/updates/1_106/cli-editor-and-terminal.png)
 
-### Agent delegation
+### Agent delegation {#agent-delegation}
 
 We continue to improve the experience for delegating to cloud agents.
 
@@ -147,11 +147,11 @@ When you use the cloud button to delegate to an agent from the chat panel, you'l
 
 ![Screenshot showing delegating from a CLI agent editor.](https://code.visualstudio.com/assets/updates/1_106/cli-delegate-editor.png)
 
-### CLI agent edit tracking
+### CLI agent edit tracking {#cli-agent-edit-tracking}
 
 Chat edit sessions now track edits made by background agents, such as the Copilot CLI. When you create sessions from the Agent Sessions view, you can see edits tracked through both inline edit pills and the working set view, making it easier to understand what changes agents are making to your workspace.
 
-### Chat modes renamed to custom agents
+### Chat modes renamed to custom agents {#chat-modes-renamed-to-custom-agents}
 
 Chat modes have been renamed to custom agents throughout VS Code to better align with terminology used in other environments.
 
@@ -163,7 +163,7 @@ Use **Chat: New Custom Agent...** to create a new agent and **Chat: Configure Cu
 
 If you have existing custom chat modes (`.chatmode.md` files in `.github/chatmodes`), they continue to work and are automatically treated as custom agents. When you open a chat agent file in the editor, a info marker appears on the first line with a quick fix to migrate it to a custom agent file.
 
-### Custom agent metadata
+### Custom agent metadata {#custom-agent-metadata}
 
 Custom agent `.agent.md` files now accept an additional `target` frontmatter property to describe how an agent should run across environments:
 
@@ -182,15 +182,15 @@ The agent file editor provides validation, code completions, hovers and code act
 
 Learn more about [custom agents and agent handoffs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
 
-## Code Editing
+## Code Editing {#code-editing}
 
-### Deleted code in diff editor is now selectable
+### Deleted code in diff editor is now selectable {#deleted-code-in-diff-editor-is-now-selectable}
 
 Previously, when you deleted code and viewed the changes in the diff editor, you couldn't copy those deleted lines. In this release, you can now select and copy text from deleted lines in the diff editor when using the inline diff view.
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/diff-editor-select-deleted-lines-text.mp4" title="Video showing selecting text in deleted lines in the diff editor." autoplay loop controls muted></video>
 
-### Inline suggestions are open source
+### Inline suggestions are open source {#inline-suggestions-are-open-source}
 
 This release continues our journey to make VS Code an open source AI editor. Following our first milestone of open sourcing GitHub Copilot Chat, we've now open sourced inline suggestions by merging them into the vscode-copilot-chat repository.
 
@@ -198,13 +198,13 @@ As part of this milestone, we're consolidating the GitHub Copilot extension and 
 
 The GitHub Copilot extension will be deprecated by early 2026. Learn more about this milestone and explore the open source code in our [blog post](https://code.visualstudio.com/blogs/2025/11/04/openSourceAIEditorSecondMilestone).
 
-### Snooze inline suggestions from gutter
+### Snooze inline suggestions from gutter {#snooze-inline-suggestions-from-gutter}
 
 You can now snooze inline suggestions directly from the gutter icon. When you hover over the gutter icon, a control appears with a **Snooze** option. Select it and choose a duration to pause suggestions.
 
 ![Screenshot showing the Snooze button in the gutter context menu for inline suggestions.](https://code.visualstudio.com/assets/updates/1_106/nes-snooze.png)
 
-### Go to line improvements
+### Go to line improvements {#go-to-line-improvements}
 
 This iteration, we've made several enhancements to the **Go to Line** command (`kb(workbench.action.gotoLine)`), improving navigation within files.
 
@@ -224,33 +224,33 @@ In addition, the **Go to Line** command also handles out-of-range values more gr
 * **Line numbers**: Typing a line number larger than the file's line count navigates to the last line.
 * **Column numbers**: Using negative column numbers navigates from the end of a line. For example, `:12:-1` takes you to the last character on line 12. Typing a column number larger than the length of the line takes you to the end of the line.
 
-## Editor Experience
+## Editor Experience {#editor-experience}
 
-### Refreshed iconography
+### Refreshed iconography {#refreshed-iconography}
 
 In this release, the codicon icon set has had a facelift. The new icons have been refined with curves, new modifier designs, and more accurate metaphors to make them feel modern, friendly and more legible.
 
 ![Screenshot of updated product icons showing a more modern appearance and increased legibility.](https://code.visualstudio.com/assets/updates/1_106/refreshed-iconography.png)
 
-### Linux policy support
+### Linux policy support {#linux-policy-support}
 
 We've introduced support for managing VS Code policies on Linux systems using JSON files. This allows administrators to enforce specific settings and configurations across all users on a Linux machine.
 
 For more details, see [JSON Policies on Linux](https://code.visualstudio.com/docs/setup/enterprise#_json-policies-on-linux).
 
-### Navigate changes in multi file diff editor
+### Navigate changes in multi file diff editor {#navigate-changes-in-multi-file-diff-editor}
 
 Just like you can navigate to next or previous changes in a diff editor for a single file, you can now do so across files in the multi-file diff editor. Use keybindings or the navigation up and down arrow keys to review your changes across files.
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/multiFileDiffNav.mp4" title="Video showing navigating changes in multi-file diff editor." autoplay loop controls muted></video>
 
-### Copy diagnostic hover text
+### Copy diagnostic hover text {#copy-diagnostic-hover-text}
 
 A copy button now appears in diagnostic hovers (errors, warnings, info, and hints) to make copying error messages easier. When you hover over a diagnostic marker, move your mouse over the hover message to reveal a copy button in the top-right corner.
 
 ![Screenshot of hovering over a diagnostic hover revealing a copy button in the top-right corner.](https://code.visualstudio.com/assets/updates/1_106/hover-copy-button.png)
 
-### Accent-insensitive command filtering
+### Accent-insensitive command filtering {#accentinsensitive-command-filtering}
 
 The Command Palette now ignores character accents when searching for commands, making it easier to find what you need regardless of your keyboard layout or language preferences. For example, when searching for a command containing the word `Générer` (French for `Generate`), type `generer` without accents and matching commands appear in the results.
 
@@ -258,7 +258,7 @@ This is helpful when using different keyboard layouts or when mistyping while lo
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/filtering.mp4" title="Video showing filtering in Command Palette." autoplay loop controls muted></video>
 
-### Advanced VS Code settings
+### Advanced VS Code settings {#advanced-vs-code-settings}
 
 VS Code now supports the concept of advanced settings. These settings are meant for configuring specialized scenarios and are intended for advanced users who need fine-grained control over their environment. By default, advanced settings are hidden in the Settings editor, keeping the interface streamlined while making these powerful options available when needed.
 
@@ -272,15 +272,15 @@ Advanced settings can be combined with other filters such as `@modified` or `@fe
 
 >**Note:** Extension authors can mark their settings as advanced by adding the `advanced` tag to the setting configuration.
 
-## Chat
+## Chat {#chat}
 
-### Embeddings-based tool selection
+### Embeddings-based tool selection {#embeddingsbased-tool-selection}
 
 In this release we've significantly improved how we filter and group tools for users that have many (over 100) tools enabled in chat. You should see the "Optimizing tool selection..." loading state less often and for a shorter period of time. We also improved tool selection with a lower probability of agent confusion to make sure the right tools are chosen.
 
-### Tool approvals and trust
+### Tool approvals and trust {#tool-approvals-and-trust}
 
-#### Post-approval for external data
+#### Post-approval for external data {#postapproval-for-external-data}
 
 Agent tools that pull in external data now support post-approval. This helps protect against potential prompt injection attacks by letting you review the data before it's used in your chat session.
 
@@ -288,7 +288,7 @@ Agent tools that pull in external data now support post-approval. This helps pro
 
 Post-approval is enabled for the `#fetch` tool and for Model Context Protocol (MCP) tools that declare `openWorldHint`.
 
-#### Trust all tools for a server or extension
+#### Trust all tools for a server or extension {#trust-all-tools-for-a-server-or-extension}
 
 You can now trust MCP servers and extension tools at the source level through the **Allow** button dropdown. This means that you can approve all tools from a specific MCP server or extension at once, rather than having to approve each tool individually.
 
@@ -296,15 +296,15 @@ We have also updated the **Chat: Manage Tool Approval** command experience to le
 
 ![Screenshot of the Manage Tool Approval command experience, enabling tools to skip approval and skipping content review.](https://code.visualstudio.com/assets/updates/1_106/manage-tool-approvals.png)
 
-#### Tool auto approval status moved
+#### Tool auto approval status moved {#tool-auto-approval-status-moved}
 
 Auto approval status has moved from being inline inside the chat view to the tool call status/tick icon:
 
 ![Screenshot of hovering a tool's tick icon will reveal why it was auto approved](https://code.visualstudio.com/assets/updates/1_106/tool-auto-approve-hover.png)
 
-### Terminal tool
+### Terminal tool {#terminal-tool}
 
-#### Auto approve parser improvements
+#### Auto approve parser improvements {#auto-approve-parser-improvements}
 
 Previously, subcommand detection in the terminal tool used the naive approach of just splitting on certain strings such as `|` or `&&`. This failed in several ways but the bigger ones were when pipe was used inside strings like `echo "a|b|c"`, which would detect the subcommands `echo`, `b` and `c"`. Another important one is that since we couldn't reliably pull subcommands, we outright banned paranthesis pairs, curly brace pairs, and backticks to be more on the safe side and prevent accidental execution.
 
@@ -314,29 +314,29 @@ This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter
 
 \* _Note that this means it can fail to catch subcommands when the shell syntax differs from bash, such as `;` in zsh_
 
-#### File write/redirection detection (Experimental)
+#### File write/redirection detection (Experimental) {#file-writeredirection-detection-experimental}
 
 Thanks to the new parser, we're able to fairly reliably extract files being written to via redirection. There's the new experimental setting `setting(chat.tools.terminal.blockDetectedFileWrites)` that will prevent auto approval conditionally.
 
 ![Screenshot showing that writing outside the workspace by default will block auto approval.](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-redirection.png)
 
-#### Disable default auto approve rules (Experimental)
+#### Disable default auto approve rules (Experimental) {#disable-default-auto-approve-rules-experimental}
 
 The new experimental setting `setting(chat.tools.terminal.ignoreDefaultAutoApproveRules)` allows disabling the default rules (both allow and deny rules). This is useful if you want more control without needing to look up the defaults.
 
-#### Shell specific prompts and command rewriting
+#### Shell specific prompts and command rewriting {#shell-specific-prompts-and-command-rewriting}
 
 The terminal tool now has shell-specific descriptions for PowerShell, bash, zsh and fish. This should make commands suggested by the agent more reliable and less likely to fail, especially for PowerShell.
 
 In addition to this, for PowerShell we also re-write `&&` to `;` since the `&&` chain operator is not supported in Windows PowerShell (v5). Note that this is temporarily also happening for PowerShell 7 until [vscode#274548](https://github.com/microsoft/vscode/issues/274548) is actioned.
 
-#### Attach terminal commands to chat
+#### Attach terminal commands to chat {#attach-terminal-commands-to-chat}
 
 You can now attach a terminal command to chat as context from the command decoration's context menu. The attachment shares the command line, captured output, and exit code so the agent understands precisely what happened. This applies to any command tracked by shell integration, making it easy to escalate troubleshooting without copying and pasting text.
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/terminal-attachment.mp4" title="Video showing attaching terminal commands to chat." autoplay loop controls muted></video>
 
-#### View terminal output inside chat (Experimental)
+#### View terminal output inside chat (Experimental) {#view-terminal-output-inside-chat-experimental}
 
 The new `setting(chat.tools.terminal.outputLocation)` setting controls where the output is displayed. The default `none` value prevents the terminals from cluttering the panel.
 
@@ -349,7 +349,7 @@ When `npm i` fails, the output is automatically expanded. The terminal is reveal
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-output.mp4" title="Video showing terminal output showing inline in the Chat view and the option to open it in the terminal." autoplay loop controls muted></video>
 
-#### Discover hidden chat terminals (Experimental)
+#### Discover hidden chat terminals (Experimental) {#discover-hidden-chat-terminals-experimental}
 
 When `setting(chat.tools.terminal.outputLocation):none`, a new **X hidden terminal(s)** button appears in the terminal tabs view when there is at least one hidden chat terminal. It opens a quick pick that lists each chat terminal alongside its chat session so you can immediately focus the right process. The same picker is available from the terminal overflow menu under **View Hidden Chat Terminals**, and it disappears once all chat terminals are visible again.
 
@@ -357,7 +357,7 @@ The agent runs `ls -la`, which succeeds, so the output is collapsed. The **hidde
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-hidden.mp4" title="Video showing discovering hidden chat terminals." autoplay loop controls muted></video>
 
-### Save conversation as prompt
+### Save conversation as prompt {#save-conversation-as-prompt}
 
 You can now save your chat conversations as reusable prompts with the `/savePrompt` command. When you invoke `/savePrompt` in an active chat session, VS Code generates a prompt file containing a generalized prompt based on your conversation. The editor displays a blue button that lets you save this prompt to a valid location, either at the user or workspace level.
 
@@ -365,7 +365,7 @@ You can now save your chat conversations as reusable prompts with the `/saveProm
 
 This feature replaces the previous `/save` command and provides a more streamlined workflow for capturing and sharing useful conversation patterns. The generated prompts can be easily reused in future chat sessions or shared with your team. Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
 
-### Edit welcome prompts
+### Edit welcome prompts {#edit-welcome-prompts}
 
 You can now right-click on suggested prompts in the Chat welcome view to access additional actions. When you right-click a prompt (or press `kbstyle(Shift+F10)`), a context menu appears with an **Edit Prompt File** option to open the corresponding prompt file directly in the editor.
 
@@ -375,13 +375,13 @@ Editing a prompt file works for prompts that have an associated file, including 
 
 Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
 
-### Automatically open edited files
+### Automatically open edited files {#automatically-open-edited-files}
 
 **Setting**: `setting(chat.openEditedFilesAutomatically)`
 
 We changed the default behavior of the agent to no longer automatically open edited files in an editor. If you prefer the previous behavior, you can enable the setting `setting(accessibility.openChatEditedFiles)`.
 
-### Reasoning (Experimental)
+### Reasoning (Experimental) {#reasoning-experimental}
 
 **Setting**: `setting(chat.agent.thinkingStyle)`, `setting(chat.agent.thinking.collapsedTools)`
 
@@ -393,7 +393,7 @@ An additional setting, `setting(chat.agent.thinking.collapsedTools)`, adds tool 
 
 ![Screenshot showing reasoning tokens displayed in chat with interweaved tool cals and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](https://code.visualstudio.com/assets/updates/1_106/reasoning.png)
 
-### Inline chat v2 (Preview)
+### Inline chat v2 (Preview) {#inline-chat-v2-preview}
 
 **Setting**: `setting(inlineChat.enableV2:true)`
 
@@ -407,7 +407,7 @@ This makes the overall experience much lighter and allows for a simplified UI. F
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/inline-chat.mp4" title="Showing Inline chat in action" autoplay loop controls muted></video>
 
-### Chat view UX improvements
+### Chat view UX improvements {#chat-view-ux-improvements}
 
 We tweaked some parts of the Chat view to make it feel more pleasant to use:
 
@@ -419,9 +419,9 @@ We tweaked some parts of the Chat view to make it feel more pleasant to use:
 
 It is now also possible to copy math source by right-clicking math expressions in the chat view.
 
-## MCP
+## MCP {#mcp}
 
-### MCP server access for your organization
+### MCP server access for your organization {#mcp-server-access-for-your-organization}
 
 **Settings**: `setting(chat.mcp.gallery.serviceUrl)`, `setting(chat.mcp.access)`
 
@@ -438,13 +438,13 @@ When your organization has configured these policies, the `setting(chat.mcp.gall
 
 To learn more about configuring MCP server access for your organization or enterprise, see [Configure MCP server access](https://docs.github.com/en/copilot/how-tos/administer-copilot/configure-mcp-server-access).
 
-### Install MCP servers to workspace configuration
+### Install MCP servers to workspace configuration {#install-mcp-servers-to-workspace-configuration}
 
 When installing an MCP server, you can now choose whether to install it globally or to the workspace configuration. Right-click on an MCP server in the extensions view and select **Install (Workspace)** from the context menu, or use the **Install (Workspace)** action directly in the MCP server editor. This adds the MCP server to the `.vscode/mcp.json` file in your current workspace, making it easier to share MCP servers with your team.
 
 ![Screenshot showing the context menu for an MCP server with the Install (Workspace) option highlighted](https://code.visualstudio.com/assets/updates/1_106/mcp-install-workspace.png)
 
-### Authentication: Client ID Metadata Document authentication flow
+### Authentication: Client ID Metadata Document authentication flow {#authentication-client-id-metadata-document-authentication-flow}
 
 Authentication support for remote MCPs now supports the [Client ID Metadata Document (CIMD)](https://www.ietf.org/archive/id/draft-parecki-oauth-client-id-metadata-document-00.html) authentication flow, which is the future standard for OAuth in MCP. This flow enables a more secure and scaleable solution to authentication over [Dynamic Client Registiration (DCR)](https://datatracker.ietf.org/doc/html/rfc7591) because now authorization servers do not have to worry about issuing client IDs per-client.
 
@@ -452,33 +452,33 @@ When connecting to an MCP server that uses an authorization server that supports
 
 _For more information about CIMD, take a look at [the resources on oauth.net](https://oauth.net/2/client-id-metadata-document/)._
 
-### Authentication: `WWW-Authenticate` scope step up
+### Authentication: `WWW-Authenticate` scope step up {#authentication-wwwauthenticate-scope-step-up}
 
 Authentication support for remote MCPs now supports dynamic scope escalation through the `WWW-Authenticate` header for remote MCP servers. This is called out in [the OAuth 2.0 specification](https://datatracker.ietf.org/doc/html/rfc6750#section-3). This allows MCP servers to request additional permissions when needed, rather than requiring all scopes upfront. For example, connecting to a server might require a minimal set of scopes, but specific tool calls can request broader permissions only when necessary. This provides better security by following the principle of least privilege.
 
 _This is currently called out in the [latest draft of the MCP specification](https://modelcontextprotocol.io/specification/draft/basic/authorization#scope-selection-strategy) which is expected to be finalized soon._
 
-## Accessibility
+## Accessibility {#accessibility}
 
-### Speech timeout is disabled by default
+### Speech timeout is disabled by default {#speech-timeout-is-disabled-by-default}
 
 The configuration `setting(accessibility.voice.speechTimeout)` has changed to be `0` by default. This means, a voice session no longer ends automatically after a certain delay (e.g. a Chat request would not be triggered automatically if you pause). We feel this is a better default experience, but you can always change back to the previous default (`2500`).
 
-### Chat input improvements
+### Chat input improvements {#chat-input-improvements}
 
 The chat input now announces the active agent and model in a clearer order so screen reader users hear the most relevant context first. The chat accessibility help also calls out that you can press **Delete** to remove attached context items, making attachment management fully keyboard-accessible.
 
-## Notebooks
+## Notebooks {#notebooks}
 
-### Notebook search
+### Notebook search {#notebook-search}
 
 Notebooks now supports searching across cells. Use key bindings (`kb(notebook.findNext.fromWidget)` and `kb(notebook.findPrevious.fromWidget)`) to navigate to the next and previous match, just like you would in the editor.
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/notebookSearch.mp4" title="Video showing search in notebook cells." autoplay loop controls muted></video>
 
-## Source Control
+## Source Control {#source-control}
 
-### Folding support in git commit messages
+### Folding support in git commit messages {#folding-support-in-git-commit-messages}
 
 **Settings**: `setting(git.verboseCommit)`, `setting(git.useEditorAsCommitInput)`
 
@@ -486,7 +486,7 @@ When writing git commit messages in the editor, you can now fold sections of the
 
 ![Screenshot showing folding nodes in the gutter and a partially collapsed commit message in the editor.](https://code.visualstudio.com/assets/updates/1_106/commit-folding.png)
 
-### Graph incoming/outgoing changes
+### Graph incoming/outgoing changes {#graph-incomingoutgoing-changes}
 
 **Settings**: `setting(scm.graph.showIncomingChanges)`, `setting(scm.graph.showOutgoingChanges)`
 
@@ -496,13 +496,13 @@ This milestone, we are adding the capability to easily view incoming and outgoin
 
 You can hide this information from the Graph view by using the `setting(scm.graph.showIncomingChanges:false)` and `setting(scm.graph.showOutgoingChanges:false)` settings.
 
-### Graph compare references
+### Graph compare references {#graph-compare-references}
 
 We have added a new command to the Source Control Graph context menu, **Compare with...**, that enables you to compare a history item in the graph with an arbitrary branch or tag. This feature lets you view changes that are in the history item but not in the branch or tag.
 
 In the context menu, there are shortcuts commands, **Compare with Remote** and **Compare with Merge Base** for comparing a history item with the remote branch and merge base respectively.
 
-### Repositories selection mode
+### Repositories selection mode {#repositories-selection-mode}
 
 **Setting**: `setting(scm.repositories.selectionMode)`
 
@@ -514,7 +514,7 @@ Apart from the new functionality in the Repositories view, this also allows us t
 
 ![Screenshot showing the Repositories view with single selection mode enabled and the context menu to toggle selection mode.](https://code.visualstudio.com/assets/updates/1_106/repositories-selection-mode.png)
 
-### Repositories explorer (experimental)
+### Repositories explorer (experimental) {#repositories-explorer-experimental}
 
 **Settings**: `setting(scm.repositories.explorer:true)`, `setting(scm.repositories.selectionMode:single)`
 
@@ -524,9 +524,9 @@ In this first iteration, we have focused on branches and tags. You can create ne
 
 ![Screenshot showing the Repositories explorer with branches and tags for a single selected repository.](https://code.visualstudio.com/assets/updates/1_106/repositories-explorer.png)
 
-## Testing
+## Testing {#testing}
 
-### Navigate uncovered lines in test coverage
+### Navigate uncovered lines in test coverage {#navigate-uncovered-lines-in-test-coverage}
 
 When reviewing test coverage, you can now easily navigate between uncovered lines using new navigation commands. Two commands are available in the editor toolbar when viewing coverage information:
 
@@ -535,9 +535,9 @@ When reviewing test coverage, you can now easily navigate between uncovered line
 
 These commands help you quickly identify coverage gaps and focus on areas that need additional test coverage, making it easier to improve the overall test quality of your codebase.
 
-## Terminal
+## Terminal {#terminal}
 
-### Terminal IntelliSense
+### Terminal IntelliSense {#terminal-intellisense}
 
 Terminal IntelliSense has been in the product as an experimental/preview feature [for around 1.5 years](https://code.visualstudio.com/updates/v1_89#_vs-codenative-intellisense-for-powershell)! This release we're removing the preview tag and will be doing a staged roll out as the default to all users on stable.
 
@@ -577,21 +577,21 @@ Apart from overall polish, this is what is coming to the feature this release:
 
 ![Screenshot of git commit completions showing branch names and their associated commit messages in the terminal suggest details view.](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-commit.png)
 
-### Consolidated shell integration timeout setting
+### Consolidated shell integration timeout setting {#consolidated-shell-integration-timeout-setting}
 
 We now have one unified configurable setting, `setting(terminal.integrated.shellIntegration.timeout)`, that controls how long VS Code waits for shell integration to become ready before executing commands in the terminal, including those triggered through the executeCommand API and by Copilot terminal tool.
 
 `setting(chat.tools.terminal.shellIntegrationTimeout)` has been deprecated in favor of this consolidation.
 
-## Authentication
+## Authentication {#authentication}
 
-### Manage extension account preferences discoverability
+### Manage extension account preferences discoverability {#manage-extension-account-preferences-discoverability}
 
 The **Manage Extension Account Preferences** command is now more discoverable. In addition to being available in the Command Palette and extension context menus, it now appears in the Account Menu alongside **Manage Language Model Access**. This makes it easier to find and configure which accounts extensions can access.
 
 ![Screenshot of Manage Extension Account Preferences in the Account menu.](https://code.visualstudio.com/assets/updates/1_106/manageExtensionAccountPref.png)
 
-### Last version of `classic` Microsoft authentication - use `msal-no-broker` if you experience issues
+### Last version of `classic` Microsoft authentication - use `msal-no-broker` if you experience issues {#last-version-of-classic-microsoft-authentication-use-msalnobroker-if-you-experience-issues}
 
 We will be removing the `classic` option for `setting(microsoft-authentication.implementation)`. This means that VS Code release 1.106 is the final version that has the `classic` option.
 
@@ -603,11 +603,11 @@ The `setting(microsoft-authentication.implementation)` setting has been around t
 
 We will remove the `classic` option since it's usage is very low and most issues with the `msal` option are due to the brokering, which is remedied with `msal-no-broker`.
 
-### Device code flow for Microsoft authentication
+### Device code flow for Microsoft authentication {#device-code-flow-for-microsoft-authentication}
 
 Microsoft authentication now supports the device code flow in non-brokered scenarios, particularly useful for remote development environments. When other authentication methods fail, VS Code automatically falls back to device code flow, which displays a code that you can enter on another device to complete authentication.
 
-### Manage accounts command
+### Manage accounts command {#manage-accounts-command}
 
 Manage your authentication accounts directly from the Command Palette using the **Accounts: Manage Accounts** command. This command provides access to account management features when the Account menu is hidden or not easily accessible.
 
@@ -619,19 +619,19 @@ When you run the **Manage Accounts** command, you'll see a quick pick menu listi
 * **Manage Trusted MCP Servers** - Manage MCP server access permissions for accounts that support this capability
 * **Sign Out** - Sign out of the account
 
-## Languages
+## Languages {#languages}
 
-### Python
+### Python {#python}
 
-#### Python Environments Extension: Support for python.poetryPath setting
+#### Python Environments Extension: Support for python.poetryPath setting {#python-environments-extension-support-for-pythonpoetrypath-setting}
 
 The Python Environments Extension now respects the existing `python.poetryPath` user setting. This allows you to specify which Poetry executable to use. The provided path will be searched for and selected when managing Poetry environments.
 
-#### Python Environments Extension: Improved venv creation: dev-requirements.txt detection
+#### Python Environments Extension: Improved venv creation: dev-requirements.txt detection {#python-environments-extension-improved-venv-creation-devrequirementstxt-detection}
 
 When creating a new virtual environment, the extension now detects both requirements.txt and dev-requirements.txt files and installs dependencies automatically.
 
-#### Add Copilot Hover Summaries as docstring
+#### Add Copilot Hover Summaries as docstring {#add-copilot-hover-summaries-as-docstring}
 
 You can now add your AI-generated documentation directly into your code as a docstring using the new **Add as docstring** command in Copilot Hover Summaries. When you generate a summary for a function or class, navigate to the symbol definition and hover over it to access the **Add as docstring** command, which inserts the summary below your cursor formatted as a proper docstring.
 
@@ -639,26 +639,26 @@ This streamlines the process of documenting your code, allowing you to quickly e
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/pylance-add-hover-summaries-as-docstring.mp4" title="Add as docstring command in Copilot Hover Summaries." autoplay loop controls muted></video>
 
-#### Localized Copilot Hover Summaries
+#### Localized Copilot Hover Summaries {#localized-copilot-hover-summaries}
 
 GitHub Copilot Hover Summaries inside Pylance now respect your display language within VS Code. When you invoke an AI-generated summary, you'll get strings in the language you've set for your editor, making it easier to understand the generated documentation.
 
 ![Screenshot of a Copilot Hover Summary generated in Portuguese.](https://code.visualstudio.com/assets/updates/1_106/hover-summaries-in-portuguese.png)
 
-#### Convert wildcard imports Code Action
+#### Convert wildcard imports Code Action {#convert-wildcard-imports-code-action}
 
 Wildcard imports (from module import *) are often discouraged in Python because they can clutter your namespace and make it unclear where names come from, reducing code clarity and maintainability.
 Pylance now helps you clean up modules that still rely on `from module import *` via a new Code Action. It replaces the wildcard with the explicit symbols, preserving aliases and keeping the import to a single statement. To try it out, you can click on the line with the wildcard import and press `kbstyle(Ctrl+.)` (or `kbstyle(Cmd+.)` on macOS) to select the **Convert to explicit imports** Code Action.
 
 ![Screenshot of the Convert wildcard imports Code Action.](https://code.visualstudio.com/assets/updates/1_106/wildcard-import.png)
 
-### dotenv
+### dotenv {#dotenv}
 
 There is built in basic support for dotenv files (`.env`), which are commonly used to define environment variables for applications.
 
-## Contributions to extensions
+## Contributions to extensions {#contributions-to-extensions}
 
-### GitHub Pull Requests
+### GitHub Pull Requests {#github-pull-requests}
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
 
@@ -668,9 +668,9 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 Review the [changelog for the 0.122.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01220) release of the extension to learn about everything in the release.
 
-## Preview Features
+## Preview Features {#preview-features}
 
-### Language Models editor
+### Language Models editor {#language-models-editor}
 
 A new **Language Models** editor provides a centralized place to view and manage all available language models for GitHub Copilot Chat. You can open it from the chat model picker or via the command **Chat: Manage Language Models**.
 
@@ -694,7 +694,7 @@ You can search and filter models using:
 
 Hover over model names or context sizes to see detailed information including model ID, version, status, and token breakdown.
 
-#### Manage model visibility
+#### Manage model visibility {#manage-model-visibility}
 
 Control which models appear in the chat model picker by toggling their visibility with the eye icon next to each model. When a model is visible, it appears in the model picker dropdown when you're using GitHub Copilot Chat, making it available for selection. Hidden models remain in the Language Models editor but won't appear in the model picker, helping you keep your model selection focused on the ones you use most frequently.
 
@@ -702,7 +702,7 @@ Control which models appear in the chat model picker by toggling their visibilit
 
 This is particularly useful when you have access to many models and want to streamline your workflow by showing only your preferred models in the picker.
 
-#### Add models from installed providers
+#### Add models from installed providers {#add-models-from-installed-providers}
 
 Use the **Add Models...** button to configure and add models from language model providers you've already installed. When you select this button, you'll see a dropdown list of all installed model providers, such as Copilot, Anthropic, Azure, Google, Groq, Ollama, OpenAI, and others. Select a provider from the list to configure it and start using its models in GitHub Copilot Chat.
 
@@ -710,9 +710,9 @@ Use the **Add Models...** button to configure and add models from language model
 
 This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
 
-## Extension Authoring
+## Extension Authoring {#extension-authoring}
 
-### ID token in authentication sessions
+### ID token in authentication sessions {#id-token-in-authentication-sessions}
 
 The `AuthenticationSession` interface now includes an optional `idToken` property. This allows authentication providers to return ID tokens in addition to access tokens, which is particularly useful for scenarios that require user identity information. The Microsoft authentication provider returns this field, while other providers like GitHub may not.
 
@@ -727,11 +727,11 @@ export interface AuthenticationSession {
 }
 ```
 
-### Git extension `getRepositoryWorkspace` API
+### Git extension `getRepositoryWorkspace` API {#git-extension-getrepositoryworkspace-api}
 
 The build in Git extension offers new API for getting a folder that's known to be associated with a git repository remote. This works by caching a repository-remote to folder mapping when the user opens a folder with a git remote.
 
-### View containers in Secondary Side Bar
+### View containers in Secondary Side Bar {#view-containers-in-secondary-side-bar}
 
 Extension authors can now register view containers in the Secondary Side Bar by using the new `secondarySidebar` contribution point. This lets extensions place their custom views alongside built-in views like Chat in the Secondary Side Bar and provide a better integration with VS Code's dual side bar layout.
 
@@ -760,15 +760,15 @@ Extension authors can now register view containers in the Secondary Side Bar by 
 }
 ```
 
-## Proposed APIs
+## Proposed APIs {#proposed-apis}
 
-### Quick Pick and Quick Input improvements
+### Quick Pick and Quick Input improvements {#quick-pick-and-quick-input-improvements}
 
 The Quick Pick and Quick Input APIs include several new capabilities that give extension developers more flexibility in creating interactive user interfaces.
 
 <video src="https://code.visualstudio.com/assets/updates/1_106/quick-pick-api.mp4" title="Video showing quick pick with prompt, toggle and file icons." autoplay loop controls muted></video>
 
-#### Proposed API: Toggle button support
+#### Proposed API: Toggle button support {#proposed-api-toggle-button-support}
 
 Extensions can add toggle buttons to Quick Pick and Quick Input interfaces through the `toggles` property on `QuickInput`. This enables scenarios like a password visibility toggle in the input box area, allowing users to interact with controls without leaving the quick pick interface.
 
@@ -798,7 +798,7 @@ export interface QuickInputButton {
 }
 ```
 
-#### Proposed API: Prompt support for Quick Pick
+#### Proposed API: Prompt support for Quick Pick {#proposed-api-prompt-support-for-quick-pick}
 
 Quick Pick supports a `prompt` property, similar to the one available in Input Box. The prompt displays persistent text beneath the input box that remains visible while users type, providing helpful guidance or instructions that doesn't disappear when the user starts entering text.
 
@@ -824,7 +824,7 @@ export interface QuickPickOptions {
 }
 ```
 
-#### Proposed API: File icons for Quick Pick items
+#### Proposed API: File icons for Quick Pick items {#proposed-api-file-icons-for-quick-pick-items}
 
 Quick Pick items can display file-type-specific icons through the `resourceUri` property on `QuickPickItem`. When you provide a resource URI, VS Code automatically derives the appropriate label, description, and icon based on the resource type, matching your current theme's file icon set. This is particularly useful when building file or folder selection interfaces, as users can quickly identify items by their familiar file type icons.
 
@@ -844,8 +844,7 @@ export interface QuickPickItem {
   resourceUri?: Uri;
 }
 ```
-
-### GitHub-style alerts in MarkdownStrings ([#209652](https://github.com/microsoft/vscode/issues/209652))
+### GitHub-style alerts in MarkdownStrings ([#209652](https://github.com/microsoft/vscode/issues/209652)) {#githubstyle-alerts-in-markdownstrings-hash209652httpsgithubcommicrosoftvscodeissues209652}
 
 We have added support for rendering [GitHub-style alert syntax](https://github.com/orgs/community/discussions/16925) in `MarkdownString` by setting a new property `supportAlertSyntax`.
 
@@ -874,7 +873,7 @@ This enables extensions to render alerts in various places in the UI, such as co
 
 ![Screenshot showing GitHub-style alerts displayed in a comment thread showing each alert type with their respective icons and styling.](https://code.visualstudio.com/assets/updates/1_106/markdown-alerts.png)
 
-### MarkdownString support in TreeItem labels ([#115365](https://github.com/microsoft/vscode/issues/115365))
+### MarkdownString support in TreeItem labels ([#115365](https://github.com/microsoft/vscode/issues/115365)) {#markdownstring-support-in-treeitem-labels-hash115365httpsgithubcommicrosoftvscodeissues115365}
 
 Extension authors can now use `MarkdownString` in tree view item labels, enabling a subset of Markdown syntax including codicons and text formatting. This allows extensions to create more visually rich tree views.
 
@@ -892,9 +891,9 @@ const combined = new vscode.TreeItem({ label: new vscode.MarkdownString('_~~**$(
 The above items render as:
 ![Screenshot of a tree view showing three items: a starred item with an icon, an italic item, and a combined item with check and star icons plus bold, italic, and strikethrough formatting.](https://code.visualstudio.com/assets/updates/1_106/markdown-labels.png)
 
-## Engineering
+## Engineering {#engineering}
 
-### Exploration of automated UX PR testing
+### Exploration of automated UX PR testing {#exploration-of-automated-ux-pr-testing}
 
 We've introduced a new automation workflow that helps reviewers understand UI changes in pull requests without manually checking out and running the code. By adding the `~copilot-video-please` label to a pull request with UI changes, an automated process kicks off that:
 
@@ -907,11 +906,11 @@ While it's still early, this workflow can reduce the manual effort required for 
 
 For more details about this automation, see <https://github.com/microsoft/vscode/issues/272529>.
 
-### macOS 11.0 support has ended
+### macOS 11.0 support has ended {#macos-110-support-has-ended}
 
 VS Code `1.106` is the last release that supports macOS 11.0 (macOS Big Sur). Refer to our [FAQ](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-old-macos-versions) for additional information.
 
-## Notable fixes
+## Notable fixes {#notable-fixes}
 
 * [vscode#258236](https://github.com/microsoft/vscode/issues/258236) - Add setting for extensions request timeout used when installing extensions
 * [vscode#272945](https://github.com/microsoft/vscode/issues/272945) - Tasks do not trigger `onDidStartTerminalShellExecution`
@@ -920,9 +919,9 @@ VS Code `1.106` is the last release that supports macOS 11.0 (macOS Big Sur). Re
 * [vscode#271952](https://github.com/microsoft/vscode/pull/271952) - Copilot 'configure instructions' quickpick doesn't show workspace-level agent instruction files (copilot-instructions.md, AGENTS.md)
 * [vscode#274631](https://github.com/microsoft/vscode/pull/274631) - Network: Load intermediate certification authorities on Windows
 
-## Thank you
+## Thank you {#thank-you}
 
-### Issue tracking
+### Issue tracking {#issue-tracking}
 
 Contributions to our issue tracking:
 
@@ -932,7 +931,7 @@ Contributions to our issue tracking:
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 * [@Accurio (Accurio)](https://github.com/Accurio)
 
-### Pull Requests
+### Pull Requests {#pull-requests}
 
 Contributions to `vscode`:
 

--- a/docs/release-notes/v1_106.md
+++ b/docs/release-notes/v1_106.md
@@ -17,7 +17,7 @@ _Release date: November 12, 2025_
 
 Welcome to the October 2025 release of Visual Studio Code.
 
-![Graphic showing the key highlights of the October 2025 release: Agent HQ, Security and trust, and great editor experience.](images/1_106/release-highlights.png)
+![Graphic showing the key highlights of the October 2025 release: Agent HQ, Security and trust, and great editor experience.](https://code.visualstudio.com/assets/updates/1_106/release-highlights.png)
 
 This releases brings significant updates across three key areas:
 
@@ -97,17 +97,17 @@ As you hand off tasks to various coding agents, it's important to have a clear o
 
 By default, the Agent Sessions view lists all your active chat sessions organized by their source. The view is divided into sections for local chat sessions in VS Code and for background agent sessions:
 
-![Screenshot of the Agent Sessions view in the Primary Side Bar, showing a view for local chat sessions, and coding agents like Copilot coding agent, Copilot CLI and Codex.](images/1_106/agent-sessions-view.png)
+![Screenshot of the Agent Sessions view in the Primary Side Bar, showing a view for local chat sessions, and coding agents like Copilot coding agent, Copilot CLI and Codex.](https://code.visualstudio.com/assets/updates/1_106/agent-sessions-view.png)
 
 If you prefer to have one consolidated view of your sessions across all providers, you can enable the `single-view` option for the `setting(chat.agentSessionsViewLocation)` setting. This option also moves the Agent Sessions view next to the Chat view in the Secondary Side Bar, making it easier to switch between chat and managing your sessions.
 
-<video src="images/1_106/agent-sessions.mp4" title="Video showing new agent sessions view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/agent-sessions.mp4" title="Video showing new agent sessions view." autoplay loop controls muted></video>
 
 Note that not all functionality is available in the consolidated view yet. We are actively working on making this view the default in the near future.
 
 The Agent Sessions view now also supports search (`kb(list.find)`) to help you easily find your sessions in the list.
 
-<video src="images/1_106/sessionsPaneSearch.mp4" title="Video showing search in the Agent Sessions view to find sessions that match your query." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/sessionsPaneSearch.mp4" title="Video showing search in the Agent Sessions view to find sessions that match your query." autoplay loop controls muted></video>
 
 Learn more about the [Agent Sessions view](https://code.visualstudio.com/docs/copilot/chat/chat-sessions/#_agent-sessions-view) in the VS Code documentation.
 
@@ -115,7 +115,7 @@ Learn more about the [Agent Sessions view](https://code.visualstudio.com/docs/co
 
 A new plan agent helps developers break down complex tasks step-by-step before any code is written. Select **Plan** from the agents dropdown in the Chat view to get started. When tackling a multi-step implementation, VS Code prompts you with clarifying questions and generates a detailed implementation plan that you approve first, ensuring all requirements and context are captured upfront.
 
-<video src="images/1_106/plan-mode.mp4" title="Video showing the plan agent in action." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/plan-mode.mp4" title="Video showing the plan agent in action." autoplay loop controls muted></video>
 
 We recommend spending time iterating on the plan before implementation. You can refine requirements, adjust scope, and address open questions multiple times to build a solid foundation. Once you approve the plan, Copilot implements it either locally in VS Code or via [cloud agents](https://code.visualstudio.com/docs/copilot/copilot-coding-agent), giving you greater control and visibility into the development process. This helps you catch gaps or missing decisions early, reducing rework and improving code quality.
 
@@ -127,17 +127,17 @@ In this release, we have made quite a few updates to cloud agent sessions in the
 
 We migrated the Copilot coding agent integration from the GitHub Pull Request extension into the Copilot Chat extension to provide a more native cloud agent experience in VS Code. This integration paves the way for smoother transitions and interactions between VS Code and [GitHub Mission Control](https://github.com/copilot/agents), such as opening a cloud agent session directly from the Agent Sessions view in the browser and vice versa.
 
-<video src="images/1_106/deeplink.mp4" title="Video showing GitHub Mission Control integration with VS Code." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/deeplink.mp4" title="Video showing GitHub Mission Control integration with VS Code." autoplay loop controls muted></video>
 
 ### CLI agents
 
 In this release, we have also shipped an initial integration with the [Copilot CLI](https://github.com/features/copilot/cli/). You can create new and resume existing CLI agent sessions in a chat editor or an integrated terminal.
 
-![Screenshot of the CLI dropdown menu showing options to create a new CLI agent session or resume an existing one.](images/1_106/cli-dropdown.png)
+![Screenshot of the CLI dropdown menu showing options to create a new CLI agent session or resume an existing one.](https://code.visualstudio.com/assets/updates/1_106/cli-dropdown.png)
 
 In a CLI agent editor, you can send messages to the Copilot CLI just as you would in a terminal, switch models, and attach context.
 
-![Screenshot showing a CLI agent editor and an integrated terminal with Copilot CLI sessions.](images/1_106/cli-editor-and-terminal.png)
+![Screenshot showing a CLI agent editor and an integrated terminal with Copilot CLI sessions.](https://code.visualstudio.com/assets/updates/1_106/cli-editor-and-terminal.png)
 
 ### Agent delegation
 
@@ -145,7 +145,7 @@ We continue to improve the experience for delegating to cloud agents.
 
 When you use the cloud button to delegate to an agent from the chat panel, you'll be provided a set of available agents to which you can delegate. You can also delegate to the Copilot coding agent from the CLI, via the `/delegate` command in a CLI editor or terminal instance.
 
-![Screenshot showing delegating from a CLI agent editor.](images/1_106/cli-delegate-editor.png)
+![Screenshot showing delegating from a CLI agent editor.](https://code.visualstudio.com/assets/updates/1_106/cli-delegate-editor.png)
 
 ### CLI agent edit tracking
 
@@ -155,7 +155,7 @@ Chat edit sessions now track edits made by background agents, such as the Copilo
 
 Chat modes have been renamed to custom agents throughout VS Code to better align with terminology used in other environments.
 
-![Screenshot of the agent picker control.](images/1_106/agent-picker.png)
+![Screenshot of the agent picker control.](https://code.visualstudio.com/assets/updates/1_106/agent-picker.png)
 
 When you create custom agents, the definition files are now located in `.github/agents` in your workspace. These files can use the `.agents.md` suffix and can also be used as Github Copilot Cloud Agents and CLI Agent.
 
@@ -178,7 +178,7 @@ All agents can be run in all environments. Each environment ignores unknown attr
 
 The agent file editor provides validation, code completions, hovers and code actions.
 
-![GIF of validation while editing custom agent files.](images/1_106/agent-file-editing.gif)
+![GIF of validation while editing custom agent files.](https://code.visualstudio.com/assets/updates/1_106/agent-file-editing.gif)
 
 Learn more about [custom agents and agent handoffs](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
 
@@ -188,7 +188,7 @@ Learn more about [custom agents and agent handoffs](https://code.visualstudio.co
 
 Previously, when you deleted code and viewed the changes in the diff editor, you couldn't copy those deleted lines. In this release, you can now select and copy text from deleted lines in the diff editor when using the inline diff view.
 
-<video src="images/1_106/diff-editor-select-deleted-lines-text.mp4" title="Video showing selecting text in deleted lines in the diff editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/diff-editor-select-deleted-lines-text.mp4" title="Video showing selecting text in deleted lines in the diff editor." autoplay loop controls muted></video>
 
 ### Inline suggestions are open source
 
@@ -202,7 +202,7 @@ The GitHub Copilot extension will be deprecated by early 2026. Learn more about 
 
 You can now snooze inline suggestions directly from the gutter icon. When you hover over the gutter icon, a control appears with a **Snooze** option. Select it and choose a duration to pause suggestions.
 
-![Screenshot showing the Snooze button in the gutter context menu for inline suggestions.](images/1_106/nes-snooze.png)
+![Screenshot showing the Snooze button in the gutter context menu for inline suggestions.](https://code.visualstudio.com/assets/updates/1_106/nes-snooze.png)
 
 ### Go to line improvements
 
@@ -217,7 +217,7 @@ To navigate to a character offset, type `::` followed by the character number in
 
 Use the toggle in the input box to switch between 1-based (default) and 0-based offset calculations.
 
-<video src="images/1_106/go-to-line.mp4" title="Video showing editor navigation using Go To Line command." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/go-to-line.mp4" title="Video showing editor navigation using Go To Line command." autoplay loop controls muted></video>
 
 In addition, the **Go to Line** command also handles out-of-range values more gracefully and makes it easier to navigate to the start or end of files and lines:
 
@@ -230,7 +230,7 @@ In addition, the **Go to Line** command also handles out-of-range values more gr
 
 In this release, the codicon icon set has had a facelift. The new icons have been refined with curves, new modifier designs, and more accurate metaphors to make them feel modern, friendly and more legible.
 
-![Screenshot of updated product icons showing a more modern appearance and increased legibility.](images/1_106/refreshed-iconography.png)
+![Screenshot of updated product icons showing a more modern appearance and increased legibility.](https://code.visualstudio.com/assets/updates/1_106/refreshed-iconography.png)
 
 ### Linux policy support
 
@@ -242,13 +242,13 @@ For more details, see [JSON Policies on Linux](https://code.visualstudio.com/doc
 
 Just like you can navigate to next or previous changes in a diff editor for a single file, you can now do so across files in the multi-file diff editor. Use keybindings or the navigation up and down arrow keys to review your changes across files.
 
-<video src="images/1_106/multiFileDiffNav.mp4" title="Video showing navigating changes in multi-file diff editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/multiFileDiffNav.mp4" title="Video showing navigating changes in multi-file diff editor." autoplay loop controls muted></video>
 
 ### Copy diagnostic hover text
 
 A copy button now appears in diagnostic hovers (errors, warnings, info, and hints) to make copying error messages easier. When you hover over a diagnostic marker, move your mouse over the hover message to reveal a copy button in the top-right corner.
 
-![Screenshot of hovering over a diagnostic hover revealing a copy button in the top-right corner.](images/1_106/hover-copy-button.png)
+![Screenshot of hovering over a diagnostic hover revealing a copy button in the top-right corner.](https://code.visualstudio.com/assets/updates/1_106/hover-copy-button.png)
 
 ### Accent-insensitive command filtering
 
@@ -256,7 +256,7 @@ The Command Palette now ignores character accents when searching for commands, m
 
 This is helpful when using different keyboard layouts or when mistyping while looking for a command. The filtering is based on [Unicode Normalization Form D](https://www.unicode.org/reports/tr15/#Norm_Forms) and supports all Unicode languages.
 
-<video src="images/1_106/filtering.mp4" title="Video showing filtering in Command Palette." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/filtering.mp4" title="Video showing filtering in Command Palette." autoplay loop controls muted></video>
 
 ### Advanced VS Code settings
 
@@ -264,7 +264,7 @@ VS Code now supports the concept of advanced settings. These settings are meant 
 
 To view and configure advanced settings, select **Advanced** from the filter dropdown menu in the Settings editor, or type `@tag:advanced` in the search box:
 
-![Screenshot showing the Settings editor with the Advanced filter applied, displaying advanced settings with the Advanced tag badge](images/1_106/advanced-settings.png)
+![Screenshot showing the Settings editor with the Advanced filter applied, displaying advanced settings with the Advanced tag badge](https://code.visualstudio.com/assets/updates/1_106/advanced-settings.png)
 
 When you search for a specific setting by its exact name or use the `@id:` filter, advanced settings appear in the results without having to apply the **Advanced** filter. This ensures you can always find the settings you're looking for.
 
@@ -284,7 +284,7 @@ In this release we've significantly improved how we filter and group tools for u
 
 Agent tools that pull in external data now support post-approval. This helps protect against potential prompt injection attacks by letting you review the data before it's used in your chat session.
 
-<video src="images/1_106/post-approval.mp4" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/post-approval.mp4" autoplay loop controls muted></video>
 
 Post-approval is enabled for the `#fetch` tool and for Model Context Protocol (MCP) tools that declare `openWorldHint`.
 
@@ -294,13 +294,13 @@ You can now trust MCP servers and extension tools at the source level through th
 
 We have also updated the **Chat: Manage Tool Approval** command experience to let you manage both pre- and post-approval of tools.
 
-![Screenshot of the Manage Tool Approval command experience, enabling tools to skip approval and skipping content review.](images/1_106/manage-tool-approvals.png)
+![Screenshot of the Manage Tool Approval command experience, enabling tools to skip approval and skipping content review.](https://code.visualstudio.com/assets/updates/1_106/manage-tool-approvals.png)
 
 #### Tool auto approval status moved
 
 Auto approval status has moved from being inline inside the chat view to the tool call status/tick icon:
 
-![Screenshot of hovering a tool's tick icon will reveal why it was auto approved](images/1_106/tool-auto-approve-hover.png)
+![Screenshot of hovering a tool's tick icon will reveal why it was auto approved](https://code.visualstudio.com/assets/updates/1_106/tool-auto-approve-hover.png)
 
 ### Terminal tool
 
@@ -310,7 +310,7 @@ Previously, subcommand detection in the terminal tool used the naive approach of
 
 This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter/) into the feature and use a [PowerShell grammar](https://github.com/airbus-cert/tree-sitter-powershell) or a [bash grammar](https://github.com/tree-sitter/tree-sitter-bash) for everything else\*. So, even really complex cases should be correctly extracted:
 
-![Screenshot of detecting "$()" inside echo calls.](images/1_106/tool-terminal-parser.png)
+![Screenshot of detecting "$()" inside echo calls.](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-parser.png)
 
 \* _Note that this means it can fail to catch subcommands when the shell syntax differs from bash, such as `;` in zsh_
 
@@ -318,7 +318,7 @@ This release, we integrated a [parser](https://tree-sitter.github.io/tree-sitter
 
 Thanks to the new parser, we're able to fairly reliably extract files being written to via redirection. There's the new experimental setting `setting(chat.tools.terminal.blockDetectedFileWrites)` that will prevent auto approval conditionally.
 
-![Screenshot showing that writing outside the workspace by default will block auto approval.](images/1_106/tool-terminal-redirection.png)
+![Screenshot showing that writing outside the workspace by default will block auto approval.](https://code.visualstudio.com/assets/updates/1_106/tool-terminal-redirection.png)
 
 #### Disable default auto approve rules (Experimental)
 
@@ -334,7 +334,7 @@ In addition to this, for PowerShell we also re-write `&&` to `;` since the `&&` 
 
 You can now attach a terminal command to chat as context from the command decoration's context menu. The attachment shares the command line, captured output, and exit code so the agent understands precisely what happened. This applies to any command tracked by shell integration, making it easy to escalate troubleshooting without copying and pasting text.
 
-<video src="images/1_106/terminal-attachment.mp4" title="Video showing attaching terminal commands to chat." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-attachment.mp4" title="Video showing attaching terminal commands to chat." autoplay loop controls muted></video>
 
 #### View terminal output inside chat (Experimental)
 
@@ -347,7 +347,7 @@ Every chat terminal invocation now surfaces two actions on the progress element:
 
 When `npm i` fails, the output is automatically expanded. The terminal is revealed with the **Show Terminal** inline action.
 
-<video src="images/1_106/terminal-chat-output.mp4" title="Video showing terminal output showing inline in the Chat view and the option to open it in the terminal." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-output.mp4" title="Video showing terminal output showing inline in the Chat view and the option to open it in the terminal." autoplay loop controls muted></video>
 
 #### Discover hidden chat terminals (Experimental)
 
@@ -355,13 +355,13 @@ When `setting(chat.tools.terminal.outputLocation):none`, a new **X hidden termin
 
 The agent runs `ls -la`, which succeeds, so the output is collapsed. The **hidden terminal** action is taken from the tabs view and the terminal is selected, revealed, and scrolled to highlight the command.
 
-<video src="images/1_106/terminal-chat-hidden.mp4" title="Video showing discovering hidden chat terminals." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-chat-hidden.mp4" title="Video showing discovering hidden chat terminals." autoplay loop controls muted></video>
 
 ### Save conversation as prompt
 
 You can now save your chat conversations as reusable prompts with the `/savePrompt` command. When you invoke `/savePrompt` in an active chat session, VS Code generates a prompt file containing a generalized prompt based on your conversation. The editor displays a blue button that lets you save this prompt to a valid location, either at the user or workspace level.
 
-![Screenshot of the Save prompt button in the editor.](images/1_106/save-prompt-prompt.png)
+![Screenshot of the Save prompt button in the editor.](https://code.visualstudio.com/assets/updates/1_106/save-prompt-prompt.png)
 
 This feature replaces the previous `/save` command and provides a more streamlined workflow for capturing and sharing useful conversation patterns. The generated prompts can be easily reused in future chat sessions or shared with your team. Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
 
@@ -371,7 +371,7 @@ You can now right-click on suggested prompts in the Chat welcome view to access 
 
 Editing a prompt file works for prompts that have an associated file, including user-defined prompts and project-specific prompts configured through the `setting(chat.promptFilesRecommendations)` setting.
 
-![Screenshot of a context menu for a suggested prompt.](images/1_106/welcome-prompt-context.png)
+![Screenshot of a context menu for a suggested prompt.](https://code.visualstudio.com/assets/updates/1_106/welcome-prompt-context.png)
 
 Learn more about [custom prompt files](https://code.visualstudio.com/docs/copilot/customization/prompt-files).
 
@@ -391,7 +391,7 @@ The `setting(chat.agent.thinkingStyle)` was adjusted to three more common styles
 
 An additional setting, `setting(chat.agent.thinking.collapsedTools)`, adds tool calls into the collapsible thinking UI.
 
-![Screenshot showing reasoning tokens displayed in chat with interweaved tool cals and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](images/1_106/reasoning.png)
+![Screenshot showing reasoning tokens displayed in chat with interweaved tool cals and reasoning output. This is the UI with `fixedScrolling` and `readOnly` for the respective thinking settings.](https://code.visualstudio.com/assets/updates/1_106/reasoning.png)
 
 ### Inline chat v2 (Preview)
 
@@ -405,7 +405,7 @@ We have ramped up our efforts to modernize inline chat. It's built to be
 
 This makes the overall experience much lighter and allows for a simplified UI. For tasks it cannot handle, you'll be automatically upgraded to the Chat view.
 
-<video src="images/1_106/inline-chat.mp4" title="Showing Inline chat in action" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/inline-chat.mp4" title="Showing Inline chat in action" autoplay loop controls muted></video>
 
 ### Chat view UX improvements
 
@@ -415,7 +415,7 @@ We tweaked some parts of the Chat view to make it feel more pleasant to use:
 * The tools and MCP server actions moved right next to the model picker
 * The configuration dropdown is cleaned up
 
-![Screenshot of the action to create a new chat dropdown menu.](images/1_106/chat-view.png)
+![Screenshot of the action to create a new chat dropdown menu.](https://code.visualstudio.com/assets/updates/1_106/chat-view.png)
 
 It is now also possible to copy math source by right-clicking math expressions in the chat view.
 
@@ -434,7 +434,7 @@ When an MCP registry endpoint is configured in your organization's policies, VS 
 
 When your organization has configured these policies, the `setting(chat.mcp.gallery.serviceUrl)` setting specifies the MCP registry endpoint URL, and the `setting(chat.mcp.access)` setting controls whether access is restricted to only the servers in that registry. These settings will be marked as "(Managed by organization)" in the Settings editor:
 
-![Screenshot showing MCP settings managed by organization policy, including the Gallery Service URL and Access control settings](images/1_106/mcp-registry-policies.png)
+![Screenshot showing MCP settings managed by organization policy, including the Gallery Service URL and Access control settings](https://code.visualstudio.com/assets/updates/1_106/mcp-registry-policies.png)
 
 To learn more about configuring MCP server access for your organization or enterprise, see [Configure MCP server access](https://docs.github.com/en/copilot/how-tos/administer-copilot/configure-mcp-server-access).
 
@@ -442,7 +442,7 @@ To learn more about configuring MCP server access for your organization or enter
 
 When installing an MCP server, you can now choose whether to install it globally or to the workspace configuration. Right-click on an MCP server in the extensions view and select **Install (Workspace)** from the context menu, or use the **Install (Workspace)** action directly in the MCP server editor. This adds the MCP server to the `.vscode/mcp.json` file in your current workspace, making it easier to share MCP servers with your team.
 
-![Screenshot showing the context menu for an MCP server with the Install (Workspace) option highlighted](images/1_106/mcp-install-workspace.png)
+![Screenshot showing the context menu for an MCP server with the Install (Workspace) option highlighted](https://code.visualstudio.com/assets/updates/1_106/mcp-install-workspace.png)
 
 ### Authentication: Client ID Metadata Document authentication flow
 
@@ -474,7 +474,7 @@ The chat input now announces the active agent and model in a clearer order so sc
 
 Notebooks now supports searching across cells. Use key bindings (`kb(notebook.findNext.fromWidget)` and `kb(notebook.findPrevious.fromWidget)`) to navigate to the next and previous match, just like you would in the editor.
 
-<video src="images/1_106/notebookSearch.mp4" title="Video showing search in notebook cells." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/notebookSearch.mp4" title="Video showing search in notebook cells." autoplay loop controls muted></video>
 
 ## Source Control
 
@@ -484,7 +484,7 @@ Notebooks now supports searching across cells. Use key bindings (`kb(notebook.fi
 
 When writing git commit messages in the editor, you can now fold sections of the commit message to keep things organized. To use this feature, enable the `setting(git.verboseCommit)` and `setting(git.useEditorAsCommitInput)` settings.
 
-![Screenshot showing folding nodes in the gutter and a partially collapsed commit message in the editor.](images/1_106/commit-folding.png)
+![Screenshot showing folding nodes in the gutter and a partially collapsed commit message in the editor.](https://code.visualstudio.com/assets/updates/1_106/commit-folding.png)
 
 ### Graph incoming/outgoing changes
 
@@ -492,7 +492,7 @@ When writing git commit messages in the editor, you can now fold sections of the
 
 This milestone, we are adding the capability to easily view incoming and outgoing changes in the Source Control Graph view. For active branches that have incoming or outgoing changes, the graph displays an "Incoming Changes" and "Outgoing Changes" node. Selecting each node displays the list of incoming or outgoing files.
 
-![Screenshot showing incoming and outgoing changes nodes in the Source Control Graph view.](images/1_106/graph-incoming-outgoing.png)
+![Screenshot showing incoming and outgoing changes nodes in the Source Control Graph view.](https://code.visualstudio.com/assets/updates/1_106/graph-incoming-outgoing.png)
 
 You can hide this information from the Graph view by using the `setting(scm.graph.showIncomingChanges:false)` and `setting(scm.graph.showOutgoingChanges:false)` settings.
 
@@ -512,7 +512,7 @@ We are looking to expand the functionality of the Repositories view and in prepa
 
 Apart from the new functionality in the Repositories view, this also allows us to remove the repository picker in the Graph view's title and have a global repository picker across all source control views. You can toggle the selection mode using the setting, or from the "..." menu of the Repositories view.
 
-![Screenshot showing the Repositories view with single selection mode enabled and the context menu to toggle selection mode.](images/1_106/repositories-selection-mode.png)
+![Screenshot showing the Repositories view with single selection mode enabled and the context menu to toggle selection mode.](https://code.visualstudio.com/assets/updates/1_106/repositories-selection-mode.png)
 
 ### Repositories explorer (experimental)
 
@@ -522,7 +522,7 @@ We are looking at enhancing the Repositories view and showing additional informa
 
 In this first iteration, we have focused on branches and tags. You can create new branches, tags, view the list of branches and tags, and take various actions of each branch/tag (ex: checkout, etc.). In the upcoming milestone, we will add more information (ex: stashes, remotes, etc). Give this experimental feature a try and let us know what you think.
 
-![Screenshot showing the Repositories explorer with branches and tags for a single selected repository.](images/1_106/repositories-explorer.png)
+![Screenshot showing the Repositories explorer with branches and tags for a single selected repository.](https://code.visualstudio.com/assets/updates/1_106/repositories-explorer.png)
 
 ## Testing
 
@@ -543,15 +543,15 @@ Terminal IntelliSense has been in the product as an experimental/preview feature
 
 When enabled, typing in the terminal will bring up IntelliSense similar to the editor for PowerShell, bash, zsh and fish:
 
-![Screenshot of typing "write" in PowerShell will bring up completions starting with the word write.](images/1_106/terminal-suggest-write.png)
+![Screenshot of typing "write" in PowerShell will bring up completions starting with the word write.](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-write.png)
 
 The completions have various sources, paths for example are all handled by core:
 
-<video src="images/1_106/terminal-suggest-cd.mp4" title="cd presents directories, pressing tab will refresh the entries" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-cd.mp4" title="cd presents directories, pressing tab will refresh the entries" autoplay loop controls muted></video>
 
 Some commands feature advanced specifications, like git which has the ability to pull in branch names:
 
-<video src="images/1_106/terminal-suggest-git.mp4" title="git completions support sub-commands, branch names, tags and so on" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-git.mp4" title="git completions support sub-commands, branch names, tags and so on" autoplay loop controls muted></video>
 
 If we learned anything when building this feature it's that no one size fits all, so there are many options to tweak the behavior to get what you're after:
 
@@ -575,7 +575,7 @@ Apart from overall polish, this is what is coming to the feature this release:
 - The extension API is close to finalization
 - Git commit completions show the commit message
 
-![Screenshot of git commit completions showing branch names and their associated commit messages in the terminal suggest details view.](images/1_106/terminal-suggest-commit.png)
+![Screenshot of git commit completions showing branch names and their associated commit messages in the terminal suggest details view.](https://code.visualstudio.com/assets/updates/1_106/terminal-suggest-commit.png)
 
 ### Consolidated shell integration timeout setting
 
@@ -589,7 +589,7 @@ We now have one unified configurable setting, `setting(terminal.integrated.shell
 
 The **Manage Extension Account Preferences** command is now more discoverable. In addition to being available in the Command Palette and extension context menus, it now appears in the Account Menu alongside **Manage Language Model Access**. This makes it easier to find and configure which accounts extensions can access.
 
-![Screenshot of Manage Extension Account Preferences in the Account menu.](images/1_106/manageExtensionAccountPref.png)
+![Screenshot of Manage Extension Account Preferences in the Account menu.](https://code.visualstudio.com/assets/updates/1_106/manageExtensionAccountPref.png)
 
 ### Last version of `classic` Microsoft authentication - use `msal-no-broker` if you experience issues
 
@@ -611,7 +611,7 @@ Microsoft authentication now supports the device code flow in non-brokered scena
 
 Manage your authentication accounts directly from the Command Palette using the **Accounts: Manage Accounts** command. This command provides access to account management features when the Account menu is hidden or not easily accessible.
 
-![Screenshot of the Manage Accounts menu.](images/1_106/manage-accounts-menu.png)
+![Screenshot of the Manage Accounts menu.](https://code.visualstudio.com/assets/updates/1_106/manage-accounts-menu.png)
 
 When you run the **Manage Accounts** command, you'll see a quick pick menu listing all your active accounts. You can select an account to view available actions, including:
 
@@ -637,20 +637,20 @@ You can now add your AI-generated documentation directly into your code as a doc
 
 This streamlines the process of documenting your code, allowing you to quickly enhance readability and maintainability without retyping.
 
-<video src="images/1_106/pylance-add-hover-summaries-as-docstring.mp4" title="Add as docstring command in Copilot Hover Summaries." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/pylance-add-hover-summaries-as-docstring.mp4" title="Add as docstring command in Copilot Hover Summaries." autoplay loop controls muted></video>
 
 #### Localized Copilot Hover Summaries
 
 GitHub Copilot Hover Summaries inside Pylance now respect your display language within VS Code. When you invoke an AI-generated summary, you'll get strings in the language you've set for your editor, making it easier to understand the generated documentation.
 
-![Screenshot of a Copilot Hover Summary generated in Portuguese.](images/1_106/hover-summaries-in-portuguese.png)
+![Screenshot of a Copilot Hover Summary generated in Portuguese.](https://code.visualstudio.com/assets/updates/1_106/hover-summaries-in-portuguese.png)
 
 #### Convert wildcard imports Code Action
 
 Wildcard imports (from module import *) are often discouraged in Python because they can clutter your namespace and make it unclear where names come from, reducing code clarity and maintainability.
 Pylance now helps you clean up modules that still rely on `from module import *` via a new Code Action. It replaces the wildcard with the explicit symbols, preserving aliases and keeping the import to a single statement. To try it out, you can click on the line with the wildcard import and press `kbstyle(Ctrl+.)` (or `kbstyle(Cmd+.)` on macOS) to select the **Convert to explicit imports** Code Action.
 
-![Screenshot of the Convert wildcard imports Code Action.](images/1_106/wildcard-import.png)
+![Screenshot of the Convert wildcard imports Code Action.](https://code.visualstudio.com/assets/updates/1_106/wildcard-import.png)
 
 ### dotenv
 
@@ -676,7 +676,7 @@ A new **Language Models** editor provides a centralized place to view and manage
 
 >**Note:** This feature is only available in [VS Code Insiders](https://code.visualstudio.com/insiders/).
 
-![Screenshot showing the Language Models editor with a list of models organized by provider.](images/1_106/language-models-editor.png)
+![Screenshot showing the Language Models editor with a list of models organized by provider.](https://code.visualstudio.com/assets/updates/1_106/language-models-editor.png)
 
 The editor displays:
 
@@ -698,7 +698,7 @@ Hover over model names or context sizes to see detailed information including mo
 
 Control which models appear in the chat model picker by toggling their visibility with the eye icon next to each model. When a model is visible, it appears in the model picker dropdown when you're using GitHub Copilot Chat, making it available for selection. Hidden models remain in the Language Models editor but won't appear in the model picker, helping you keep your model selection focused on the ones you use most frequently.
 
-![Screenshot showing the eye icon to toggle model visibility with a tooltip displaying "Show in the chat model picker"](images/1_106/toggle-language-model-visibility.png)
+![Screenshot showing the eye icon to toggle model visibility with a tooltip displaying "Show in the chat model picker"](https://code.visualstudio.com/assets/updates/1_106/toggle-language-model-visibility.png)
 
 This is particularly useful when you have access to many models and want to streamline your workflow by showing only your preferred models in the picker.
 
@@ -706,7 +706,7 @@ This is particularly useful when you have access to many models and want to stre
 
 Use the **Add Models...** button to configure and add models from language model providers you've already installed. When you select this button, you'll see a dropdown list of all installed model providers, such as Copilot, Anthropic, Azure, Google, Groq, Ollama, OpenAI, and others. Select a provider from the list to configure it and start using its models in GitHub Copilot Chat.
 
-![Screenshot showing the Add Models dropdown with a list of installed language model providers including Copilot, Anthropic, Azure, Google, and more](images/1_106/add-language-models-dropdown.png)
+![Screenshot showing the Add Models dropdown with a list of installed language model providers including Copilot, Anthropic, Azure, Google, and more](https://code.visualstudio.com/assets/updates/1_106/add-language-models-dropdown.png)
 
 This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
 
@@ -766,7 +766,7 @@ Extension authors can now register view containers in the Secondary Side Bar by 
 
 The Quick Pick and Quick Input APIs include several new capabilities that give extension developers more flexibility in creating interactive user interfaces.
 
-<video src="images/1_106/quick-pick-api.mp4" title="Video showing quick pick with prompt, toggle and file icons." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_106/quick-pick-api.mp4" title="Video showing quick pick with prompt, toggle and file icons." autoplay loop controls muted></video>
 
 #### Proposed API: Toggle button support
 
@@ -872,7 +872,7 @@ markdown.value = `
 
 This enables extensions to render alerts in various places in the UI, such as comments:
 
-![Screenshot showing GitHub-style alerts displayed in a comment thread showing each alert type with their respective icons and styling.](images/1_106/markdown-alerts.png)
+![Screenshot showing GitHub-style alerts displayed in a comment thread showing each alert type with their respective icons and styling.](https://code.visualstudio.com/assets/updates/1_106/markdown-alerts.png)
 
 ### MarkdownString support in TreeItem labels ([#115365](https://github.com/microsoft/vscode/issues/115365))
 
@@ -890,7 +890,7 @@ const combined = new vscode.TreeItem({ label: new vscode.MarkdownString('_~~**$(
 ```
 
 The above items render as:
-![Screenshot of a tree view showing three items: a starred item with an icon, an italic item, and a combined item with check and star icons plus bold, italic, and strikethrough formatting.](images/1_106/markdown-labels.png)
+![Screenshot of a tree view showing three items: a starred item with an icon, an italic item, and a combined item with check and star icons plus bold, italic, and strikethrough formatting.](https://code.visualstudio.com/assets/updates/1_106/markdown-labels.png)
 
 ## Engineering
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_106.md
     - release-notes/v1_105.md
     - release-notes/v1_104.md
     - release-notes/v1_103.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/503dd0f745f2a3c402f7a1283632e50c4cf10f4c

For future reference ...

1. Checkout original file (CLI command)
   ```
   curl --output-dir docs/release-notes -fLOJ https://github.com/microsoft/vscode-docs/raw/503dd0f745f2a3c402f7a1283632e50c4cf10f4c/release-notes/v1_106.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Agent mode - GPT-5 mini)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Edit mode - Gemini 2.5 Pro)
   ```
   Translate the full Markdown content into Japanese. Insert a half-width space between full-width and half-width characters.
   ```