### PR TITLE
Translate November 2025 (version 1.107)

### DIFF
--- a/docs/release-notes/v1_107.md
+++ b/docs/release-notes/v1_107.md
@@ -1,0 +1,863 @@
+---
+Order: 116
+TOCTitle: November 2025
+PageTitle: Visual Studio Code November 2025
+MetaDescription: What's new in the Visual Studio Code November 2025 Release (1.107).
+MetaSocialImage: 1_107/release-highlights-stable.webp
+Date: 2025-12-10
+DownloadVersion: 1.107.1
+---
+# November 2025 (version 1.107)
+
+_Release date: December 10, 2025_
+
+**Update 1.107.1**: The update improves the [agent sessions experience](#integrating-agent-sessions-and-chat), adds an [agent workflow tutorial](https://code.visualstudio.com/docs/copilot/agents/agents-tutorial), and addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22November+2025+Recovery+1%22+). The key highlights include:
+
+* Agent sessions view defaults to side-by-side and remembers your toggle state.
+* Agent sessions that require your input are now clearly marked.
+* Support for copying workspace changes when creating a background session.
+* Chat prompt is not cleared when creating a new session.
+* Tool calls in cloud sessions are now collapsed by default.
+
+<!-- DOWNLOAD_LINKS_PLACEHOLDER -->
+
+---
+
+VS Code 1.107 introduces multi-agent orchestration - use GitHub Copilot and custom agents together to accelerate and parallelize development.
+
+* **Agent HQ** gives you one place to manage all your agents, letting Copilot and custom agents collaborate across tasks.
+* **Background agents** run in isolated workspaces to not interfere with your active work, and enabling multiple background tasks at once.
+* **Delegate** work across local, background, or cloud agents to keep your workflow moving without interruptions.
+
+![VS Code November 2025 release image.](images/1_107/release-highlights-stable.webp)
+
+<br>
+
+Watch our [VS Code 1.107 release highlights video](https://aka.ms/VSCode/1-107rn) to hear about these features from our engineers!
+
+Happy Coding!
+
+<br>
+
+>Read these release notes online at [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
+>**Insiders:** [Download the nightly Insiders build](https://code.visualstudio.com/insiders) to try the latest updates as soon as they're available.<br>
+
+---
+
+<!-- TOC
+<div class="toc-nav-layout">
+  <nav id="toc-nav">
+    <div>In this update</div>
+    <ul>
+      <li><a href="#agents">Agents</a></li>
+      <li><a href="#chat">Chat</a></li>
+      <li><a href="#mcp">MCP</a></li>
+      <li><a href="#accessibility">Accessibility</a></li>
+      <li><a href="#editor-experience">Editor Experience</a></li>
+      <li><a href="#code-editing">Code Editing</a></li>
+      <li><a href="#source-control">Source Control</a></li>
+      <li><a href="#debugging">Debugging</a></li>
+      <li><a href="#terminal">Terminal</a></li>
+      <li><a href="#authentication">Authentication</a></li>
+      <li><a href="#languages">Languages</a></li>
+      <li><a href="#remote-development">Remote Development</a></li>
+      <li><a href="#enterprise">Enterprise</a></li>
+      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
+      <li><a href="#proposed-apis">Proposed APIs</a></li>
+      <li><a href="#engineering">Engineering</a></li>
+      <li><a href="#notable-fixes">Notable fixes</a></li>
+      <li><a href="#thank-you">Thank you</a></li>
+    </ul>
+  </nav>
+  <div class="notes-main">
+Navigation End -->
+
+## Agents
+
+* Manage your agents from chat ([Show more](#integrating-agent-sessions-and-chat)).
+* Share agents across your organization ([Show more](#share-custom-agents-across-your-github-organization-experimental)).
+* Keep agents active while chat is closed ([Show more](#local-agent-sessions-remain-active-when-closed)).
+* Move agent sessions from local to cloud ([Show more](#continue-tasks-in-background-or-cloud-agents)).
+* Run agents in dedicated Git worktrees ([Show more](#isolate-background-agents-with-git-worktrees)).
+* Attach context to background agents ([Show more](#adding-context-to-background-agents)).
+* Customize background agents ([Show more](#use-custom-agents-with-background-agents-experimental)).
+* Reuse custom agents across environments ([Show more](#agent-tooling-reorganization)).
+* Run custom subagents ([Show more](#run-agents-as-subagents-experimental)).
+* Reuse Claude skills ([Show more](#reuse-your-claude-skills-experimental)).
+
+### Integrating agent sessions and chat
+
+**Setting**: `setting(chat.viewSessions.enabled)`
+
+**Update 1.107.1**: This update significantly improves the side-by-side sessions experience. Hiding the sessions with the toggle now remembers your choice, allowing you to resize the Chat view at will. Get started with the [agent workflow tutorial](https://code.visualstudio.com/docs/copilot/agents/agents-tutorial).
+
+Agents are key to autonomously performing coding tasks on your behalf. The chat interface is the main way to interact with agents, regardless of where they are running: locally in VS Code, in the background using a CLI, in the cloud, or from 3rd party extensions. Learn more about [using agents in VS Code](https://code.visualstudio.com/docs/copilot/agents/overview) in our documentation.
+
+This iteration, we integrated the agent sessions into the Chat view to give you a unified experience when working with agents. At a glance, you can see the session's status, progress, and file change statistics. You can archive or unarchive sessions to keep the sessions list manageable.
+
+<video src="images/1_107/agent-sessions.mp4" title="Video demonstrating the use agent sessions in Chat view." autoplay loop controls muted></video>
+
+If you are working in a workspace, the session list only shows sessions related to the current workspace. If you are in an empty window, all sessions across workspaces are shown.
+
+When you select a session from the list, it opens the session in the Chat view in the Side Bar, allowing you to see the full conversation history. If you prefer, you can also open a session as an editor tab or in a new window. Right-click a session to see the context menu with these options.
+
+![Screenshot showing the context menu of a session in the sessions list.](images/1_107/sessions-context.png)
+
+You can disable the sessions list in the Chat view by configuring `setting(chat.viewSessions.enabled)`.
+
+As a consequence of this change, we're disabling the standalone **Agent Sessions** view by default. If you prefer to keep using the standalone view, you can re-enable it via `setting(chat.agentSessionsViewLocation)`. In a future release, we plan to remove the standalone view entirely.
+
+#### Compact view
+
+When the Chat view is narrow, the list of sessions is shown inside the Chat view when you start a new chat session. By default, the list shows the three most recent sessions that are not archived.
+
+![Screenshot showing the recent sessions in the Chat view.](images/1_107/recent-sessions.png)
+
+Select **Show All Sessions** to view the full list of sessions with options to search and filter.
+
+![Screenshot showing all sessions in the Chat view.](images/1_107/recent-sessions-all.png)
+
+You can use the action to toggle the agent sessions sidebar for a wider experience of all sessions.
+
+#### Side-by-side view
+
+Once the Chat view is wide enough (for example, when you maximize it), the list of agent sessions is automatically shown side-by-side with the Chat view. This view lets you quickly navigate between sessions without losing context. You can also manually toggle this side-by-side view using the corresponding control.
+
+![Screenshot showing all sessions side-by-side with the Chat view.](images/1_107/all-sessions.png)
+
+To limit the sessions list, you can filter sessions by provider or state. VS Code persists this filter.
+
+#### Orientation setting
+
+**Setting**: `setting(chat.viewSessions.orientation)`
+
+By default, the sessions list appears side-by-side with the Chat view when it's wide enough or if you manually toggle the sessions list. You can change this behavior with the `setting(chat.viewSessions.orientation)` setting.
+
+* `auto` (default): show the sessions side-by-side if the width allows it, otherwise show them above empty chats
+* `stacked`: always show the sessions above empty chats
+* `sideBySide`: show the session list side-by-side if the width allows it, otherwise hide the sessions list
+
+### Local agent sessions remain active when closed
+
+Previously, when you closed a local chat session, a running agent request was cancelled. This limited the usefulness of local agents for long-running tasks or for running multiple tasks simultaneously.
+
+Now, the local agent continues running in the background, even when not open in a chat editor or the Chat view. You are able to see the status of the running agent in the sessions list and can switch back to the session at any time to see the detailed progress.
+
+<video src="images/1_107/local-agent-active-when-closed.mp4" title="Video showing local agent running in background." autoplay loop controls muted></video>
+
+Learn more about [using local agent in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_switch-between-agents).
+
+### Continue tasks in background or cloud agents
+
+Local agents are great for interactive sessions inside VS Code where you can go back and forth with the agent. This can be useful for brainstorming, performing exploratory tasks, or to work out an implementation plan. Once you have a clear plan, you can then hand the task off to a background or cloud agent to execute it autonomously.
+
+This iteration, we have improved the experience to continue a local chat with a background or cloud agent. Across the UI, you can now continue a task seamlessly using the new **Continue in** option.
+
+When you continue a local chat to background or cloud agent, the current chat context is passed along and the original session is archived after handoff.
+
+* Chat view:
+
+    ![Screenshot showing the 'Continue in' button in the Chat view.](images/1_107/continue-in-chatwidget.png)
+
+* Plan agent:
+
+    ![Screenshot showing the 'Start implementation' button when using the Plan agent.](images/1_107/continue-in-planmode.png)
+
+* Untitled prompt file:
+
+    ![Screenshot showing the 'Continue in' button in an untitled prompt file.](images/1_107/continue-in-promptfile.png)
+
+### Isolate background agents with Git worktrees
+
+Background agents (previously called CLI agents) are designed to run autonomously in the background, allowing you to offload tasks while you focus on other work. Running multiple background agents simultaneously can lead to conflicts if they modify the same files in your workspace.
+
+This iteration, we enhanced the isolation of background agents by introducing support for [Git worktrees](https://code.visualstudio.com/docs/sourcecontrol/branches-worktrees#_working-with-git-worktrees). When you create a new background agent, you can choose to either run it on the current workspace or to run it in a dedicated Git worktree.
+
+![Screenshot showing the Git Worktree dropdown when creating a background agent.](images/1_107/background_worktree.png)
+
+When you run a background agent in a worktree, the agent automatically creates a new Git worktree for the session, isolating its changes in a separate folder. This lets you run multiple background agents simultaneously without conflicts.
+
+You can easily review and merge the changes made by the background agent in the worktree back into your main workspace when the agent completes its task. We've also added a new action to directly apply the changes from a worktree directly into your workspace.
+
+![Screenshot of a background agent, showing the file changes that occurred in the worktree.](images/1_107/filechanges.png)
+
+Learn more about using [background agents in VS Code](https://code.visualstudio.com/docs/copilot/agents/background-agents).
+
+### Adding context to background agents
+
+Background agents now support multiple context attachment types. You can attach selections, problems, symbols, search results, git commits, and more to any prompt. This makes it possible to build richer, more precise prompts, unlocking more complex and flexible workflows. For example, attach a reported problem and ask the agent to fix it without manually specifying file paths and line numbers.
+
+![Screenshot of a background agent session with a symbol and error attached as context.](images/1_107/background_attachments.png)
+
+### Share custom agents across your GitHub organization (Experimental)
+
+**Setting**: `setting(github.copilot.chat.customAgents.showOrganizationAndEnterpriseAgents)`
+
+Previously, you could only define custom agents at a workspace or user level. If you wanted to share custom agents across your organization, you had to manually distribute the agent files to each user.
+
+In this release, you can now define custom agents at the organization level for your GitHub account. This experimental feature enables you to use organization-specific agents alongside your personal agents in chat.
+
+To enable this feature, set `setting(github.copilot.chat.customAgents.showOrganizationAndEnterpriseAgents)` to `true`. Once enabled, custom agents created by your organization appear in the Agents dropdown in VS Code.
+
+To learn more about creating custom agents for your organization, see [Create custom agents](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents) in the GitHub documentation.
+
+### Use custom agents with background agents (Experimental)
+
+**Setting**: `setting(github.copilot.chat.cli.customAgents.enabled)`
+
+You can now bring your own custom agents into Background Agents. Once enabled, custom agents defined in your `.github/agents` folder will appear in your agent list, allowing you to leverage agents tailored to your workflows and requirements.
+
+This experimental functionality can be enabled with the `setting(github.copilot.chat.cli.customAgents.enabled)` setting.
+
+![Screenshot showing a background agent session with a custom Planner agent in the Agents dropdown list.](images/1_107/background_agents.png)
+
+Learn more about [defining custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
+
+### Agent tooling reorganization
+
+We've reorganized the agent tooling structure to enable better compatibility with GitHub custom agents. This lets you more easily reuse custom agents across VS Code and GitHub environments without requiring separate configurations.
+
+As part of this change, we've renamed certain existing tool references and the toolsets they belong to. Existing tool references in your agent files will continue to work, but you'll see a Code Action for renaming them to the latest recommended format. This ensures that your agent configurations follow the current best practices and maintain compatibility across platforms.
+
+### Run agents as subagents (Experimental)
+
+**Setting**: `setting(chat.customAgentInSubagent.enabled)`
+
+When an agent needs to solve a complex issue, it can delegate tasks to [subagents](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents). Subagents work independently from the main chat session and have their own context window. This helps the main conversation to stay focused on the high-level objective and helps to manage context window limitations.
+
+With this release, you can customize subagents via [custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents). Custom agents let you define specialized personas for the AI, tailoring their behavior to specific tasks or domains. For example, a code reviewer agent focuses on reviewing code rather than make code changes.
+
+To use custom agents as subagents, follow these steps:
+
+1. Enable `setting(chat.customAgentInSubagent.enabled)`
+
+1. Create a custom agent with the **Chat: New Custom Agent** command, if you don't have one yet.
+
+1. In chat, ask the model "what subagents can you use?" to see the list of available subagents. Your custom agent should appear in the list.
+
+1. Enter a prompt that meets the requirements for your custom agent. The language model uses the custom agent description and arguments to determine if it should be used for your request.
+
+    ![Screenshot of a chat conversation that uses a custom agent as subagent.](images/1_107/use-agents-as-subagents.png)
+
+To prevent a custom agent from being used as a subagent, set the metadata property `infer` to `false` in the `*.agent.md` file.
+
+Learn more about [using subagents in chat](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents).
+
+### Reuse your Claude skills (Experimental)
+
+**Setting**: `setting(chat.useClaudeSkills)`
+
+Skills were introduced by [Claude Code](https://code.claude.com/docs/en/skills) and are capabilities that an agent can load on-demand. Each skill comes with a short description that advertizes the skill. If useful, the agent can decide to read the full skill instructions. Skill instructions can come with supporting files like scripts and templates.
+Once loaded, skills instructions and supporting files are part of the context of the main conversation.
+
+VS Code can now reuse your existing skills. Enable the `setting(chat.useClaudeSkills)` setting to allow agents to discover and use your skills.
+
+![Screenshot that shows reusing Claude skills in chat in VS Code.](images/1_107/use-claude-skills.png)
+
+VS Code supports personal skills found at `~/.claude/skills/skill-name/SKILL.md` and project skills found in workspace folders at `${workspaceFolder}.claude/skills/skill-name/SKILL.md`.
+
+Check that the `SKILL.md` file has a `description` attribute in the header that advertizes the skill. Note that the `allowed-tools` attribute is not supported in VS Code.
+
+In agent mode, make sure you have the read-file tool enabled and ask "What skills do you have" to find out if skills are found. Next, make a request that can be answered with a skill. If the agent doesn't use the skill, improve the skill description or nudge the model to use skills.
+
+## Chat
+
+* Inline chat is optimized for code edits ([Show more](#inline-chat-ux)).
+* Manage your chat models ([Show more](#language-models-editor)).
+* Review external web content ([Show more](#url-and-domain-auto-approval)).
+* Fetch dynamic web content ([Show more](#more-robust-fetch-tool)).
+* Search ignored files ([Show more](#text-search-tool-can-search-ignored-files)).
+* Access terminal output in chat ([Show more](#rich-terminal-output-in-chat)).
+* Automatically approve terminal commands for your session ([Show more](#allow-all-terminal-commands-in-this-session)).
+* More keyboard shortcuts are available ([Show more](#keyboard-shortcuts-for-chat-terminal-actions)).
+* Use Entra ID for Azure-hosted models ([Show more](#azure-model-provider-entra-id-as-the-default-authentication)).
+* Configure extended thinking budget for Anthropic models ([Show more](#anthropic-models-extended-thinking-support)).
+* Use chat more efficiently ([Show more](#chat-view-appearance-improvements)).
+* View diffs for edits to sensitive files ([Show more](#diffs-for-edits-to-sensitive-files)).
+* Hide chat tool calls for reasoning models ([Show more](#collapsible-reasoning-and-tools-output-experimental)).
+
+### Inline chat UX
+
+**Setting**: `setting(inlineChat.enableV2:true)`
+
+We continue to improve the inline chat experience to align it with the other chat experiences in VS Code and to optimize it for quick, single-file code changes.
+
+<video src="images/1_107/inline_chat_edit.mp4" title="Video showing the updated UX for inline chat in action." autoplay loop controls muted></video>
+
+Previously, you could also use inline chat for general questions and discussions. Now, inline chat is optimized for code changes within the current file. For tasks that inline chat cannot handle, you are automatically upgraded to the Chat view where your prompt is being replayed, using the same model and the same context
+
+<video src="images/1_107/inline_chat_exit.mp4" title="Video showing inline chat exit to Chat view flow." autoplay loop controls muted></video>
+The `setting(inlineChat.enableV2:true)` setting (preview) now only controls how the extension handles your prompt. This is still under development but can be tried with confidence.
+
+### Language Models editor
+
+Chat in VS Code supports multiple language models, either provided by GitHub Copilot, third-party extensions, or via bring your own key (BYOK) providers. Managing all these models can be challenging, especially when you have access to many models across different providers. Learn more about [using language models in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
+
+The **Language Models** editor provides a centralized place to view and manage all available language models for chat in VS Code. You can open it from the model picker in chat or via the Command Palette with **Chat: Manage Language Models**.
+
+<video src="images/1_107/language-models-editor.mp4" title="Video showing the Language Models editor" autoplay loop controls muted></video>
+
+The editor lists all models available to you, showing key information such as the model capabilities, context size, billing details, and visibility status. By default, models are grouped by provider, but you can also group them by visibility.
+
+Hover over model names or context sizes to see detailed information including model ID, version, status, and token breakdown.
+
+You can search and filter models using:
+
+* Text search with highlighting
+* Provider filter: `@provider:"OpenAI"`
+* Capability filters: `@capability:tools`, `@capability:vision`, `@capability:agent`
+* Visibility filter: `@visible:true/false`
+
+#### Manage model visibility
+
+As more models are available to you, the model picker can become overwhelming and difficult to navigate. In the Language Models editor, you can toggle the visibility of each model to control which models appear in the model picker. Hover over a model and select the eye icon to toggle its visibility.
+
+#### Add models from installed providers
+
+From the Language Models editor, you can add more models with **Add Models...**. This shows a dropdown list of all installed model providers. Select a provider to configure it and add its models to chat in VS Code.
+
+This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
+
+### URL and domain auto approval
+
+This iteration, we enhanced the security and user experience of auto-approving URLs for the fetch tool. When the model decides to fetch content from a URL that you did not explicitly ask for, you'll see the new two-step approval experience:
+
+* **Approve the initial request to fetch the URL**
+
+    This step ensures that you trust the domain being contacted and can prevent sensitive data to be sent to untrusted sites.
+
+    ![Screenshot showing a confirmation to approve the initial fetch request.](images/1_107/approve-fetch.png)
+
+    You have options for one-time approval or automatically approving future requests to the specific URL or domain.
+
+    The pre-approval respects the ["Trusted Domains" feature](https://code.visualstudio.com/docs/editing/editingevolved#_outgoing-link-protection). If a domain is listed there, you are automatically approved to make requests to that domain and are deferred to the response reviewing step.
+
+* **Approve to use the fetched content in chat and follow-up tool calls**
+
+    This step ensures that you review the fetched content before it is added to the chat or passed to other tools, preventing potential prompt injection attacks.
+
+    For example, you might approve a request to fetch content from a well-known site, like GitHub.com. But because the content, such as issue description or comments, is user-generated, it could contain harmful content that might manipulate the model's behavior.
+
+Learn more about [URL and domain approval](https://code.visualstudio.com/docs/copilot/chat/chat-tools#url-approval) in VS Code chat.
+
+### More robust fetch tool
+
+The `#fetch` agent tool now handles dynamic web content more effectively. It can retrieve dynamic content, in addition to static HTML. Websites that rely on JavaScript to load their content, such as Single-Page Applications (SPAs), modern documentation sites, or issue tracking systems like Jira, no longer return incomplete or empty results.
+
+The fetch tool waits for JavaScript to execute and content to load before retrieving the page, ensuring that dynamically-rendered content is captured. This improvement makes the tool significantly more useful in real-life scenarios.
+
+When you use `#fetch` followed by a URL, the model accesses the actual content you'd see in the browser, not just the initial HTML skeleton. This means more accurate and complete information when asking questions about web pages or requesting the model to analyze online content.
+
+### Text Search tool can search ignored files
+
+The `#textSearch` tool now supports searching in ignored files/folders specified by `files.exclude` or `search.exclude` settings or `.gitignore` files, such as the `node_modules` folder. It also returns hints to the agent about the ignored files/folders when there are no results, allowing agents to turn around and enable searching in those ignored files/folders.
+
+### Rich terminal output in chat
+
+Using **Toggle Output** on a **Run in Terminal** response now renders output in a full, read-only `xterm.js` terminal inside chat. A nice benefit of this approach is that VS Code preserves captured output even after the backing terminal has exited, so you can reopen previous runs at any time and see the terminal output as it was when the command ran.
+
+The chat terminal now adopts the integrated terminal's color theme for improved ANSI color contrast. Screen reader users can open the accessible view `kb(editor.action.accessibleView)` when the output has focus, enabling easy review and navigation.
+
+Learn more about [using terminal commands in chat](https://code.visualstudio.com/docs/copilot/chat/chat-tools#_terminal-commands).
+
+### Command status details in chat terminals
+
+Chat terminal messages now display command start time, duration, and exit code on hover of the command decoration.
+
+![Screenshot of the terminal showing npm install candy is run by the agent and the command decoration hover displays command execution time and status.](images/1_107/terminal-command-exit.png)
+
+### Allow all terminal commands in this session
+
+To optimize your chat experience, while maintaining security and control, the terminal tool has a new auto approve option to allow all future commands for the session. When you start a new session, terminal commands will follow the existing approval configuration.
+
+![Screenshot that shows the Allow All Commands in this Session option when approving a terminal command in chat.](images/1_107/terminal-allow-all.png)
+
+### Keyboard shortcuts for chat terminal actions
+
+You can now focus the most recent chat terminal `kb(workbench.action.terminal.chat.focusMostRecentChatTerminal)` or toggle its expansion state `kb(workbench.action.terminal.chat.focusMostRecentChatTerminalOutput)` via dedicated keyboard shortcuts.
+
+### Keyboard shortcuts for custom agents
+
+Each custom agent now has a separate action in the command list for them and you can bind keyboard shortcuts to them individually. For example, if you define a "Code Reviewer" custom agent, there will be a **Chat: Open Chat (Code Reviewer Agent)** command in the Command Palette to bind a keyboard shortcut to.
+
+![Screenshot of custom agent commands in the Command Palette.](images/1_107/custom-agent-commands.png)
+
+### Azure model provider: Entra ID as the default authentication
+
+**Setting**: `setting(github.copilot.chat.azureAuthType)`
+
+By default, the Azure model provider now uses Entra ID authentication when connecting to Bring-Your-Own-Key (BYOK) models, providing improved security and a more streamlined sign-in experience.
+
+If you prefer to authenticate using an API key, set `setting(github.copilot.chat.azureAuthType)` to `apiKey` instead of `entraId` (default).
+
+### Anthropic models: Extended thinking support
+
+**Setting**: `setting(github.copilot.chat.anthropic.thinking.budgetTokens)`
+
+Anthropic models now support extended thinking, which is enabled by default for all Anthropic extended thinking models. Extended thinking gives Claude enhanced reasoning capabilities for complex tasks by allowing it to spend additional tokens on its step-by-step thought process before generating a response, leading to more thoughtful and accurate outputs.
+
+The default thinking budget is set to 4,000 tokens. You can customize this budget by modifying the `setting(github.copilot.chat.anthropic.thinking.budgetTokens)` setting to adjust how many tokens the model can use for extended thinking. To turn off extended thinking entirely, set the budget to `0`.
+
+> **Note**: Interleaved thinking, which enables Claude to reason between tool calls, is only available when using Anthropic models via Bring-Your-Own-Key (BYOK). It uses the same thinking budget setting configured above.
+
+### Chat view appearance improvements
+
+We've made several improvements to the Chat view's appearance to enhance readability and usability:
+
+* **Chat title**:
+
+    When you open a chat, a new title control appears to the top showing you the title of the chat as well as giving you a quick way to get back to an empty chat. Configure this behavior via the `setting(chat.viewTitle.enabled)` setting.
+
+    <video src="images/1_107/chat-title.mp4" title="Video showing chat titles and returning back to the session list." autoplay loop controls muted></video>
+
+* **Welcome banner**:
+
+    If you prefer a more minimal experience when opening a new chat, the new setting `setting(chat.viewWelcome.enabled)` lets you hide the icon and welcome text.
+
+    ![Screenshot of empty chat view with the icon and welcome text hidden.](images/1_107/chat-welcome.png)
+
+* **Restore previous chat session**:
+
+    When you open chat after restarting or opening a different workspace, the previous session is now restored by default. You can change this behavior via the `setting(chat.viewRestorePreviousSession)` setting and choose to always start with an empty chat.
+
+### Diffs for edits to sensitive files
+
+When chat attempts to edit sensitive files, such as the `settings.json` or `package.json`, you get a notification and are asked to approve the changes before they are applied. You can configure which files are considered sensitive via the `setting(chat.tools.edits.autoApprove)` setting.
+
+Previously, you would see the raw edit that the model proposed, which could be difficult to understand. Now, we show you a diff of the proposed changes, making it easier to review and approve the edits.
+
+![Screenshot showing a diff of proposed changes to `package.json` in chat.](images/1_107/sensitive-file-diff.png)
+
+Learn more about editing [sensitive files in chat](https://code.visualstudio.com/docs/copilot/chat/review-code-edits#_edit-sensitive-files).
+
+### Collapsible reasoning and tools output (Experimental)
+
+**Setting**: `setting(chat.agent.thinkingStyle)`, `setting(chat.agent.thinking.collapsedTools)`
+
+With language model reasoning and agent tools output, a chat conversation can quickly become long and difficult to follow. Last iteration, we already worked on improving how we display thinking tokens in chat with the `setting(chat.agent.thinkingStyle)` setting.
+
+This iteration, we're further optimizing the chat experience by introducing collapsible chat sections for non-reasoning chat output, such as tool calls. By default, successive tool calls are now collapsed to reduce visual noise.
+
+Collapsible items (most tools and reasoning text) will be summarized and an AI-generated title will be given to each collapsible section.
+
+![Screenshot showing multiple tool calls collapsed in a collapsible section.](images/1_107/collapsed-tools.png)
+
+## MCP
+
+* We added support for the latest MCP specification ([Show more](#support-for-the-latest-mcp-specification)).
+* Use the GitHub remote MCP server without extra setup ([Show more](#github-mcp-server-provided-by-github-copilot-chat-preview)).
+
+### Support for the latest MCP specification
+
+VS Code supports the latest revision of the MCP specification, `2025-11-25`. This includes, among other things:
+
+* [URL mode elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-elicitation-requests)
+* [Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) for long-running, resilient tool calls and client work.
+* [Enhancements](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330) to enum choices in elicitation
+
+These improvements come in addition to the `2025-11-25` draft features VS Code already supported, such as `WWW-Authenticate` scope consent, the Client ID Metadata Document authentication flow, and icons for tools, resources, and servers. You can view the changelog for the 2025-11-25 draft on the [MCP website](https://modelcontextprotocol.io/specification/2025-11-25/changelog#major-changes).
+
+Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
+
+### GitHub MCP Server provided by GitHub Copilot Chat (Preview)
+
+**Setting**: `setting(github.copilot.chat.githubMcpServer.enabled)`
+
+The GitHub remote MCP Server is now provided as a built-in MCP server in the GitHub Copilot Chat extension, providing seamless integration with GitHub repositories and services. This integration offers several benefits:
+
+* Alignment with other Copilot agent harnesses like Copilot CLI and Copilot Cloud Agent that already use the GitHub MCP Server
+* Reuse of existing GitHub authentication state, eliminating additional authentication prompts
+* Transparent support for different GitHub MCP endpoints including GHE.com
+
+To enable the GitHub MCP Server, set the `setting(github.copilot.chat.githubMcpServer.enabled)` setting to `true`. Once enabled, the server automatically appears in the tool picker when using agents. This enables you to ask questions about GitHub issues, pull requests, and other repository information without additional configuration and setup.
+
+The GitHub MCP Server supports customization through several settings:
+
+* `setting(github.copilot.chat.githubMcpServer.toolsets)`: Configure which tools are available. By default, the `default` toolset is used, but you can extend it by adding `workflows` or other toolsets as documented in the [GitHub MCP Server documentation](https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md#remote-mcp-toolsets). **Note:** Adding certain toolsets may require additional permissions and re-authentication is not yet supported. Please see [this GitHub issue](https://github.com/microsoft/vscode/issues/280640) to track progress.
+* `setting(github.copilot.chat.githubMcpServer.readonly)`: Force the server to return only read-only tools, preventing any write operations.
+* `setting(github.copilot.chat.githubMcpServer.lockdown)`: Additional security control for tool behavior.
+
+> **Note**: This feature is currently in Preview and requires explicit opt-in through the setting mentioned above. We are planning to enable it by default in a future release in a way that makes it available when wanted, but not intrusive when not needed.
+
+## Accessibility
+
+### Keyboard approval for chat confirmations
+
+When an agent prompts for confirmation, you can now approve via keyboard using `kb(workbench.action.chat.acceptTool)`.
+
+## Editor Experience
+
+* More easily identify open projects ([Show more](#more-support-to-indicate-opened-windows-in-pickers)).
+* Swipe to navigate on macOS ([Show more](#macos-mouse-swipe-to-navigate)).
+* Choose when to view hover popups ([Show more](#on-demand-editor-hover-popups)).
+
+### More support to indicate opened windows in pickers
+
+We added an indicator to the **Open Recent** picker for when a workspace is already open in a VS Code window.
+
+![Screenshot of recently opened workspaces.](images/1_107/pickers.png)
+
+The currently active window is indicated slightly differently from other opened windows to make that distinction clearer. Entries that are not opened in any window have no icon.
+
+The indicator of which window is active has also been applied to the window picker.
+
+### macOS: Mouse swipe to navigate
+
+**Setting**: `setting(workbench.editor.swipeToNavigate)`
+
+On macOS you can now navigate between editors using 3-finger swipe gesture with the trackpad. Swiping left or right navigates across recently used editors in any editor group. Enable this with the `setting(workbench.editor.swipeToNavigate)` setting.
+
+> **Note**: We currently only support 3-finger swipe gesture. Make sure that your trackpad settings for swiping are configured like the following to make this work:
+>
+> * Swipe between pages: Scroll left or right with three fingers.
+> * Swipe between full-screen apps: Swipe left or right with four fingers.
+
+### On demand editor hover popups
+
+**Setting**: `setting(editor.hover.enabled)`
+
+You can now disable automatic hover popups in the editor, while retaining the ability to trigger hover information on-demand using a keyboard modifier. The `setting(editor.hover.enabled)` setting now supports three values: `on`, `off`, and `onKeyboardModifier`.
+
+When set to `onKeyboardModifier`, hover information only appears when you hold the opposite modifier key from your `setting(editor.multiCursorModifier)` setting while hovering over code. This reduces visual distractions during text selection while preserving quick access to contextual information when needed.
+
+For example, if your `setting(editor.multiCursorModifier)` is set to `ctrlCmd`, hover appears when you hold `kbstyle(Alt)` while hovering. If set to `alt`, hover appears when you hold `kbstyle(Ctrl)` (or `kbstyle(Cmd)` on macOS).
+
+## Code Editing
+
+* TypeScript offers rename suggestions ([Show more](#rename-suggestions-for-typescript)).
+* Use a new model for next edit suggestions ([Show more](#new-model-for-next-edit-suggestions)).
+* Preview next edit suggestions outside your viewport ([Show more](#preview-next-edit-suggestions-outside-the-viewport)).
+
+### Rename suggestions for TypeScript
+
+Rename suggestions predict when a symbol rename should happen instead of a regular text suggestion. When predicted, an additional indicator is shown together with the normal textual edit. You can then apply the symbol rename by using `kbstyle(Shift+Tab)`.
+
+In the following video, property `a` is renamed to `width`. The rename suggestion then suggests to rename `b` to `height`, as well as renaming the two parameters `a` and `b` accordingly. Next rename suggestion works best when it predicts related renames to other symbols.
+
+<video src="images/1_107/next-rename-suggestion.mp4" title="Video showing next rename suggestion in the editor." autoplay loop controls muted></video>
+
+> **Note**: this feature is currently rolled out to our user base using an experiment and is only available for TypeScript for now. Support for other programming languages is planned.
+
+### New model for next edit suggestions
+
+We have released a new model for next edit suggestions that is smarter and more in-tune with your latest edits. It delivers significantly better acceptance and dismissal performance. Learn more about the [model and its development](https://github.blog/ai-and-ml/github-copilot/evolving-github-copilots-next-edit-suggestions-through-custom-model-training/#h-continuous-improvements-nbsp) in our GitHub blog post.
+
+### Preview next edit suggestions outside the viewport
+
+When you receive a next edit suggestion that is outside the current viewport, it can be difficult to know what the suggestion is without scrolling away from your current position. We improved this experience by rendering a preview of the next edit suggestion where your cursor is currently located. This helps reduce the impact on your flow when reviewing suggestions.
+
+<video src="images/1_107/nes-outside-viewport.mp4" title="Video of next edit suggestion preview." autoplay loop controls muted></video>
+
+> **Note**: Our current language model focuses on next edit suggestions close to the cursor, so you might not often see suggestions outside the viewport. However, we are actively working on models which can give you suggestions much further away!
+
+Learn more about [inline suggestions in VS Code](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
+
+## Source Control
+
+### Stashes in the Source Control Repositories view (Experimental)
+
+**Settings**: `setting(scm.repositories.explorer:true)`, `setting(scm.repositories.selectionMode:single)`
+
+This milestone, we continued to expand the list of repository artifacts shown in the Source Control Repositories view by adding a Stashes node. Under this node, you can see the complete list of stashes, view, apply, and pop each stash. The context menu also contains an action to drop each stash.
+
+![Screenshot of the Source Control Repositories view showing the Stashes node and its context menu.](images/1_107/stashes-repo-explorer.png)
+
+You can enable the experimental repository explorer by setting the `setting(scm.repositories.selectionMode:single)` and `setting(scm.repositories.explorer:true)` settings. Please give it a try and let us know what other repository artifacts you would like to see in the repositories explorer.
+
+Learn more about [using source control in VS Code](https://code.visualstudio.com/docs/sourcecontrol/overview).
+
+## Debugging
+
+### Attach variables to chat
+
+You can now attach variables, scopes, and expressions to your chat context in VS Code. You can do this by right clicking on data in the **Variables** and **Watch** views, or by using the **Add Context** button in chat.
+
+## Terminal
+
+### Terminal suggest rolled out to stable
+
+Terminal Suggest is now enabled for stable users, offering inline completions and contextual hints while you type shell commands. Suggestions now group related argument values together, so option flags and their parameters stay organized in the list.
+
+## Authentication
+
+### Cross-platform native broker support for Microsoft Authentication
+
+**Setting**: `setting(microsoft-authentication.implementation)`
+
+This milestone, we adopted the latest MSAL libraries, enabling you to sign in through a native experience on:
+
+* Intel Macs
+* Linux x64 (just certain distros that are Debian-based)
+
+![Screenshot of a native broker dialog window asking to sign into VS Code.](images/1_107/macOS-auth-broker.png)
+
+This is in addition to the existing support for:
+
+* Windows x64
+* macOS M-series (ARM)
+
+macOS and Linux support requires your machine to be Intune enrolled and be opted in to using the native broker.
+
+This enables nice single sign-on flows and is the recommended way of acquiring a Microsoft authentication session. The MSAL team will enable this up for the remaining platforms (Windows ARM, Linux ARM and additional distros) over time, so stay tuned!
+
+> NOTE: If you have trouble authenticating via the broker, you can change the `setting(microsoft-authentication.implementation)` to `msal-no-broker`, which will use your browser to authenticate instead.
+
+### `classic` Microsoft authentication no longer available
+
+As mentioned last month, we have removed the `classic` option for `setting(microsoft-authentication.implementation)` due to low usage and it not being recommended by the Entra ID team.
+
+Reminder: The `setting(microsoft-authentication.implementation)` setting has been around to let users opt-out of native brokered authentication for Microsoft accounts if they experienced issues. The values for this setting are:
+
+* `msal` - Use MSAL with brokered authentication when available (default)
+* `msal-no-broker` - Use MSAL without brokered authentication
+
+## Languages
+
+### TypeScript 7.0 preview
+
+We continued to work with the TypeScript team to improve VS Code's support for the [upcoming TypeScript 7 release](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/). TypeScript 7 is a complete rewrite in native code and offers dramatically better performance.
+
+The TypeScript 7 preview has almost complete type checking support, and the TypeScript team has been busy adding editor features too. Recent highlights include auto import completions, rename support, and references code lenses.
+
+You can try out TypeScript 7.0 today by installing the [`TypeScript (Native Preview)` extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview). Then run the `TypeScript (Native Preview): Enable (Experimental)` command in a JavaScript or TypeScript file to switch all IntelliSense to use the native preview. Checkout the [most recent TypeScript 7 blog post](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/) for a full update on TypeScript 7 and the general direction of the TypeScript project.
+
+We plan to continue working closely with the TypeScript team to improve TypeScript 7's VS Code support. Once TypeScript 7 is ready, our longer term plan is to switch to it as the default experience powering VS Code's JavaScript and TypeScript IntelliSense. If you need to use an older TS version or need editor features like TypeScript service plugins that can't be easily ported to TypeScript 7, we're planning to continue supporting existing TypeScript versions for the foreseeable future alongside TypeScript 7.0+.
+
+## Remote Development
+
+The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+
+Highlights include:
+
+* SSH reconnection grace time control
+
+You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_107.md).
+
+## Enterprise
+
+Learn more about the [enterprise capabilities of VS Code](https://code.visualstudio.com/docs/setup/enterprise) in our documentation.
+
+### Control auto approval for agent tools
+
+**Setting**: `setting(chat.tools.eligibleForAutoApproval)`
+
+Specific agent tools can be risky to use without explicit user approval, especially those that can perform destructive actions, access sensitive data, or run arbitrary code in the background (for example, `runTask`).
+
+You can now define which tools are eligible for auto-approval with the new `setting(chat.tools.eligibleForAutoApproval)` setting. When a tool is denied from auto-approval, users won't have the option to always approve this tool in chat and must explicitly approve each use.
+
+Organizations can enforce this behavior via an enterprise policy across their users to enhance security when using agents.
+
+### Disable the use of agents by policy
+
+When an enterprise policy disables the use of agents in chat, the Agents picker now better communicates why they're not available.
+
+![Screenshot of the Agent picker shows agent mode unavailable due to enterprise policy.](images/1_107/agent-mode-disabled-by-policy.png)
+
+### Support GitHub Enterprise policies in Codespaces
+
+You can specify policies for your enterprise or organization in GitHub that are applied in VS Code. For example, you can [configure the MCP registry URL](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry) to be used by developers in your organization.
+
+In this release, we added support for these policies when using VS Code with GitHub Codespaces. When a developer opens a Codespace, the same policies are applied automatically, as they already are when using VS Code locally.
+
+## Contributions to extensions
+
+### GitHub Pull Requests
+
+There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+
+* Pull request and issue implicit context when a pull request or issue webview is active.
+* Pull requests and issues can be added explicitly as context to chat sessions through "Add Context".
+* Copilot pull requests can be marked ready for review, approved, and auto-merge set with a single button.
+
+Review the [changelog for the 0.124.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01240) release of the extension to learn about everything in the release.
+
+## Proposed APIs
+
+### Contributed Chat Context
+
+We have a new API proposal to let extensions contribute context providers for chat. This enables extensions to provide rich context from their own domain to be used in chat sessions. For example, the GitHub Pull Request extension provides the following context:
+
+* Workspace context, with information about the current repository, branch, and pull request.
+* Implicit pull request and issue context when a pull request or issue webview is active.
+* Explicit pull request and issue context when the user adds them via "Add Context".
+
+The API is still in the early stages, so expect changes to come. We'd love to get feedback on what parts of the proposal will solve extension authors' needs. You can find the proposal here: [vscode.proposed.chatContextProvider.d.ts](https://github.com/microsoft/vscode/blob/615abcc4ae680ef1950fe607c3b3532d3ee0a576/src/vscode-dts/vscode.proposed.chatContextProvider.d.ts).
+
+## Engineering
+
+### Builds rollout
+
+We've started progressively rolling out Insiders build releases over a 4-hour time window. This means that, as an Insiders user, you might receive the update notification a bit later than usual. If you're in a hurry, you can always run **Check for Updates** to force the update to be applied immediately.
+
+We'll roll out the November 2025 (1.107) release to Stable users over a 24-hour time window. Just like Insiders, you can always run **Check for Updates** to force the update to be applied immediately.
+
+### Improved website search functionality
+
+We've improved [our website](https://code.visualstudio.com) with fast, client-side search that allows you to easily and quickly navigate across our documentation.
+
+<video src="images/1_107/website-search.mp4" title="Video showing the website search functionality with search result suggestions showing in a dropdown list." autoplay loop controls muted></video>
+
+We've open-sourced the library behind this functionality: you can download [docfind](https://github.com/microsoft/docfind) and use it for your projects today! We'll follow up with a blog post on the innovations behind this tech.
+
+### Updated build scripts run directly as TypeScript
+
+This iteration, we cleaned up our build scripts to make them easier to work with and maintain. These build scripts were a mix of compiled TypeScript, TypeScript files run using `ts-node`, and JavaScript. Many of these scripts were not type checked and were using commonjs (`require`) instead of modern modules with `import` and `export`. Even worse, many of the TypeScript build scripts required checking in the compiled JS output to our source control. What a mess!
+
+Thankfully Node 22.18+ now allows [running scripts directly as TypeScript](https://nodejs.org/en/learn/typescript/run-natively). This lets us incrementally convert our build scripts to modern TypeScript. We used the follow tsconfig options to make sure our new TypeScript code could be run directly by Node:
+
+```json
+{
+  "compilerOptions": {
+     "target": "esnext",
+     "module": "nodenext",
+     "noEmit": true, // Don't generate .js files
+     "erasableSyntaxOnly": true, // Only allow TypeScript syntax that node can strip out. Enums and namespaces for example are not allowed
+     "allowImportingTsExtensions": true, // Allow importing of .ts files
+     "verbatimModuleSyntax": true // Make sure imports will be valid when the script is run by node directly
+  }
+}
+```
+
+GitHub Copilot helped automate many of the required changes, such as converting old commonjs files to modules and adding type annotations.
+
+One thing to keep in mind is that while Node can run TypeScript code, it doesn't actually type check it. You still need to use `tsc` for that. For vscode, we're actually using [`ts-go`](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/), which can fully type check all of our build scripts in well under a second.
+
+It's pretty amazing to be able to run `node build/hygiene.ts` directly. Switching fully to TypeScript also lets us modernize and bring type safety to our build scripts, which will make it much easier to understand and make changes to them. Plus it enabled us to delete around 15,000 lines of compiled JS code that we previously had to keep checked in!
+
+### Copilot extensions unification
+
+**Setting**: `setting(chat.extensionUnification.enabled)`
+
+We have fully rolled out inline suggestions to be served from the GitHub Copilot Chat extension. As part of this change, the GitHub Copilot extension will be disabled by default for all users.
+
+If you run into any issues with inline suggestions, please report them. You can temporarily revert to the previous behavior by setting `setting(chat.extensionUnification.enabled)` to `false`, which reenables the GitHub Copilot extension.
+
+Note that we are planning to fully deprecate the GitHub Copilot extension in January 2026, at which point the `setting(chat.extensionUnification.enabled)` setting will also be removed.
+
+## Notable fixes
+
+* [vscode#233635](https://github.com/microsoft/vscode/issues/233635) - Add an action to close other windows
+* [vscode#262817](https://github.com/microsoft/vscode/issues/262817) - Running "Move Editor into Previous Group" from the left-most group should create a new group to the left
+* [vscode#264569](https://github.com/microsoft/vscode/issues/264569) - Setting and removing window.activeBorder color does not reset the window border color
+* [vscode#140186](https://github.com/microsoft/vscode/issues/140186) - Cannot open local terminal when remote container is opened as a workspace
+* [vscode#228359](https://github.com/microsoft/vscode/issues/228359) - Relaunching the terminal will often just close the terminal
+* [vscode#232420](https://github.com/microsoft/vscode/issues/232420) - Terminal Cursor is at the wrong place with Python3.13
+* [vscode#247568](https://github.com/microsoft/vscode/issues/247568) - Terminal Ctrl+Click on a file with colon in filename does not open the file, preceding zeroes are deleted
+* [vscode#275011](https://github.com/microsoft/vscode/issues/275011) - Getting strange terminal message when opening VS Code in WSL on a trusted workspace
+* [vscode#275417](https://github.com/microsoft/vscode/issues/275417) - Tasks with reveal:never, close:true no longer work on WSL
+* [vscode#277311](https://github.com/microsoft/vscode/issues/277311) - Add "X" button to remove command from "recently used" list in Command Palette
+* [vscode#282222](https://github.com/microsoft/vscode/issues/282222) - SCM - improve git blame/timeline/graph hover rendering. Thanks to Stanislav Fort (Aisle Research)
+* [vscode-python-environments#1000](https://github.com/microsoft/vscode-python-environments/issues/1000) - Environment activation is not working reliably with "Command Prompt"
+
+## Thank you
+
+### Issue tracking
+
+Contributions to our issue tracking:
+
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
+* [@RedCMD (RedCMD)](https://github.com/RedCMD)
+* [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
+* [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
+* [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
+
+Contributions to `vscode`:
+
+* [@Abrifq (Arda Aydın)](https://github.com/Abrifq)
+  * Fix terminal tab prompt input breaking when backticks are included [PR #272425](https://github.com/microsoft/vscode/pull/272425)
+  * Cleanup microsoft#272425 [PR #277406](https://github.com/microsoft/vscode/pull/277406)
+* [@bilogic](https://github.com/bilogic): also recognize `// #region ...` as valid markers [PR #278943](https://github.com/microsoft/vscode/pull/278943)
+* [@busorgin (Artem Busorgin)](https://github.com/busorgin): Set TextDecoder.ignoreBOM to true in VSBuffer [PR #272389](https://github.com/microsoft/vscode/pull/272389)
+* [@cannona (Aaron Cannon)](https://github.com/cannona): Allow "Move Editor into Previous Group" to create new group [PR #275968](https://github.com/microsoft/vscode/pull/275968)
+* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): Fix breakpoint range calculation [PR #280263](https://github.com/microsoft/vscode/pull/280263)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Correct non-standard capitalization of term 'status bar' in some settings (fix #277376) [PR #277383](https://github.com/microsoft/vscode/pull/277383)
+* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): Update `@types/vscode` package.json too [PR #277972](https://github.com/microsoft/vscode/pull/277972)
+* [@JeffreyCA](https://github.com/JeffreyCA): Terminal suggest - include persistent options in suggestions and improve suggestion grouping [PR #276409](https://github.com/microsoft/vscode/pull/276409)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Expect runtime config from NuGet MCP install [PR #271770](https://github.com/microsoft/vscode/pull/271770)
+* [@Josbleuet (Eric Fortin)](https://github.com/Josbleuet): Fix illegal characters in Dynamic Auth Provider logger filename [PR #280217](https://github.com/microsoft/vscode/pull/280217)
+* [@nikdmello (Nik D'Mello)](https://github.com/nikdmello): Update katex regex for jQuery expressions in KaTeX matching [PR #269635](https://github.com/microsoft/vscode/pull/269635)
+* [@ramanverse (Raman)](https://github.com/ramanverse): Remove obsolete maybeMigrateCurrentSession method [PR #280042](https://github.com/microsoft/vscode/pull/280042)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Mark Cursor mdc files as markdown [PR #276518](https://github.com/microsoft/vscode/pull/276518)
+* [@SalerSimo](https://github.com/SalerSimo): Fix settings boolean widget object overflow [PR #278884](https://github.com/microsoft/vscode/pull/278884)
+* [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
+  * fix: memory leak in breadcrumbs [PR #276597](https://github.com/microsoft/vscode/pull/276597)
+  * fix: memory leak in quick diff model [PR #276914](https://github.com/microsoft/vscode/pull/276914)
+  * fix: memory leak in breadcrumbs [PR #276915](https://github.com/microsoft/vscode/pull/276915)
+  * fix: memory leak in terminal process (partially) [PR #276962](https://github.com/microsoft/vscode/pull/276962)
+  * fix: memory leak in startup page [PR #277199](https://github.com/microsoft/vscode/pull/277199)
+  * fix: memory leak in terminal tabs list [PR #277225](https://github.com/microsoft/vscode/pull/277225)
+  * fix: memory leak with subdecorations not being disposed [PR #278328](https://github.com/microsoft/vscode/pull/278328)
+  * fix: possible memory leak with decoration registration [PR #278331](https://github.com/microsoft/vscode/pull/278331)
+  * fix: memory leak in task problem monitor [PR #279093](https://github.com/microsoft/vscode/pull/279093)
+  * fix: memory leak in history service [PR #279246](https://github.com/microsoft/vscode/pull/279246)
+  * fix: memory leak in composite bar [PR #280659](https://github.com/microsoft/vscode/pull/280659)
+* [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
+  * Fire onDidChangeHeight after code block editor render completes. Fix #265031 [PR #274691](https://github.com/microsoft/vscode/pull/274691)
+  * fix: use childNodes instead of children in DOM.reset for markdown rendering. Fix #266103 [PR #276890](https://github.com/microsoft/vscode/pull/276890)
+  * fix: update mathInlineRegExp to correctly handle $(a+b)^2$ [PR #280021](https://github.com/microsoft/vscode/pull/280021)
+* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): Improve performance of UriIdentityService (#273108) [PR #273111](https://github.com/microsoft/vscode/pull/273111)
+* [@yaxiaoliu](https://github.com/yaxiaoliu): fix(process-explorer): find name regexp error [PR #280273](https://github.com/microsoft/vscode/pull/280273)
+
+Contributions to `vscode-copilot-chat`:
+
+* [@AbdelrahmanAbouelenin (ababouelenin)](https://github.com/AbdelrahmanAbouelenin)
+  * Adding VSC hidden family [PR #1996](https://github.com/microsoft/vscode-copilot-chat/pull/1996)
+  * Merging hashes [PR #2181](https://github.com/microsoft/vscode-copilot-chat/pull/2181)
+  * Enable Replace String Tool For VSC Model C. [PR #2344](https://github.com/microsoft/vscode-copilot-chat/pull/2344)
+* [@cuining](https://github.com/cuining): Update ESLint configuration to use Node's built-in modules instead of a hard-coded restricted imports list [PR #2107](https://github.com/microsoft/vscode-copilot-chat/pull/2107)
+* [@IanMatthewHuff (Ian Huff)](https://github.com/IanMatthewHuff)
+  * fix any types in nullWorkspaceFileIndex [PR #1964](https://github.com/microsoft/vscode-copilot-chat/pull/1964)
+  * Fix up for the GitDiffService [PR #2116](https://github.com/microsoft/vscode-copilot-chat/pull/2116)
+* [@jeffreyhunter77 (Jeff Hunter)](https://github.com/jeffreyhunter77)
+  * Inline completions in @vscode/chat-lib [PR #2131](https://github.com/microsoft/vscode-copilot-chat/pull/2131)
+  * Fix @vscode/chat-lib install script and package [PR #2134](https://github.com/microsoft/vscode-copilot-chat/pull/2134)
+  * Make capi client optional for completions in chat-lib [PR #2369](https://github.com/microsoft/vscode-copilot-chat/pull/2369)
+  * Update completions fallback model id [PR #2370](https://github.com/microsoft/vscode-copilot-chat/pull/2370)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Decouple server.json formatting from VS Code core [PR #1373](https://github.com/microsoft/vscode-copilot-chat/pull/1373)
+
+Contributions to `vscode-js-debug`:
+
+* [@marat-gainullin](https://github.com/marat-gainullin): Dereferences of undefined at various places [PR #2297](https://github.com/microsoft/vscode-js-debug/pull/2297)
+
+Contributions to `vscode-pull-request-github`:
+
+* [@vicky1999 (Vignesh)](https://github.com/vicky1999)
+  * fix: message wrapping in narrow editor panes [PR #8121](https://github.com/microsoft/vscode-pull-request-github/pull/8121)
+  * feat: Display commit status icon for each commit [PR #8142](https://github.com/microsoft/vscode-pull-request-github/pull/8142)
+  * feat: Add copy comment link button in PR overview [PR #8150](https://github.com/microsoft/vscode-pull-request-github/pull/8150)
+
+Contributions to `vscode-python`:
+
+* [@iBug](https://github.com/iBug): Fix [microsoft/vscode#232420](https://github.com/microsoft/vscode/issues/232420): Python REPL cursor drifting [PR #25521](https://github.com/microsoft/vscode-python/pull/25521)
+
+Contributions to `vscode-python-debugger`:
+
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Update to latest debugpy [PR #877](https://github.com/microsoft/vscode-python-debugger/pull/877)
+
+Contributions to `vscode-python-environments`:
+
+* [@zsol (Zsolt Dollenstein)](https://github.com/zsol): Support UvWorkspace envs too [PR #1022](https://github.com/microsoft/vscode-python-environments/pull/1022)
+
+Contributions to `language-server-protocol`:
+
+* [@arshadrr (Arshad Riyaz)](https://github.com/arshadrr): add slang-server [PR #2200](https://github.com/microsoft/language-server-protocol/pull/2200)
+
+Contributions to `node-native-keymap`:
+
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Fix casing of msctf.h header [PR #64](https://github.com/microsoft/node-native-keymap/pull/64)
+* [@yonas (Yonas Yanfa)](https://github.com/yonas): Update README.md - add libxkbfile as a dependency on FreeBSD [PR #61](https://github.com/microsoft/node-native-keymap/pull/61)
+
+Contributions to `node-pty`:
+
+* [@42lizard (Oliver Gassner)](https://github.com/42lizard): Add OpenBSD includes for termios and util [PR #817](https://github.com/microsoft/node-pty/pull/817)
+* [@huangcs427 (huangcs)](https://github.com/huangcs427): add "Enjoy Git" Real-world Uses [PR #818](https://github.com/microsoft/node-pty/pull/818)
+
+Contributions to `python-environment-tools`:
+
+* [@reflectronic (John Tur)](https://github.com/reflectronic): Run commands without creating a console window on Windows [PR #266](https://github.com/microsoft/python-environment-tools/pull/266)
+* [@zsol (Zsolt Dollenstein)](https://github.com/zsol): Discover uv workspaces [PR #263](https://github.com/microsoft/python-environment-tools/pull/263)
+
+---
+
+<a id="scroll-to-top" role="button" title="Scroll to top" aria-label="scroll to top" href="#"><span class="icon"></span></a>
+<link rel="stylesheet" type="text/css" href="css/inproduct_releasenotes.css"/>

--- a/docs/release-notes/v1_107.md
+++ b/docs/release-notes/v1_107.md
@@ -7,753 +7,753 @@ MetaSocialImage: 1_107/release-highlights-stable.webp
 Date: 2025-12-10
 DownloadVersion: 1.107.1
 ---
-# November 2025 (version 1.107) {: #november-2025-version-1107 }
+# 2025 年 11 月 (バージョン 1.107) {: #november-2025-version-1107 }
 
-_Release date: December 10, 2025_
+_リリース日: 2025 年 12 月 10 日_
 
-**Update 1.107.1**: The update improves the [agent sessions experience](#integrating-agent-sessions-and-chat), adds an [agent workflow tutorial](https://code.visualstudio.com/docs/copilot/agents/agents-tutorial), and addresses these [issues](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22November+2025+Recovery+1%22+). The key highlights include:
+**Update 1.107.1**: このアップデートでは、[エージェントセッションエクスペリエンス](#integrating-agent-sessions-and-chat) が改善され、[エージェントワークフローチュートリアル](https://code.visualstudio.com/docs/copilot/agents/agents-tutorial) が追加され、いくつかの [問題](https://github.com/microsoft/vscode/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22November+2025+Recovery+1%22+) が修正されました。主なハイライトは以下の通りです:
 
-* Agent sessions view defaults to side-by-side and remembers your toggle state.
-* Agent sessions that require your input are now clearly marked.
-* Support for copying workspace changes when creating a background session.
-* Chat prompt is not cleared when creating a new session.
-* Tool calls in cloud sessions are now collapsed by default.
+* エージェントセッションビューがデフォルトでサイドバイサイドになり、トグル状態が記憶されるようになりました。
+* 入力が必要なエージェントセッションが明確にマークされるようになりました。
+* バックグラウンドセッションを作成する際にワークスペースの変更をコピーする機能がサポートされました。
+* 新しいセッションを作成してもチャットプロンプトがクリアされなくなりました。
+* クラウドセッションでのツール呼び出しがデフォルトで折りたたまれるようになりました。
 
 <!-- DOWNLOAD_LINKS_PLACEHOLDER -->
 
 ---
 
-VS Code 1.107 introduces multi-agent orchestration - use GitHub Copilot and custom agents together to accelerate and parallelize development.
+VS Code 1.107 では、マルチエージェントオーケストレーションが導入されました。GitHub Copilot とカスタムエージェントを併用して、開発を加速および並列化できます。
 
-* **Agent HQ** gives you one place to manage all your agents, letting Copilot and custom agents collaborate across tasks.
-* **Background agents** run in isolated workspaces to not interfere with your active work, and enabling multiple background tasks at once.
-* **Delegate** work across local, background, or cloud agents to keep your workflow moving without interruptions.
+* **Agent HQ** は、すべてのエージェントを管理するための単一の場所を提供し、Copilot とカスタムエージェントがタスク全体で連携できるようにします。
+* **Background agents** は、アクティブな作業を妨げないように分離されたワークスペースで実行され、複数のバックグラウンドタスクを同時に有効にします。
+* **Delegate** ローカル、バックグラウンド、またはクラウドエージェント間で作業を委任し、中断することなくワークフローを維持します。
 
-![VS Code November 2025 release image.](https://code.visualstudio.com/assets/updates/1_107/release-highlights-stable.webp)
-
-<br>
-
-Watch our [VS Code 1.107 release highlights video](https://aka.ms/VSCode/1-107rn) to hear about these features from our engineers!
-
-Happy Coding!
+![VS Code 2025年11月リリース画像。](https://code.visualstudio.com/assets/updates/1_107/release-highlights-stable.webp)
 
 <br>
 
->Read these release notes online at [Updates](https://code.visualstudio.com/updates) on [code.visualstudio.com](https://code.visualstudio.com).<br>
->**Insiders:** [Download the nightly Insiders build](https://code.visualstudio.com/insiders) to try the latest updates as soon as they're available.<br>
+エンジニアによるこれらの機能の紹介については、[VS Code 1.107 リリースハイライトビデオ](https://aka.ms/VSCode/1-107rn) をご覧ください！
+
+ハッピーコーディング！
+
+<br>
+
+>これらのリリースノートは、[code.visualstudio.com](https://code.visualstudio.com) の [Updates](https://code.visualstudio.com/updates) でオンラインで読むことができます。<br>
+>**Insiders:** [Insiders ビルドのナイトリービルドをダウンロード](https://code.visualstudio.com/insiders) して、最新のアップデートが利用可能になり次第お試しください。<br>
 
 ---
 
 <!-- TOC
 <div class="toc-nav-layout">
   <nav id="toc-nav">
-    <div>In this update</div>
+    <div>このアップデートについて</div>
     <ul>
-      <li><a href="#agents">Agents</a></li>
-      <li><a href="#chat">Chat</a></li>
+      <li><a href="#agents">エージェント</a></li>
+      <li><a href="#chat">チャット</a></li>
       <li><a href="#mcp">MCP</a></li>
-      <li><a href="#accessibility">Accessibility</a></li>
-      <li><a href="#editor-experience">Editor Experience</a></li>
-      <li><a href="#code-editing">Code Editing</a></li>
-      <li><a href="#source-control">Source Control</a></li>
-      <li><a href="#debugging">Debugging</a></li>
-      <li><a href="#terminal">Terminal</a></li>
-      <li><a href="#authentication">Authentication</a></li>
-      <li><a href="#languages">Languages</a></li>
-      <li><a href="#remote-development">Remote Development</a></li>
-      <li><a href="#enterprise">Enterprise</a></li>
-      <li><a href="#contributions-to-extensions">Contributions to extensions</a></li>
-      <li><a href="#proposed-apis">Proposed APIs</a></li>
-      <li><a href="#engineering">Engineering</a></li>
-      <li><a href="#notable-fixes">Notable fixes</a></li>
-      <li><a href="#thank-you">Thank you</a></li>
+      <li><a href="#accessibility">アクセシビリティ</a></li>
+      <li><a href="#editor-experience">エディターのエクスペリエンス</a></li>
+      <li><a href="#code-editing">コード編集</a></li>
+      <li><a href="#source-control">ソース管理</a></li>
+      <li><a href="#debugging">デバッグ</a></li>
+      <li><a href="#terminal">ターミナル</a></li>
+      <li><a href="#authentication">認証</a></li>
+      <li><a href="#languages">言語</a></li>
+      <li><a href="#remote-development">リモート開発</a></li>
+      <li><a href="#enterprise">エンタープライズ</a></li>
+      <li><a href="#contributions-to-extensions">拡張機能への貢献</a></li>
+      <li><a href="#proposed-apis">提案された API</a></li>
+      <li><a href="#engineering">エンジニアリング</a></li>
+      <li><a href="#notable-fixes">注目すべき修正</a></li>
+      <li><a href="#thank-you">ありがとう</a></li>
     </ul>
   </nav>
   <div class="notes-main">
 Navigation End -->
 
-## Agents {: #agents }
+## エージェント {: #agents }
 
-* Manage your agents from chat ([Show more](#integrating-agent-sessions-and-chat)).
-* Share agents across your organization ([Show more](#share-custom-agents-across-your-github-organization-experimental)).
-* Keep agents active while chat is closed ([Show more](#local-agent-sessions-remain-active-when-closed)).
-* Move agent sessions from local to cloud ([Show more](#continue-tasks-in-background-or-cloud-agents)).
-* Run agents in dedicated Git worktrees ([Show more](#isolate-background-agents-with-git-worktrees)).
-* Attach context to background agents ([Show more](#adding-context-to-background-agents)).
-* Customize background agents ([Show more](#use-custom-agents-with-background-agents-experimental)).
-* Reuse custom agents across environments ([Show more](#agent-tooling-reorganization)).
-* Run custom subagents ([Show more](#run-agents-as-subagents-experimental)).
-* Reuse Claude skills ([Show more](#reuse-your-claude-skills-experimental)).
+* チャットからエージェントを管理 ([詳細](#integrating-agent-sessions-and-chat))。
+* 組織全体でエージェントを共有 ([詳細](#share-custom-agents-across-your-github-organization-experimental))。
+* チャットが閉じている間もエージェントをアクティブに維持 ([詳細](#local-agent-sessions-remain-active-when-closed))。
+* エージェントセッションをローカルからクラウドへ移動 ([詳細](#continue-tasks-in-background-or-cloud-agents))。
+* 専用の Git ワークツリーでエージェントを実行 ([詳細](#isolate-background-agents-with-git-worktrees))。
+* バックグラウンドエージェントにコンテキストを添付 ([詳細](#adding-context-to-background-agents))。
+* バックグラウンドエージェントをカスタマイズ ([詳細](#use-custom-agents-with-background-agents-experimental))。
+* 環境全体でカスタムエージェントを再利用 ([詳細](#agent-tooling-reorganization))。
+* カスタムサブエージェントを実行 ([詳細](#run-agents-as-subagents-experimental))。
+* Claude スキルを再利用 ([詳細](#reuse-your-claude-skills-experimental))。
 
-### Integrating agent sessions and chat {: #integrating-agent-sessions-and-chat }
+### エージェントセッションとチャットの統合 {: #integrating-agent-sessions-and-chat }
 
 **Setting**: `setting(chat.viewSessions.enabled)`
 
-**Update 1.107.1**: This update significantly improves the side-by-side sessions experience. Hiding the sessions with the toggle now remembers your choice, allowing you to resize the Chat view at will. Get started with the [agent workflow tutorial](https://code.visualstudio.com/docs/copilot/agents/agents-tutorial).
+**Update 1.107.1**: このアップデートでは、サイドバイサイドセッションエクスペリエンスが大幅に改善されました。トグルでセッションを非表示にすると、その選択が記憶され、チャットビューのサイズを自由に調整できるようになりました。[エージェントワークフローチュートリアル](https://code.visualstudio.com/docs/copilot/agents/agents-tutorial) で始めましょう。
 
-Agents are key to autonomously performing coding tasks on your behalf. The chat interface is the main way to interact with agents, regardless of where they are running: locally in VS Code, in the background using a CLI, in the cloud, or from 3rd party extensions. Learn more about [using agents in VS Code](https://code.visualstudio.com/docs/copilot/agents/overview) in our documentation.
+エージェントは、ユーザーに代わってコーディングタスクを自律的に実行するための鍵となります。チャットインターフェイスは、VS Code 内でローカルに実行されているか、CLI を使用してバックグラウンドで実行されているか、クラウドで実行されているか、サードパーティの拡張機能から実行されているかに関係なく、エージェントと対話するための主要な方法です。詳細については、ドキュメントの [VS Code でのエージェントの使用](https://code.visualstudio.com/docs/copilot/agents/overview) を参照してください。
 
-This iteration, we integrated the agent sessions into the Chat view to give you a unified experience when working with agents. At a glance, you can see the session's status, progress, and file change statistics. You can archive or unarchive sessions to keep the sessions list manageable.
+このイテレーションでは、エージェントセッションをチャットビューに統合し、エージェントを使用する際の統一されたエクスペリエンスを提供しました。一目で、セッションのステータス、進行状況、ファイル変更の統計を確認できます。セッションをアーカイブまたはアーカイブ解除して、セッションリストを管理しやすくすることができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_107/agent-sessions.mp4" title="Video demonstrating the use agent sessions in Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/agent-sessions.mp4" title="チャットビューでのエージェントセッションの使用を示すビデオ。" autoplay loop controls muted></video>
 
-If you are working in a workspace, the session list only shows sessions related to the current workspace. If you are in an empty window, all sessions across workspaces are shown.
+ワークスペースで作業している場合、セッションリストには現在のワークスペースに関連するセッションのみが表示されます。空のウィンドウにいる場合は、ワークスペース全体のすべてのセッションが表示されます。
 
-When you select a session from the list, it opens the session in the Chat view in the Side Bar, allowing you to see the full conversation history. If you prefer, you can also open a session as an editor tab or in a new window. Right-click a session to see the context menu with these options.
+リストからセッションを選択すると、サイドバーのチャットビューでセッションが開き、完全な会話履歴を確認できます。必要に応じて、セッションをエディタータブまたは新しいウィンドウとして開くこともできます。セッションを右クリックすると、これらのオプションを含むコンテキストメニューが表示されます。
 
-![Screenshot showing the context menu of a session in the sessions list.](https://code.visualstudio.com/assets/updates/1_107/sessions-context.png)
+![セッションリスト内のセッションのコンテキストメニューを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/sessions-context.png)
 
-You can disable the sessions list in the Chat view by configuring `setting(chat.viewSessions.enabled)`.
+`setting(chat.viewSessions.enabled)` を構成することで、チャットビューのセッションリストを無効にすることができます。
 
-As a consequence of this change, we're disabling the standalone **Agent Sessions** view by default. If you prefer to keep using the standalone view, you can re-enable it via `setting(chat.agentSessionsViewLocation)`. In a future release, we plan to remove the standalone view entirely.
+この変更の結果として、スタンドアロンの **Agent Sessions** ビューをデフォルトで無効にしています。スタンドアロンビューを引き続き使用したい場合は、`setting(chat.agentSessionsViewLocation)` を介して再度有効にすることができます。将来のリリースでは、スタンドアロンビューを完全に削除する予定です。
 
-#### Compact view {: #compact-view }
+#### コンパクトビュー {: #compact-view }
 
-When the Chat view is narrow, the list of sessions is shown inside the Chat view when you start a new chat session. By default, the list shows the three most recent sessions that are not archived.
+チャットビューが狭い場合、新しいチャットセッションを開始すると、セッションのリストがチャットビュー内に表示されます。デフォルトでは、リストにはアーカイブされていない最新の 3 つのセッションが表示されます。
 
-![Screenshot showing the recent sessions in the Chat view.](https://code.visualstudio.com/assets/updates/1_107/recent-sessions.png)
+![チャットビューの最近のセッションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/recent-sessions.png)
 
-Select **Show All Sessions** to view the full list of sessions with options to search and filter.
+**Show All Sessions** を選択すると、検索とフィルターのオプションを含むセッションの完全なリストが表示されます。
 
-![Screenshot showing all sessions in the Chat view.](https://code.visualstudio.com/assets/updates/1_107/recent-sessions-all.png)
+![チャットビューのすべてのセッションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/recent-sessions-all.png)
 
-You can use the action to toggle the agent sessions sidebar for a wider experience of all sessions.
+アクションを使用してエージェントセッションサイドバーを切り替え、すべてのセッションをより広く表示することができます。
 
-#### Side-by-side view {: #sidebyside-view }
+#### サイドバイサイドビュー {: #sidebyside-view }
 
-Once the Chat view is wide enough (for example, when you maximize it), the list of agent sessions is automatically shown side-by-side with the Chat view. This view lets you quickly navigate between sessions without losing context. You can also manually toggle this side-by-side view using the corresponding control.
+チャットビューが十分に広い場合 (たとえば、最大化したとき)、エージェントセッションのリストは自動的にチャットビューと並べて表示されます。このビューでは、コンテキストを失うことなくセッション間をすばやく移動できます。対応するコントロールを使用して、このサイドバイサイドビューを手動で切り替えることもできます。
 
-![Screenshot showing all sessions side-by-side with the Chat view.](https://code.visualstudio.com/assets/updates/1_107/all-sessions.png)
+![チャットビューと並んで表示されるすべてのセッションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/all-sessions.png)
 
-To limit the sessions list, you can filter sessions by provider or state. VS Code persists this filter.
+セッションリストを制限するには、プロバイダーまたは状態でセッションをフィルター処理できます。VS Code はこのフィルターを保持します。
 
-#### Orientation setting {: #orientation-setting }
+#### 向きの設定 {: #orientation-setting }
 
 **Setting**: `setting(chat.viewSessions.orientation)`
 
-By default, the sessions list appears side-by-side with the Chat view when it's wide enough or if you manually toggle the sessions list. You can change this behavior with the `setting(chat.viewSessions.orientation)` setting.
+デフォルトでは、セッションリストは、幅が十分にある場合、または手動でセッションリストを切り替えた場合に、チャットビューと並べて表示されます。`setting(chat.viewSessions.orientation)` 設定でこの動作を変更できます。
 
-* `auto` (default): show the sessions side-by-side if the width allows it, otherwise show them above empty chats
-* `stacked`: always show the sessions above empty chats
-* `sideBySide`: show the session list side-by-side if the width allows it, otherwise hide the sessions list
+* `auto` (デフォルト): 幅が許せばセッションを並べて表示し、それ以外の場合は空のチャットの上に表示します
+* `stacked`: 常に空のチャットの上にセッションを表示します
+* `sideBySide`: 幅が許せばセッションリストを並べて表示し、それ以外の場合はセッションリストを非表示にします
 
-### Local agent sessions remain active when closed {: #local-agent-sessions-remain-active-when-closed }
+### ローカルエージェントセッションは閉じてもアクティブなまま {: #local-agent-sessions-remain-active-when-closed }
 
-Previously, when you closed a local chat session, a running agent request was cancelled. This limited the usefulness of local agents for long-running tasks or for running multiple tasks simultaneously.
+以前は、ローカルチャットセッションを閉じると、実行中のエージェントリクエストがキャンセルされていました。これにより、長時間実行されるタスクや複数のタスクを同時に実行する場合のローカルエージェントの有用性が制限されていました。
 
-Now, the local agent continues running in the background, even when not open in a chat editor or the Chat view. You are able to see the status of the running agent in the sessions list and can switch back to the session at any time to see the detailed progress.
+現在、ローカルエージェントは、チャットエディターやチャットビューで開いていなくても、バックグラウンドで実行され続けます。セッションリストで実行中のエージェントのステータスを確認でき、いつでもセッションに戻って詳細な進行状況を確認できます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_107/local-agent-active-when-closed.mp4" title="Video showing local agent running in background." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/local-agent-active-when-closed.mp4" title="バックグラウンドで実行されているローカルエージェントを示すビデオ。" autoplay loop controls muted></video>
 
-Learn more about [using local agent in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_switch-between-agents).
+詳細については、[チャットでのローカルエージェントの使用](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_switch-between-agents) を参照してください。
 
-### Continue tasks in background or cloud agents {: #continue-tasks-in-background-or-cloud-agents }
+### バックグラウンドまたはクラウドエージェントでタスクを継続 {: #continue-tasks-in-background-or-cloud-agents }
 
-Local agents are great for interactive sessions inside VS Code where you can go back and forth with the agent. This can be useful for brainstorming, performing exploratory tasks, or to work out an implementation plan. Once you have a clear plan, you can then hand the task off to a background or cloud agent to execute it autonomously.
+ローカルエージェントは、VS Code 内でエージェントとやり取りできるインタラクティブなセッションに最適です。これは、ブレインストーミング、探索的タスクの実行、または実装計画の作成に役立ちます。明確な計画ができたら、タスクをバックグラウンドまたはクラウドエージェントに引き継いで自律的に実行させることができます。
 
-This iteration, we have improved the experience to continue a local chat with a background or cloud agent. Across the UI, you can now continue a task seamlessly using the new **Continue in** option.
+このイテレーションでは、ローカルチャットをバックグラウンドまたはクラウドエージェントで継続するエクスペリエンスを改善しました。UI 全体で、新しい **Continue in** オプションを使用してタスクをシームレスに継続できるようになりました。
 
-When you continue a local chat to background or cloud agent, the current chat context is passed along and the original session is archived after handoff.
+ローカルチャットをバックグラウンドまたはクラウドエージェントに継続すると、現在のチャットコンテキストが引き継がれ、元のセッションはハンドオフ後にアーカイブされます。
 
-* Chat view:
+* チャットビュー:
 
-    ![Screenshot showing the 'Continue in' button in the Chat view.](https://code.visualstudio.com/assets/updates/1_107/continue-in-chatwidget.png)
+    ![チャットビューの 'Continue in' ボタンを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/continue-in-chatwidget.png)
 
-* Plan agent:
+* プランエージェント:
 
-    ![Screenshot showing the 'Start implementation' button when using the Plan agent.](https://code.visualstudio.com/assets/updates/1_107/continue-in-planmode.png)
+    ![プランエージェントを使用しているときの 'Start implementation' ボタンを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/continue-in-planmode.png)
 
-* Untitled prompt file:
+* 無題のプロンプトファイル:
 
-    ![Screenshot showing the 'Continue in' button in an untitled prompt file.](https://code.visualstudio.com/assets/updates/1_107/continue-in-promptfile.png)
+    ![無題のプロンプトファイルの 'Continue in' ボタンを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/continue-in-promptfile.png)
 
-### Isolate background agents with Git worktrees {: #isolate-background-agents-with-git-worktrees }
+### Git ワークツリーによるバックグラウンドエージェントの分離 {: #isolate-background-agents-with-git-worktrees }
 
-Background agents (previously called CLI agents) are designed to run autonomously in the background, allowing you to offload tasks while you focus on other work. Running multiple background agents simultaneously can lead to conflicts if they modify the same files in your workspace.
+バックグラウンドエージェント (以前は CLIエージェントと呼ばれていました) は、バックグラウンドで自律的に実行されるように設計されており、他の作業に集中している間にタスクをオフロードできます。複数のバックグラウンドエージェントを同時に実行すると、ワークスペース内の同じファイルを変更する場合に競合が発生する可能性があります。
 
-This iteration, we enhanced the isolation of background agents by introducing support for [Git worktrees](https://code.visualstudio.com/docs/sourcecontrol/branches-worktrees#_working-with-git-worktrees). When you create a new background agent, you can choose to either run it on the current workspace or to run it in a dedicated Git worktree.
+このイテレーションでは、[Git ワークツリー](https://code.visualstudio.com/docs/sourcecontrol/branches-worktrees#_working-with-git-worktrees) のサポートを導入することで、バックグラウンドエージェントの分離を強化しました。新しいバックグラウンドエージェントを作成するときに、現在のワークスペースで実行するか、専用の Git ワークツリーで実行するかを選択できます。
 
-![Screenshot showing the Git Worktree dropdown when creating a background agent.](https://code.visualstudio.com/assets/updates/1_107/background_worktree.png)
+![バックグラウンドエージェントを作成するときの Git ワークツリー ドロップダウンを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/background_worktree.png)
 
-When you run a background agent in a worktree, the agent automatically creates a new Git worktree for the session, isolating its changes in a separate folder. This lets you run multiple background agents simultaneously without conflicts.
+ワークツリーでバックグラウンドエージェントを実行すると、エージェントはセッション用に新しい Git ワークツリーを自動的に作成し、変更を別のフォルダーに分離します。これにより、競合することなく複数のバックグラウンドエージェントを同時に実行できます。
 
-You can easily review and merge the changes made by the background agent in the worktree back into your main workspace when the agent completes its task. We've also added a new action to directly apply the changes from a worktree directly into your workspace.
+エージェントがタスクを完了したら、ワークツリー内のバックグラウンドエージェントによる変更を簡単に確認してメインワークスペースにマージできます。また、ワークツリーからの変更をワークスペースに直接適用する新しいアクションも追加しました。
 
-![Screenshot of a background agent, showing the file changes that occurred in the worktree.](https://code.visualstudio.com/assets/updates/1_107/filechanges.png)
+![ワークツリーで発生したファイル変更を示すバックグラウンドエージェントのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/filechanges.png)
 
-Learn more about using [background agents in VS Code](https://code.visualstudio.com/docs/copilot/agents/background-agents).
+詳細については、[VS Code でのバックグラウンドエージェントの使用](https://code.visualstudio.com/docs/copilot/agents/background-agents) を参照してください。
 
-### Adding context to background agents {: #adding-context-to-background-agents }
+### バックグラウンドエージェントへのコンテキストの追加 {: #adding-context-to-background-agents }
 
-Background agents now support multiple context attachment types. You can attach selections, problems, symbols, search results, git commits, and more to any prompt. This makes it possible to build richer, more precise prompts, unlocking more complex and flexible workflows. For example, attach a reported problem and ask the agent to fix it without manually specifying file paths and line numbers.
+バックグラウンドエージェントは、複数のコンテキスト添付タイプをサポートするようになりました。選択範囲、問題、シンボル、検索結果、git コミットなどを任意のプロンプトに添付できます。これにより、よりリッチで正確なプロンプトを作成し、より複雑で柔軟なワークフローを実現できます。たとえば、報告された問題を添付し、ファイルパスや行番号を手動で指定せずにエージェントに修正を依頼できます。
 
-![Screenshot of a background agent session with a symbol and error attached as context.](https://code.visualstudio.com/assets/updates/1_107/background_attachments.png)
+![シンボルとエラーがコンテキストとして添付されたバックグラウンドエージェントセッションのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/background_attachments.png)
 
-### Share custom agents across your GitHub organization (Experimental) {: #share-custom-agents-across-your-github-organization-experimental }
+### GitHub 組織全体でのカスタムエージェントの共有 (実験的) {: #share-custom-agents-across-your-github-organization-experimental }
 
 **Setting**: `setting(github.copilot.chat.customAgents.showOrganizationAndEnterpriseAgents)`
 
-Previously, you could only define custom agents at a workspace or user level. If you wanted to share custom agents across your organization, you had to manually distribute the agent files to each user.
+以前は、カスタムエージェントはワークスペースまたはユーザーレベルでのみ定義できました。組織全体でカスタムエージェントを共有したい場合は、エージェントファイルを各ユーザーに手動で配布する必要がありました。
 
-In this release, you can now define custom agents at the organization level for your GitHub account. This experimental feature enables you to use organization-specific agents alongside your personal agents in chat.
+このリリースでは、GitHub アカウントの組織レベルでカスタムエージェントを定義できるようになりました。この実験的な機能により、チャットで個人用エージェントと一緒に組織固有のエージェントを使用できます。
 
-To enable this feature, set `setting(github.copilot.chat.customAgents.showOrganizationAndEnterpriseAgents)` to `true`. Once enabled, custom agents created by your organization appear in the Agents dropdown in VS Code.
+この機能を有効にするには、`setting(github.copilot.chat.customAgents.showOrganizationAndEnterpriseAgents)` を `true` に設定します。有効にすると、組織によって作成されたカスタムエージェントが VS Code のエージェントドロップダウンに表示されます。
 
-To learn more about creating custom agents for your organization, see [Create custom agents](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents) in the GitHub documentation.
+組織向けのカスタムエージェントの作成の詳細については、GitHub ドキュメントの [カスタムエージェントの作成](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents) を参照してください。
 
-### Use custom agents with background agents (Experimental) {: #use-custom-agents-with-background-agents-experimental }
+### バックグラウンドエージェントでのカスタムエージェントの使用 (実験的) {: #use-custom-agents-with-background-agents-experimental }
 
 **Setting**: `setting(github.copilot.chat.cli.customAgents.enabled)`
 
-You can now bring your own custom agents into Background Agents. Once enabled, custom agents defined in your `.github/agents` folder will appear in your agent list, allowing you to leverage agents tailored to your workflows and requirements.
+独自のカスタムエージェントをバックグラウンドエージェントに取り込むことができるようになりました。有効にすると、`.github/agents` フォルダーで定義されたカスタムエージェントがエージェントリストに表示され、ワークフローや要件に合わせて調整されたエージェントを活用できます。
 
-This experimental functionality can be enabled with the `setting(github.copilot.chat.cli.customAgents.enabled)` setting.
+この実験的な機能は、`setting(github.copilot.chat.cli.customAgents.enabled)` 設定で有効にできます。
 
-![Screenshot showing a background agent session with a custom Planner agent in the Agents dropdown list.](https://code.visualstudio.com/assets/updates/1_107/background_agents.png)
+![エージェントドロップダウンリストにカスタムプランナーエージェントがあるバックグラウンドエージェントセッションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/background_agents.png)
 
-Learn more about [defining custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
+詳細については、ドキュメントの [カスタムエージェントの定義](https://code.visualstudio.com/docs/copilot/customization/custom-agents) を参照してください。
 
-### Agent tooling reorganization {: #agent-tooling-reorganization }
+### エージェントツールの再編成 {: #agent-tooling-reorganization }
 
-We've reorganized the agent tooling structure to enable better compatibility with GitHub custom agents. This lets you more easily reuse custom agents across VS Code and GitHub environments without requiring separate configurations.
+GitHub カスタムエージェントとの互換性を向上させるために、エージェントツール構造を再編成しました。これにより、個別の構成を必要とせずに、VS Code と GitHub 環境全体でカスタムエージェントをより簡単に再利用できます。
 
-As part of this change, we've renamed certain existing tool references and the toolsets they belong to. Existing tool references in your agent files will continue to work, but you'll see a Code Action for renaming them to the latest recommended format. This ensures that your agent configurations follow the current best practices and maintain compatibility across platforms.
+この変更の一環として、特定の既存のツール参照とそれらが属するツールセットの名前を変更しました。エージェントファイル内の既存のツール参照は引き続き機能しますが、最新の推奨形式に名前を変更するためのコードアクションが表示されます。これにより、エージェント構成が現在のベストプラクティスに従い、プラットフォーム間での互換性が維持されます。
 
-### Run agents as subagents (Experimental) {: #run-agents-as-subagents-experimental }
+### エージェントをサブエージェントとして実行 (実験的) {: #run-agents-as-subagents-experimental }
 
 **Setting**: `setting(chat.customAgentInSubagent.enabled)`
 
-When an agent needs to solve a complex issue, it can delegate tasks to [subagents](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents). Subagents work independently from the main chat session and have their own context window. This helps the main conversation to stay focused on the high-level objective and helps to manage context window limitations.
+エージェントが複雑な問題を解決する必要がある場合、タスクを [サブエージェント](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents) に委任できます。サブエージェントはメインチャットセッションから独立して動作し、独自のコンテキストウィンドウを持ちます。これにより、メインの会話が高レベルの目的に集中し続け、コンテキストウィンドウの制限を管理するのに役立ちます。
 
-With this release, you can customize subagents via [custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents). Custom agents let you define specialized personas for the AI, tailoring their behavior to specific tasks or domains. For example, a code reviewer agent focuses on reviewing code rather than make code changes.
+このリリースでは、[カスタムエージェント](https://code.visualstudio.com/docs/copilot/customization/custom-agents) を介してサブエージェントをカスタマイズできます。カスタムエージェントを使用すると、AI の特定のペルソナを定義し、特定のタスクやドメインに合わせて動作を調整できます。たとえば、コードレビュー担当者エージェントは、コードを変更するのではなく、コードのレビューに重点を置きます。
 
-To use custom agents as subagents, follow these steps:
+カスタムエージェントをサブエージェントとして使用するには、次の手順に従います:
 
-1. Enable `setting(chat.customAgentInSubagent.enabled)`
+1. `setting(chat.customAgentInSubagent.enabled)` を有効にします
 
-1. Create a custom agent with the **Chat: New Custom Agent** command, if you don't have one yet.
+1. まだ持っていない場合は、**Chat: New Custom Agent** コマンドを使用してカスタムエージェントを作成します。
 
-1. In chat, ask the model "what subagents can you use?" to see the list of available subagents. Your custom agent should appear in the list.
+1. チャットで、モデルに「what subagents can you use?」と尋ねて、利用可能なサブエージェントのリストを確認します。カスタムエージェントがリストに表示されるはずです。
 
-1. Enter a prompt that meets the requirements for your custom agent. The language model uses the custom agent description and arguments to determine if it should be used for your request.
+1. カスタムエージェントの要件を満たすプロンプトを入力します。言語モデルは、カスタムエージェントの説明と引数を使用して、リクエストに使用する必要があるかどうかを判断します。
 
-    ![Screenshot of a chat conversation that uses a custom agent as subagent.](https://code.visualstudio.com/assets/updates/1_107/use-agents-as-subagents.png)
+    ![カスタムエージェントをサブエージェントとして使用するチャット会話のスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/use-agents-as-subagents.png)
 
-To prevent a custom agent from being used as a subagent, set the metadata property `infer` to `false` in the `*.agent.md` file.
+カスタムエージェントがサブエージェントとして使用されないようにするには、`*.agent.md` ファイルのメタデータプロパティ `infer` を `false` に設定します。
 
-Learn more about [using subagents in chat](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents).
+詳細については、[チャットでのサブエージェントの使用](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents) を参照してください。
 
-### Reuse your Claude skills (Experimental) {: #reuse-your-claude-skills-experimental }
+### Claude スキルの再利用 (実験的) {: #reuse-your-claude-skills-experimental }
 
 **Setting**: `setting(chat.useClaudeSkills)`
 
-Skills were introduced by [Claude Code](https://code.claude.com/docs/en/skills) and are capabilities that an agent can load on-demand. Each skill comes with a short description that advertizes the skill. If useful, the agent can decide to read the full skill instructions. Skill instructions can come with supporting files like scripts and templates.
-Once loaded, skills instructions and supporting files are part of the context of the main conversation.
+スキルは [Claude Code](https://code.claude.com/docs/en/skills) によって導入されたもので、エージェントがオンデマンドでロードできる機能です。各スキルには、スキルを宣伝する短い説明が付いています。有用な場合、エージェントは完全なスキルの指示を読むことを決定できます。スキルの指示には、スクリプトやテンプレートなどのサポートファイルを含めることができます。
+ロードされると、スキルの指示とサポートファイルはメインの会話のコンテキストの一部になります。
 
-VS Code can now reuse your existing skills. Enable the `setting(chat.useClaudeSkills)` setting to allow agents to discover and use your skills.
+VS Code は既存のスキルを再利用できるようになりました。`setting(chat.useClaudeSkills)` 設定を有効にして、エージェントがスキルを発見して使用できるようにします。
 
-![Screenshot that shows reusing Claude skills in chat in VS Code.](https://code.visualstudio.com/assets/updates/1_107/use-claude-skills.png)
+![VS Code のチャットで Claude スキルを再利用している様子を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/use-claude-skills.png)
 
-VS Code supports personal skills found at `~/.claude/skills/skill-name/SKILL.md` and project skills found in workspace folders at `${workspaceFolder}.claude/skills/skill-name/SKILL.md`.
+VS Code は、`~/.claude/skills/skill-name/SKILL.md` にある個人用スキルと、`${workspaceFolder}.claude/skills/skill-name/SKILL.md` にあるワークスペースフォルダー内のプロジェクトスキルをサポートしています。
 
-Check that the `SKILL.md` file has a `description` attribute in the header that advertizes the skill. Note that the `allowed-tools` attribute is not supported in VS Code.
+`SKILL.md` ファイルのヘッダーに、スキルを宣伝する `description` 属性があることを確認してください。VS Code では `allowed-tools` 属性はサポートされていないことに注意してください。
 
-In agent mode, make sure you have the read-file tool enabled and ask "What skills do you have" to find out if skills are found. Next, make a request that can be answered with a skill. If the agent doesn't use the skill, improve the skill description or nudge the model to use skills.
+エージェントモードでは、read-file ツールが有効になっていることを確認し、「What skills do you have」と尋ねてスキルが見つかるかどうかを確認します。次に、スキルで回答できるリクエストを行います。エージェントがスキルを使用しない場合は、スキルの説明を改善するか、モデルにスキルを使用するように促します。
 
-## Chat {: #chat }
+## チャット {: #chat }
 
-* Inline chat is optimized for code edits ([Show more](#inline-chat-ux)).
-* Manage your chat models ([Show more](#language-models-editor)).
-* Review external web content ([Show more](#url-and-domain-auto-approval)).
-* Fetch dynamic web content ([Show more](#more-robust-fetch-tool)).
-* Search ignored files ([Show more](#text-search-tool-can-search-ignored-files)).
-* Access terminal output in chat ([Show more](#rich-terminal-output-in-chat)).
-* Automatically approve terminal commands for your session ([Show more](#allow-all-terminal-commands-in-this-session)).
-* More keyboard shortcuts are available ([Show more](#keyboard-shortcuts-for-chat-terminal-actions)).
-* Use Entra ID for Azure-hosted models ([Show more](#azure-model-provider-entra-id-as-the-default-authentication)).
-* Configure extended thinking budget for Anthropic models ([Show more](#anthropic-models-extended-thinking-support)).
-* Use chat more efficiently ([Show more](#chat-view-appearance-improvements)).
-* View diffs for edits to sensitive files ([Show more](#diffs-for-edits-to-sensitive-files)).
-* Hide chat tool calls for reasoning models ([Show more](#collapsible-reasoning-and-tools-output-experimental)).
+* インラインチャットがコード編集用に最適化されました ([詳細](#inline-chat-ux))。
+* チャットモデルを管理 ([詳細](#language-models-editor))。
+* 外部 Web コンテンツを確認 ([詳細](#url-and-domain-auto-approval))。
+* 動的 Web コンテンツを取得 ([詳細](#more-robust-fetch-tool))。
+* 無視されたファイルを検索 ([詳細](#text-search-tool-can-search-ignored-files))。
+* チャットでターミナル出力にアクセス ([詳細](#rich-terminal-output-in-chat))。
+* セッションのターミナルコマンドを自動的に承認 ([詳細](#allow-all-terminal-commands-in-this-session))。
+* より多くのキーボードショートカットが利用可能 ([詳細](#keyboard-shortcuts-for-chat-terminal-actions))。
+* Azure ホストモデルに Entra ID を使用 ([詳細](#azure-model-provider-entra-id-as-the-default-authentication))。
+* Anthropic モデルの拡張思考予算を構成 ([詳細](#anthropic-models-extended-thinking-support))。
+* チャットをより効率的に使用 ([詳細](#chat-view-appearance-improvements))。
+* 機密ファイルへの編集の差分を表示 ([詳細](#diffs-for-edits-to-sensitive-files))。
+* 推論モデルのチャットツール呼び出しを非表示 ([詳細](#collapsible-reasoning-and-tools-output-experimental))。
 
-### Inline chat UX {: #inline-chat-ux }
+### インラインチャットの UX {: #inline-chat-ux }
 
 **Setting**: `setting(inlineChat.enableV2:true)`
 
-We continue to improve the inline chat experience to align it with the other chat experiences in VS Code and to optimize it for quick, single-file code changes.
+インラインチャットエクスペリエンスを継続的に改善し、VS Code の他のチャットエクスペリエンスと整合させ、迅速な単一ファイルのコード変更に最適化しています。
 
-<video src="https://code.visualstudio.com/assets/updates/1_107/inline_chat_edit.mp4" title="Video showing the updated UX for inline chat in action." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/inline_chat_edit.mp4" title="動作中のインラインチャットの更新された UX を示すビデオ。" autoplay loop controls muted></video>
 
-Previously, you could also use inline chat for general questions and discussions. Now, inline chat is optimized for code changes within the current file. For tasks that inline chat cannot handle, you are automatically upgraded to the Chat view where your prompt is being replayed, using the same model and the same context
+以前は、一般的な質問や議論にもインラインチャットを使用できました。現在、インラインチャットは現在のファイル内のコード変更に最適化されています。インラインチャットで処理できないタスクの場合、自動的にチャットビューにアップグレードされ、同じモデルと同じコンテキストを使用してプロンプトが再生されます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_107/inline_chat_exit.mp4" title="Video showing inline chat exit to Chat view flow." autoplay loop controls muted></video>
-The `setting(inlineChat.enableV2:true)` setting (preview) now only controls how the extension handles your prompt. This is still under development but can be tried with confidence.
+<video src="https://code.visualstudio.com/assets/updates/1_107/inline_chat_exit.mp4" title="インラインチャットからチャットビューへの終了フローを示すビデオ。" autoplay loop controls muted></video>
+`setting(inlineChat.enableV2:true)` 設定 (プレビュー) は、拡張機能がプロンプトを処理する方法のみを制御するようになりました。これはまだ開発中ですが、安心してお試しいただけます。
 
-### Language Models editor {: #language-models-editor }
+### 言語モデルエディター {: #language-models-editor }
 
-Chat in VS Code supports multiple language models, either provided by GitHub Copilot, third-party extensions, or via bring your own key (BYOK) providers. Managing all these models can be challenging, especially when you have access to many models across different providers. Learn more about [using language models in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
+VS Code のチャットは、GitHub Copilot、サードパーティの拡張機能、または Bring Your Own Key (BYOK) プロバイダーを介して提供される複数の言語モデルをサポートしています。これらすべてのモデルを管理することは、特にさまざまなプロバイダーの多くのモデルにアクセスできる場合に困難になる可能性があります。詳細については、[VS Code での言語モデルの使用](https://code.visualstudio.com/docs/copilot/customization/language-models) を参照してください。
 
-The **Language Models** editor provides a centralized place to view and manage all available language models for chat in VS Code. You can open it from the model picker in chat or via the Command Palette with **Chat: Manage Language Models**.
+**Language Models** エディターは、VS Code のチャットで使用可能なすべての言語モデルを表示および管理するための一元化された場所を提供します。チャットのモデルピッカーから、またはコマンドパレットで **Chat: Manage Language Models** を使用して開くことができます。
 
-<video src="https://code.visualstudio.com/assets/updates/1_107/language-models-editor.mp4" title="Video showing the Language Models editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/language-models-editor.mp4" title="Language Models エディターを示すビデオ" autoplay loop controls muted></video>
 
-The editor lists all models available to you, showing key information such as the model capabilities, context size, billing details, and visibility status. By default, models are grouped by provider, but you can also group them by visibility.
+エディターには、利用可能なすべてのモデルが一覧表示され、モデルの機能、コンテキストサイズ、請求の詳細、可視性ステータスなどの主要な情報が表示されます。デフォルトでは、モデルはプロバイダーごとにグループ化されていますが、可視性ごとにグループ化することもできます。
 
-Hover over model names or context sizes to see detailed information including model ID, version, status, and token breakdown.
+モデル名またはコンテキストサイズにカーソルを合わせると、モデルID、バージョン、ステータス、トークンの内訳などの詳細情報が表示されます。
 
-You can search and filter models using:
+以下を使用してモデルを検索およびフィルター処理できます:
 
-* Text search with highlighting
-* Provider filter: `@provider:"OpenAI"`
-* Capability filters: `@capability:tools`, `@capability:vision`, `@capability:agent`
-* Visibility filter: `@visible:true/false`
+* ハイライト付きのテキスト検索
+* プロバイダー フィルター: `@provider:"OpenAI"`
+* 機能 フィルター: `@capability:tools`, `@capability:vision`, `@capability:agent`
+* 可視性 フィルター: `@visible:true/false`
 
-#### Manage model visibility {: #manage-model-visibility }
+#### モデルの可視性の管理 {: #manage-model-visibility }
 
-As more models are available to you, the model picker can become overwhelming and difficult to navigate. In the Language Models editor, you can toggle the visibility of each model to control which models appear in the model picker. Hover over a model and select the eye icon to toggle its visibility.
+利用可能なモデルが増えると、モデルピッカーが圧倒され、ナビゲートが難しくなる可能性があります。Language Models エディターでは、各モデルの可視性を切り替えて、モデルピッカーに表示されるモデルを制御できます。モデルにカーソルを合わせ、目のアイコンを選択して可視性を切り替えます。
 
-#### Add models from installed providers {: #add-models-from-installed-providers }
+#### インストール済みプロバイダーからのモデルの追加 {: #add-models-from-installed-providers }
 
-From the Language Models editor, you can add more models with **Add Models...**. This shows a dropdown list of all installed model providers. Select a provider to configure it and add its models to chat in VS Code.
+Language Models エディターから、**Add Models...** を使用してさらにモデルを追加できます。これにより、インストールされているすべてのモデルプロバイダーのドロップダウンリストが表示されます。プロバイダーを選択して構成し、そのモデルを VS Code のチャットに追加します。
 
-This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
+これにより、Language Models エディターから移動することなく、インストールした追加のモデルプロバイダーを簡単にアクティブ化できます。プロバイダー行の歯車アイコンを選択して、プロバイダー管理にアクセスします。
 
-### URL and domain auto approval {: #url-and-domain-auto-approval }
+### URL とドメインの自動承認 {: #url-and-domain-auto-approval }
 
-This iteration, we enhanced the security and user experience of auto-approving URLs for the fetch tool. When the model decides to fetch content from a URL that you did not explicitly ask for, you'll see the new two-step approval experience:
+このイテレーションでは、フェッチツールの URL 自動承認のセキュリティとユーザーエクスペリエンスを強化しました。モデルが明示的に要求していない URL からコンテンツを取得することを決定すると、新しい 2 段階の承認エクスペリエンスが表示されます:
 
 * **Approve the initial request to fetch the URL**
 
-    This step ensures that you trust the domain being contacted and can prevent sensitive data to be sent to untrusted sites.
+    このステップにより、連絡先のドメインを信頼し、信頼できないサイトに機密データが送信されるのを防ぐことができます。
 
-    ![Screenshot showing a confirmation to approve the initial fetch request.](https://code.visualstudio.com/assets/updates/1_107/approve-fetch.png)
+    ![最初の取得リクエストを承認するための確認を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/approve-fetch.png)
 
-    You have options for one-time approval or automatically approving future requests to the specific URL or domain.
+    1 回限りの承認、または特定の URL またはドメインへの将来のリクエストを自動的に承認するオプションがあります。
 
-    The pre-approval respects the ["Trusted Domains" feature](https://code.visualstudio.com/docs/editing/editingevolved#_outgoing-link-protection). If a domain is listed there, you are automatically approved to make requests to that domain and are deferred to the response reviewing step.
+    事前承認は、["Trusted Domains" 機能](https://code.visualstudio.com/docs/editing/editingevolved#_outgoing-link-protection) を尊重します。ドメインがそこにリストされている場合、そのドメインへのリクエストを行うことが自動的に承認され、応答の確認ステップに延期されます。
 
 * **Approve to use the fetched content in chat and follow-up tool calls**
 
-    This step ensures that you review the fetched content before it is added to the chat or passed to other tools, preventing potential prompt injection attacks.
+    このステップにより、取得したコンテンツがチャットに追加されたり、他のツールに渡されたりする前に確認し、潜在的なプロンプトインジェクション攻撃を防ぐことができます。
 
-    For example, you might approve a request to fetch content from a well-known site, like GitHub.com. But because the content, such as issue description or comments, is user-generated, it could contain harmful content that might manipulate the model's behavior.
+    たとえば、GitHub.com などの有名なサイトからコンテンツを取得するリクエストを承認する場合があります。しかし、問題の説明やコメントなどのコンテンツはユーザー生成であるため、モデルの動作を操作する可能性のある有害なコンテンツが含まれている可能性があります。
 
-Learn more about [URL and domain approval](https://code.visualstudio.com/docs/copilot/chat/chat-tools#url-approval) in VS Code chat.
+詳細については、VS Code チャットの [URL とドメインの承認](https://code.visualstudio.com/docs/copilot/chat/chat-tools#url-approval) を参照してください。
 
-### More robust fetch tool {: #more-robust-fetch-tool }
+### より堅牢なフェッチツール {: #more-robust-fetch-tool }
 
-The `#fetch` agent tool now handles dynamic web content more effectively. It can retrieve dynamic content, in addition to static HTML. Websites that rely on JavaScript to load their content, such as Single-Page Applications (SPAs), modern documentation sites, or issue tracking systems like Jira, no longer return incomplete or empty results.
+`#fetch` エージェントツールは、動的 Web コンテンツをより効果的に処理するようになりました。静的 HTML に加えて、動的コンテンツを取得できます。コンテンツをロードするために JavaScript に依存する Web サイト (シングルページアプリケーション (SPA)、最新のドキュメントサイト、Jira などの課題追跡システムなど) は、不完全または空の結果を返さなくなりました。
 
-The fetch tool waits for JavaScript to execute and content to load before retrieving the page, ensuring that dynamically-rendered content is captured. This improvement makes the tool significantly more useful in real-life scenarios.
+フェッチツールは、ページを取得する前に JavaScript が実行され、コンテンツがロードされるのを待機し、動的にレンダリングされたコンテンツがキャプチャされるようにします。この改善により、実際のシナリオでツールが大幅に便利になります。
 
-When you use `#fetch` followed by a URL, the model accesses the actual content you'd see in the browser, not just the initial HTML skeleton. This means more accurate and complete information when asking questions about web pages or requesting the model to analyze online content.
+`#fetch` の後に URL を使用すると、モデルは最初の HTML スケルトンだけでなく、ブラウザーで表示される実際のコンテンツにアクセスします。これは、Web ページについて質問したり、モデルにオンラインコンテンツの分析を依頼したりするときに、より正確で完全な情報を意味します。
 
-### Text Search tool can search ignored files {: #text-search-tool-can-search-ignored-files }
+### テキスト検索ツールで無視されたファイルを検索可能に {: #text-search-tool-can-search-ignored-files }
 
-The `#textSearch` tool now supports searching in ignored files/folders specified by `files.exclude` or `search.exclude` settings or `.gitignore` files, such as the `node_modules` folder. It also returns hints to the agent about the ignored files/folders when there are no results, allowing agents to turn around and enable searching in those ignored files/folders.
+`#textSearch` ツールは、`files.exclude` または `search.exclude` 設定、または `node_modules` フォルダーなどの `.gitignore` ファイルで指定された無視されたファイル/フォルダー内の検索をサポートするようになりました。また、結果がない場合に無視されたファイル/フォルダーに関するヒントをエージェントに返し、エージェントがそれらの無視されたファイル/フォルダー内の検索を有効にできるようにします。
 
-### Rich terminal output in chat {: #rich-terminal-output-in-chat }
+### チャットでのリッチなターミナル出力 {: #rich-terminal-output-in-chat }
 
-Using **Toggle Output** on a **Run in Terminal** response now renders output in a full, read-only `xterm.js` terminal inside chat. A nice benefit of this approach is that VS Code preserves captured output even after the backing terminal has exited, so you can reopen previous runs at any time and see the terminal output as it was when the command ran.
+**Run in Terminal** 応答で **Toggle Output** を使用すると、チャット内に完全な読み取り専用の `xterm.js` ターミナルで出力がレンダリングされるようになりました。このアプローチの優れた利点は、バッキングターミナルが終了した後でも VS Code がキャプチャされた出力を保持するため、いつでも以前の実行を再度開いて、コマンド実行時のターミナル出力を確認できることです。
 
-The chat terminal now adopts the integrated terminal's color theme for improved ANSI color contrast. Screen reader users can open the accessible view `kb(editor.action.accessibleView)` when the output has focus, enabling easy review and navigation.
+チャットターミナルは、統合ターミナルのカラーテーマを採用し、ANSI カラーコントラストを向上させました。スクリーンリーダーユーザーは、出力にフォーカスがあるときにアクセシブルビュー `kb(editor.action.accessibleView)` を開いて、簡単に確認およびナビゲートできます。
 
-Learn more about [using terminal commands in chat](https://code.visualstudio.com/docs/copilot/chat/chat-tools#_terminal-commands).
+詳細については、[チャットでのターミナルコマンドの使用](https://code.visualstudio.com/docs/copilot/chat/chat-tools#_terminal-commands) を参照してください。
 
-### Command status details in chat terminals {: #command-status-details-in-chat-terminals }
+### チャットターミナルでのコマンドステータスの詳細 {: #command-status-details-in-chat-terminals }
 
-Chat terminal messages now display command start time, duration, and exit code on hover of the command decoration.
+チャットターミナルメッセージは、コマンド装飾にカーソルを合わせると、コマンドの開始時間、期間、終了コードを表示するようになりました。
 
-![Screenshot of the terminal showing npm install candy is run by the agent and the command decoration hover displays command execution time and status.](https://code.visualstudio.com/assets/updates/1_107/terminal-command-exit.png)
+![エージェントによって npm install candy が実行されているターミナルのスクリーンショット。コマンド装飾のホバーには、コマンドの実行時間とステータスが表示されます。](https://code.visualstudio.com/assets/updates/1_107/terminal-command-exit.png)
 
-### Allow all terminal commands in this session {: #allow-all-terminal-commands-in-this-session }
+### このセッションのすべてのターミナルコマンドを許可 {: #allow-all-terminal-commands-in-this-session }
 
-To optimize your chat experience, while maintaining security and control, the terminal tool has a new auto approve option to allow all future commands for the session. When you start a new session, terminal commands will follow the existing approval configuration.
+セキュリティと制御を維持しながらチャットエクスペリエンスを最適化するために、ターミナルツールには、セッションのすべての将来のコマンドを許可する新しい自動承認オプションがあります。新しいセッションを開始すると、ターミナルコマンドは既存の承認構成に従います。
 
-![Screenshot that shows the Allow All Commands in this Session option when approving a terminal command in chat.](https://code.visualstudio.com/assets/updates/1_107/terminal-allow-all.png)
+![チャットでターミナルコマンドを承認するときに、'Allow All Commands in this Session' オプションを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/terminal-allow-all.png)
 
-### Keyboard shortcuts for chat terminal actions {: #keyboard-shortcuts-for-chat-terminal-actions }
+### チャットターミナルアクションのキーボードショートカット {: #keyboard-shortcuts-for-chat-terminal-actions }
 
-You can now focus the most recent chat terminal `kb(workbench.action.terminal.chat.focusMostRecentChatTerminal)` or toggle its expansion state `kb(workbench.action.terminal.chat.focusMostRecentChatTerminalOutput)` via dedicated keyboard shortcuts.
+専用のキーボードショートカットを使用して、最新のチャットターミナルにフォーカス `kb(workbench.action.terminal.chat.focusMostRecentChatTerminal)` したり、展開状態を切り替えたり `kb(workbench.action.terminal.chat.focusMostRecentChatTerminalOutput)` できるようになりました。
 
-### Keyboard shortcuts for custom agents {: #keyboard-shortcuts-for-custom-agents }
+### カスタムエージェントのキーボードショートカット {: #keyboard-shortcuts-for-custom-agents }
 
-Each custom agent now has a separate action in the command list for them and you can bind keyboard shortcuts to them individually. For example, if you define a "Code Reviewer" custom agent, there will be a **Chat: Open Chat (Code Reviewer Agent)** command in the Command Palette to bind a keyboard shortcut to.
+各カスタムエージェントには、コマンドリストに個別のアクションがあり、個別にキーボードショートカットをバインドできます。たとえば、「Code Reviewer」カスタムエージェントを定義した場合、キーボードショートカットをバインドするための **Chat: Open Chat (Code Reviewer Agent)** コマンドがコマンドパレットに表示されます。
 
-![Screenshot of custom agent commands in the Command Palette.](https://code.visualstudio.com/assets/updates/1_107/custom-agent-commands.png)
+![コマンドパレットのカスタムエージェントコマンドのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/custom-agent-commands.png)
 
-### Azure model provider: Entra ID as the default authentication {: #azure-model-provider-entra-id-as-the-default-authentication }
+### Azure モデルプロバイダー: デフォルトの認証として Entra ID を使用 {: #azure-model-provider-entra-id-as-the-default-authentication }
 
 **Setting**: `setting(github.copilot.chat.azureAuthType)`
 
-By default, the Azure model provider now uses Entra ID authentication when connecting to Bring-Your-Own-Key (BYOK) models, providing improved security and a more streamlined sign-in experience.
+デフォルトでは、Azure モデルプロバイダーは、Bring-Your-Own-Key (BYOK) モデルに接続するときに Entra ID 認証を使用するようになり、セキュリティが向上し、サインインエクスペリエンスが合理化されました。
 
-If you prefer to authenticate using an API key, set `setting(github.copilot.chat.azureAuthType)` to `apiKey` instead of `entraId` (default).
+API キーを使用して認証する場合は、`setting(github.copilot.chat.azureAuthType)` を `entraId` (デフォルト) ではなく `apiKey` に設定します。
 
-### Anthropic models: Extended thinking support {: #anthropic-models-extended-thinking-support }
+### Anthropic モデル: 拡張思考のサポート {: #anthropic-models-extended-thinking-support }
 
 **Setting**: `setting(github.copilot.chat.anthropic.thinking.budgetTokens)`
 
-Anthropic models now support extended thinking, which is enabled by default for all Anthropic extended thinking models. Extended thinking gives Claude enhanced reasoning capabilities for complex tasks by allowing it to spend additional tokens on its step-by-step thought process before generating a response, leading to more thoughtful and accurate outputs.
+Anthropic モデルは、すべての Anthropic 拡張思考モデルでデフォルトで有効になっている拡張思考をサポートするようになりました。拡張思考は、応答を生成する前にステップバイステップの思考プロセスに追加のトークンを費やすことを可能にすることで、複雑なタスクに対する Claude の推論機能を強化し、より思慮深く正確な出力を導きます。
 
-The default thinking budget is set to 4,000 tokens. You can customize this budget by modifying the `setting(github.copilot.chat.anthropic.thinking.budgetTokens)` setting to adjust how many tokens the model can use for extended thinking. To turn off extended thinking entirely, set the budget to `0`.
+デフォルトの思考予算は 4,000 トークンに設定されています。`setting(github.copilot.chat.anthropic.thinking.budgetTokens)` 設定を変更して、モデルが拡張思考に使用できるトークン数を調整することで、この予算をカスタマイズできます。拡張思考を完全にオフにするには、予算を `0` に設定します。
 
-> **Note**: Interleaved thinking, which enables Claude to reason between tool calls, is only available when using Anthropic models via Bring-Your-Own-Key (BYOK). It uses the same thinking budget setting configured above.
+> **Note**: ツール呼び出し間の推論を可能にするインターリーブ思考は、Bring-Your-Own-Key (BYOK) を介して Anthropic モデルを使用する場合にのみ使用できます。上記で構成された同じ思考予算設定を使用します。
 
-### Chat view appearance improvements {: #chat-view-appearance-improvements }
+### チャットビューの外観の改善 {: #chat-view-appearance-improvements }
 
-We've made several improvements to the Chat view's appearance to enhance readability and usability:
+読みやすさと使いやすさを向上させるために、チャットビューの外観にいくつかの改善を加えました:
 
 * **Chat title**:
 
-    When you open a chat, a new title control appears to the top showing you the title of the chat as well as giving you a quick way to get back to an empty chat. Configure this behavior via the `setting(chat.viewTitle.enabled)` setting.
+    チャットを開くと、上部に新しいタイトルコントロールが表示され、チャットのタイトルが表示されるだけでなく、空のチャットにすばやく戻ることができます。`setting(chat.viewTitle.enabled)` 設定でこの動作を構成します。
 
     <video src="https://code.visualstudio.com/assets/updates/1_107/chat-title.mp4" title="Video showing chat titles and returning back to the session list." autoplay loop controls muted></video>
 
 * **Welcome banner**:
 
-    If you prefer a more minimal experience when opening a new chat, the new setting `setting(chat.viewWelcome.enabled)` lets you hide the icon and welcome text.
+    新しいチャットを開くときにより最小限のエクスペリエンスを好む場合は、新しい設定 `setting(chat.viewWelcome.enabled)` を使用してアイコンとウェルカムテキストを非表示にできます。
 
-    ![Screenshot of empty chat view with the icon and welcome text hidden.](https://code.visualstudio.com/assets/updates/1_107/chat-welcome.png)
+    ![アイコンとウェルカムテキストが非表示になっている空のチャットビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/chat-welcome.png)
 
 * **Restore previous chat session**:
 
-    When you open chat after restarting or opening a different workspace, the previous session is now restored by default. You can change this behavior via the `setting(chat.viewRestorePreviousSession)` setting and choose to always start with an empty chat.
+    再起動後または別のワークスペースを開いた後にチャットを開くと、前のセッションがデフォルトで復元されるようになりました。`setting(chat.viewRestorePreviousSession)` 設定でこの動作を変更し、常に空のチャットで開始することを選択できます。
 
-### Diffs for edits to sensitive files {: #diffs-for-edits-to-sensitive-files }
+### 機密ファイルへの編集の差分 {: #diffs-for-edits-to-sensitive-files }
 
-When chat attempts to edit sensitive files, such as the `settings.json` or `package.json`, you get a notification and are asked to approve the changes before they are applied. You can configure which files are considered sensitive via the `setting(chat.tools.edits.autoApprove)` setting.
+チャットが `settings.json` や `package.json` などの機密ファイルを編集しようとすると、通知が表示され、変更が適用される前に承認を求められます。`setting(chat.tools.edits.autoApprove)` 設定で機密と見なされるファイルを構成できます。
 
-Previously, you would see the raw edit that the model proposed, which could be difficult to understand. Now, we show you a diff of the proposed changes, making it easier to review and approve the edits.
+以前は、モデルが提案した生の編集が表示されていましたが、理解するのが難しい場合がありました。現在、提案された変更の差分が表示され、編集の確認と承認が容易になりました。
 
-![Screenshot showing a diff of proposed changes to `package.json` in chat.](https://code.visualstudio.com/assets/updates/1_107/sensitive-file-diff.png)
+![チャットでの package.json への提案された変更の差分を示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/sensitive-file-diff.png)
 
-Learn more about editing [sensitive files in chat](https://code.visualstudio.com/docs/copilot/chat/review-code-edits#_edit-sensitive-files).
+詳細については、[チャットでの機密ファイルの編集](https://code.visualstudio.com/docs/copilot/chat/review-code-edits#_edit-sensitive-files) を参照してください。
 
-### Collapsible reasoning and tools output (Experimental) {: #collapsible-reasoning-and-tools-output-experimental }
+### 折りたたみ可能な推論とツール出力 (実験的) {: #collapsible-reasoning-and-tools-output-experimental }
 
 **Setting**: `setting(chat.agent.thinkingStyle)`, `setting(chat.agent.thinking.collapsedTools)`
 
-With language model reasoning and agent tools output, a chat conversation can quickly become long and difficult to follow. Last iteration, we already worked on improving how we display thinking tokens in chat with the `setting(chat.agent.thinkingStyle)` setting.
+言語モデルの推論とエージェントツール出力により、チャットの会話はすぐに長くなり、追跡が難しくなる可能性があります。前回のイテレーションでは、`setting(chat.agent.thinkingStyle)` 設定を使用してチャットで思考トークンを表示する方法の改善にすでに取り組みました。
 
-This iteration, we're further optimizing the chat experience by introducing collapsible chat sections for non-reasoning chat output, such as tool calls. By default, successive tool calls are now collapsed to reduce visual noise.
+このイテレーションでは、ツール呼び出しなどの非推論チャット出力用の折りたたみ可能なチャットセクションを導入することで、チャットエクスペリエンスをさらに最適化しています。デフォルトでは、連続するツール呼び出しは、視覚的なノイズを減らすために折りたたまれるようになりました。
 
-Collapsible items (most tools and reasoning text) will be summarized and an AI-generated title will be given to each collapsible section.
+折りたたみ可能なアイテム (ほとんどのツールと推論テキスト) は要約され、AI によって生成されたタイトルが各折りたたみ可能なセクションに付けられます。
 
-![Screenshot showing multiple tool calls collapsed in a collapsible section.](https://code.visualstudio.com/assets/updates/1_107/collapsed-tools.png)
+![折りたたみ可能なセクションに折りたたまれた複数のツール呼び出しを示すスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/collapsed-tools.png)
 
 ## MCP {: #mcp }
 
-* We added support for the latest MCP specification ([Show more](#support-for-the-latest-mcp-specification)).
-* Use the GitHub remote MCP server without extra setup ([Show more](#github-mcp-server-provided-by-github-copilot-chat-preview)).
+* 最新の MCP 仕様のサポートを追加しました ([詳細](#support-for-the-latest-mcp-specification))。
+* 追加の設定なしで GitHub リモート MCP サーバーを使用 ([詳細](#github-mcp-server-provided-by-github-copilot-chat-preview))。
 
-### Support for the latest MCP specification {: #support-for-the-latest-mcp-specification }
+### 最新の MCP 仕様のサポート {: #support-for-the-latest-mcp-specification }
 
-VS Code supports the latest revision of the MCP specification, `2025-11-25`. This includes, among other things:
+VS Code は、MCP 仕様の最新リビジョン `2025-11-25` をサポートしています。これには、特に以下が含まれます:
 
-* [URL mode elicitation](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-elicitation-requests)
-* [Tasks](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks) for long-running, resilient tool calls and client work.
-* [Enhancements](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330) to enum choices in elicitation
+* [URL モードの抽出](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation#url-elicitation-requests)
+* 長時間実行され、回復力のあるツール呼び出しとクライアント作業のための [タスク](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks)。
+* 抽出における列挙型の選択肢の [強化](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1330)
 
-These improvements come in addition to the `2025-11-25` draft features VS Code already supported, such as `WWW-Authenticate` scope consent, the Client ID Metadata Document authentication flow, and icons for tools, resources, and servers. You can view the changelog for the 2025-11-25 draft on the [MCP website](https://modelcontextprotocol.io/specification/2025-11-25/changelog#major-changes).
+これらの改善は、`WWW-Authenticate` スコープの同意、クライアント ID メタデータドキュメント認証フロー、ツール、リソース、サーバーのアイコンなど、VS Code がすでにサポートしていた `2025-11-25` ドラフト機能に加えて提供されます。2025-11-25 ドラフトの変更ログは、[MCP Web サイト](https://modelcontextprotocol.io/specification/2025-11-25/changelog#major-changes) で確認できます。
 
-Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
+詳細については、[VS Code での MCP サーバーの使用](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) を参照してください。
 
-### GitHub MCP Server provided by GitHub Copilot Chat (Preview) {: #github-mcp-server-provided-by-github-copilot-chat-preview }
+### GitHub Copilot Chat が提供する GitHub MCP サーバー (プレビュー) {: #github-mcp-server-provided-by-github-copilot-chat-preview }
 
 **Setting**: `setting(github.copilot.chat.githubMcpServer.enabled)`
 
-The GitHub remote MCP Server is now provided as a built-in MCP server in the GitHub Copilot Chat extension, providing seamless integration with GitHub repositories and services. This integration offers several benefits:
+GitHub リモート MCP サーバーは、GitHub Copilot Chat 拡張機能の組み込み MCP サーバーとして提供されるようになり、GitHub リポジトリおよびサービスとのシームレスな統合が提供されます。この統合には、いくつかの利点があります:
 
-* Alignment with other Copilot agent harnesses like Copilot CLI and Copilot Cloud Agent that already use the GitHub MCP Server
-* Reuse of existing GitHub authentication state, eliminating additional authentication prompts
-* Transparent support for different GitHub MCP endpoints including GHE.com
+* すでに GitHub MCP サーバーを使用している Copilot CLI や Copilot Cloud Agent などの他の Copilot エージェントハーネスとの整合性
+* 既存の GitHub 認証状態の再利用により、追加の認証プロンプトが不要になります
+* GHE.com を含むさまざまな GitHub MCP エンドポイントの透過的なサポート
 
-To enable the GitHub MCP Server, set the `setting(github.copilot.chat.githubMcpServer.enabled)` setting to `true`. Once enabled, the server automatically appears in the tool picker when using agents. This enables you to ask questions about GitHub issues, pull requests, and other repository information without additional configuration and setup.
+GitHub MCP サーバーを有効にするには、`setting(github.copilot.chat.githubMcpServer.enabled)` 設定を `true` に設定します。有効にすると、エージェントを使用するときにサーバーがツールピッカーに自動的に表示されます。これにより、追加の構成や設定なしで、GitHub の問題、プルリクエスト、その他のリポジトリ情報について質問できます。
 
-The GitHub MCP Server supports customization through several settings:
+GitHub MCP サーバーは、いくつかの設定によるカスタマイズをサポートしています:
 
-* `setting(github.copilot.chat.githubMcpServer.toolsets)`: Configure which tools are available. By default, the `default` toolset is used, but you can extend it by adding `workflows` or other toolsets as documented in the [GitHub MCP Server documentation](https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md#remote-mcp-toolsets). **Note:** Adding certain toolsets may require additional permissions and re-authentication is not yet supported. Please see [this GitHub issue](https://github.com/microsoft/vscode/issues/280640) to track progress.
-* `setting(github.copilot.chat.githubMcpServer.readonly)`: Force the server to return only read-only tools, preventing any write operations.
-* `setting(github.copilot.chat.githubMcpServer.lockdown)`: Additional security control for tool behavior.
+* `setting(github.copilot.chat.githubMcpServer.toolsets)`: 使用可能なツールを構成します。デフォルトでは `default` ツールセットが使用されますが、[GitHub MCP サーバーのドキュメント](https://github.com/github/github-mcp-server/blob/main/docs/remote-server.md#remote-mcp-toolsets) に記載されているように、`workflows` やその他のツールセットを追加して拡張できます。**Note:** 特定のツールセットを追加すると、追加の権限が必要になる場合があり、再認証はまだサポートされていません。進行状況を追跡するには、[この GitHub の問題](https://github.com/microsoft/vscode/issues/280640) を参照してください。
+* `setting(github.copilot.chat.githubMcpServer.readonly)`: サーバーに読み取り専用ツールのみを返すように強制し、書き込み操作を防ぎます。
+* `setting(github.copilot.chat.githubMcpServer.lockdown)`: ツールの動作に対する追加のセキュリティ制御。
 
-> **Note**: This feature is currently in Preview and requires explicit opt-in through the setting mentioned above. We are planning to enable it by default in a future release in a way that makes it available when wanted, but not intrusive when not needed.
+> **Note**: この機能は現在プレビュー段階であり、上記の設定による明示的なオプトインが必要です。将来のリリースでは、必要なときに利用でき、不要なときは邪魔にならない方法で、デフォルトで有効にする予定です。
 
-## Accessibility {: #accessibility }
+## アクセシビリティ {: #accessibility }
 
-### Keyboard approval for chat confirmations {: #keyboard-approval-for-chat-confirmations }
+### チャット確認のキーボード承認 {: #keyboard-approval-for-chat-confirmations }
 
-When an agent prompts for confirmation, you can now approve via keyboard using `kb(workbench.action.chat.acceptTool)`.
+エージェントが確認を求めたときに、`kb(workbench.action.chat.acceptTool)` を使用してキーボードで承認できるようになりました。
 
-## Editor Experience {: #editor-experience }
+## エディターのエクスペリエンス {: #editor-experience }
 
-* More easily identify open projects ([Show more](#more-support-to-indicate-opened-windows-in-pickers)).
-* Swipe to navigate on macOS ([Show more](#macos-mouse-swipe-to-navigate)).
-* Choose when to view hover popups ([Show more](#on-demand-editor-hover-popups)).
+* 開いているプロジェクトをより簡単に識別 ([詳細](#more-support-to-indicate-opened-windows-in-pickers))。
+* macOS でスワイプしてナビゲート ([詳細](#macos-mouse-swipe-to-navigate))。
+* ホバーポップアップを表示するタイミングを選択 ([詳細](#on-demand-editor-hover-popups))。
 
-### More support to indicate opened windows in pickers {: #more-support-to-indicate-opened-windows-in-pickers }
+### ピッカーで開いているウィンドウを示すサポートの強化 {: #more-support-to-indicate-opened-windows-in-pickers }
 
-We added an indicator to the **Open Recent** picker for when a workspace is already open in a VS Code window.
+ワークスペースがすでに VS Code ウィンドウで開いている場合のために、**Open Recent** ピッカーにインジケーターを追加しました。
 
-![Screenshot of recently opened workspaces.](https://code.visualstudio.com/assets/updates/1_107/pickers.png)
+![最近開いたワークスペースのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/pickers.png)
 
-The currently active window is indicated slightly differently from other opened windows to make that distinction clearer. Entries that are not opened in any window have no icon.
+現在アクティブなウィンドウは、他の開いているウィンドウとは少し異なって表示され、区別が明確になります。どのウィンドウでも開かれていないエントリにはアイコンがありません。
 
-The indicator of which window is active has also been applied to the window picker.
+どのウィンドウがアクティブであるかを示すインジケーターは、ウィンドウピッカーにも適用されています。
 
-### macOS: Mouse swipe to navigate {: #macos-mouse-swipe-to-navigate }
+### macOS: マウススワイプによるナビゲート {: #macos-mouse-swipe-to-navigate }
 
 **Setting**: `setting(workbench.editor.swipeToNavigate)`
 
-On macOS you can now navigate between editors using 3-finger swipe gesture with the trackpad. Swiping left or right navigates across recently used editors in any editor group. Enable this with the `setting(workbench.editor.swipeToNavigate)` setting.
+macOS では、トラックパッドで 3 本指のスワイプジェスチャを使用してエディター間を移動できるようになりました。左または右にスワイプすると、任意のエディターグループ内の最近使用したエディター間を移動します。`setting(workbench.editor.swipeToNavigate)` 設定でこれを有効にします。
 
-> **Note**: We currently only support 3-finger swipe gesture. Make sure that your trackpad settings for swiping are configured like the following to make this work:
+> **Note**: 現在、3 本指のスワイプジェスチャのみをサポートしています。これが機能するように、スワイプのトラックパッド設定が次のように構成されていることを確認してください:
 >
-> * Swipe between pages: Scroll left or right with three fingers.
-> * Swipe between full-screen apps: Swipe left or right with four fingers.
+> * ページ間をスワイプ: 3 本指で左または右にスクロールします。
+> * フルスクリーンアプリ間をスワイプ: 4 本指で左または右にスワイプします。
 
-### On demand editor hover popups {: #on-demand-editor-hover-popups }
+### オンデマンドのエディターホバーポップアップ {: #on-demand-editor-hover-popups }
 
 **Setting**: `setting(editor.hover.enabled)`
 
-You can now disable automatic hover popups in the editor, while retaining the ability to trigger hover information on-demand using a keyboard modifier. The `setting(editor.hover.enabled)` setting now supports three values: `on`, `off`, and `onKeyboardModifier`.
+エディターでの自動ホバーポップアップを無効にしつつ、キーボード修飾子を使用してオンデマンドでホバー情報をトリガーする機能を維持できるようになりました。`setting(editor.hover.enabled)` 設定は、`on`、`off`、および `onKeyboardModifier` の 3 つの値をサポートするようになりました。
 
-When set to `onKeyboardModifier`, hover information only appears when you hold the opposite modifier key from your `setting(editor.multiCursorModifier)` setting while hovering over code. This reduces visual distractions during text selection while preserving quick access to contextual information when needed.
+`onKeyboardModifier` に設定すると、コードにカーソルを合わせているときに `setting(editor.multiCursorModifier)` 設定とは逆の修飾キーを押している場合にのみ、ホバー情報が表示されます。これにより、テキスト選択中の視覚的な気晴らしが軽減され、必要に応じてコンテキスト情報にすばやくアクセスできます。
 
-For example, if your `setting(editor.multiCursorModifier)` is set to `ctrlCmd`, hover appears when you hold `kbstyle(Alt)` while hovering. If set to `alt`, hover appears when you hold `kbstyle(Ctrl)` (or `kbstyle(Cmd)` on macOS).
+たとえば、`setting(editor.multiCursorModifier)` が `ctrlCmd` に設定されている場合、ホバー中に `kbstyle(Alt)` を押すとホバーが表示されます。`alt` に設定されている場合、`kbstyle(Ctrl)` (または macOS では `kbstyle(Cmd)`) を押すとホバーが表示されます。
 
-## Code Editing {: #code-editing }
+## コード編集 {: #code-editing }
 
-* TypeScript offers rename suggestions ([Show more](#rename-suggestions-for-typescript)).
-* Use a new model for next edit suggestions ([Show more](#new-model-for-next-edit-suggestions)).
-* Preview next edit suggestions outside your viewport ([Show more](#preview-next-edit-suggestions-outside-the-viewport)).
+* TypeScript が名前変更の提案を提供 ([詳細](#rename-suggestions-for-typescript))。
+* 次の編集提案に新しいモデルを使用 ([詳細](#new-model-for-next-edit-suggestions))。
+* ビューポート外の次の編集提案をプレビュー ([詳細](#preview-next-edit-suggestions-outside-the-viewport))。
 
-### Rename suggestions for TypeScript {: #rename-suggestions-for-typescript }
+### TypeScript の名前変更の提案 {: #rename-suggestions-for-typescript }
 
-Rename suggestions predict when a symbol rename should happen instead of a regular text suggestion. When predicted, an additional indicator is shown together with the normal textual edit. You can then apply the symbol rename by using `kbstyle(Shift+Tab)`.
+名前変更の提案は、通常のテキスト提案の代わりにシンボルの名前変更を行うべきタイミングを予測します。予測されると、通常のテキスト編集と一緒に追加のインジケーターが表示されます。その後、`kbstyle(Shift+Tab)` を使用してシンボルの名前変更を適用できます。
 
-In the following video, property `a` is renamed to `width`. The rename suggestion then suggests to rename `b` to `height`, as well as renaming the two parameters `a` and `b` accordingly. Next rename suggestion works best when it predicts related renames to other symbols.
+次のビデオでは、プロパティ `a` の名前が `width` に変更されています。名前変更の提案は、`b` の名前を `height` に変更すること、および 2 つのパラメーター `a` と `b` の名前をそれに応じて変更することを提案します。次の名前変更の提案は、他のシンボルへの関連する名前変更を予測する場合に最適に機能します。
 
 <video src="https://code.visualstudio.com/assets/updates/1_107/next-rename-suggestion.mp4" title="Video showing next rename suggestion in the editor." autoplay loop controls muted></video>
 
-> **Note**: this feature is currently rolled out to our user base using an experiment and is only available for TypeScript for now. Support for other programming languages is planned.
+> **Note**: この機能は現在、実験を使用してユーザーベースにロールアウトされており、今のところ TypeScript でのみ使用できます。他のプログラミング言語のサポートも計画されています。
 
-### New model for next edit suggestions {: #new-model-for-next-edit-suggestions }
+### 次の編集提案のための新しいモデル {: #new-model-for-next-edit-suggestions }
 
-We have released a new model for next edit suggestions that is smarter and more in-tune with your latest edits. It delivers significantly better acceptance and dismissal performance. Learn more about the [model and its development](https://github.blog/ai-and-ml/github-copilot/evolving-github-copilots-next-edit-suggestions-through-custom-model-training/#h-continuous-improvements-nbsp) in our GitHub blog post.
+よりスマートで、最新の編集に合わせた次の編集提案のための新しいモデルをリリースしました。これにより、受け入れと却下のパフォーマンスが大幅に向上します。詳細については、GitHub ブログ投稿の [モデルとその開発](https://github.blog/ai-and-ml/github-copilot/evolving-github-copilots-next-edit-suggestions-through-custom-model-training/#h-continuous-improvements-nbsp) を参照してください。
 
-### Preview next edit suggestions outside the viewport {: #preview-next-edit-suggestions-outside-the-viewport }
+### ビューポート外の次の編集提案のプレビュー {: #preview-next-edit-suggestions-outside-the-viewport }
 
-When you receive a next edit suggestion that is outside the current viewport, it can be difficult to know what the suggestion is without scrolling away from your current position. We improved this experience by rendering a preview of the next edit suggestion where your cursor is currently located. This helps reduce the impact on your flow when reviewing suggestions.
+現在のビューポートの外にある次の編集提案を受け取った場合、現在の位置からスクロールせずに提案内容を知ることは困難な場合があります。カーソルが現在ある場所に次の編集提案のプレビューをレンダリングすることで、このエクスペリエンスを改善しました。これにより、提案を確認する際のフローへの影響を軽減できます。
 
 <video src="https://code.visualstudio.com/assets/updates/1_107/nes-outside-viewport.mp4" title="Video of next edit suggestion preview." autoplay loop controls muted></video>
 
-> **Note**: Our current language model focuses on next edit suggestions close to the cursor, so you might not often see suggestions outside the viewport. However, we are actively working on models which can give you suggestions much further away!
+> **Note**: 現在の言語モデルは、カーソルの近くにある次の編集提案に焦点を当てているため、ビューポートの外にある提案はあまり表示されない場合があります。ただし、はるか遠くにある提案を提供できるモデルの開発に積極的に取り組んでいます！
 
-Learn more about [inline suggestions in VS Code](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
+詳細については、[VS Code でのインライン提案](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions) を参照してください。
 
-## Source Control {: #source-control }
+## ソース管理 {: #source-control }
 
-### Stashes in the Source Control Repositories view (Experimental) {: #stashes-in-the-source-control-repositories-view-experimental }
+### ソース管理リポジトリビューでのスタッシュ (実験的) {: #stashes-in-the-source-control-repositories-view-experimental }
 
 **Settings**: `setting(scm.repositories.explorer:true)`, `setting(scm.repositories.selectionMode:single)`
 
-This milestone, we continued to expand the list of repository artifacts shown in the Source Control Repositories view by adding a Stashes node. Under this node, you can see the complete list of stashes, view, apply, and pop each stash. The context menu also contains an action to drop each stash.
+このマイルストーンでは、Stashes ノードを追加することで、Source Control Repositories ビューに表示されるリポジトリアーティファクトのリストを引き続き拡張しました。このノードの下で、スタッシュの完全なリストを表示し、各スタッシュを表示、適用、およびポップできます。コンテキストメニューには、各スタッシュを削除するアクションも含まれています。
 
-![Screenshot of the Source Control Repositories view showing the Stashes node and its context menu.](https://code.visualstudio.com/assets/updates/1_107/stashes-repo-explorer.png)
+![Stashes ノードとそのコンテキストメニューを示す Source Control Repositories ビューのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/stashes-repo-explorer.png)
 
-You can enable the experimental repository explorer by setting the `setting(scm.repositories.selectionMode:single)` and `setting(scm.repositories.explorer:true)` settings. Please give it a try and let us know what other repository artifacts you would like to see in the repositories explorer.
+`setting(scm.repositories.selectionMode:single)` および `setting(scm.repositories.explorer:true)` 設定を設定することで、実験的なリポジトリエクスプローラーを有効にできます。ぜひ試してみて、リポジトリエクスプローラーで他にどのようなリポジトリアーティファクトを見たいかをお知らせください。
 
-Learn more about [using source control in VS Code](https://code.visualstudio.com/docs/sourcecontrol/overview).
+詳細については、[VS Code でのソース管理の使用](https://code.visualstudio.com/docs/sourcecontrol/overview) を参照してください。
 
-## Debugging {: #debugging }
+## デバッグ {: #debugging }
 
-### Attach variables to chat {: #attach-variables-to-chat }
+### チャットへの変数の添付 {: #attach-variables-to-chat }
 
-You can now attach variables, scopes, and expressions to your chat context in VS Code. You can do this by right clicking on data in the **Variables** and **Watch** views, or by using the **Add Context** button in chat.
+VS Code のチャットコンテキストに変数を添付できるようになりました。これを行うには、**Variables** および **Watch** ビューでデータを右クリックするか、チャットの **Add Context** ボタンを使用します。
 
-## Terminal {: #terminal }
+## ターミナル {: #terminal }
 
-### Terminal suggest rolled out to stable {: #terminal-suggest-rolled-out-to-stable }
+### ターミナルの提案が安定版にロールアウト {: #terminal-suggest-rolled-out-to-stable }
 
-Terminal Suggest is now enabled for stable users, offering inline completions and contextual hints while you type shell commands. Suggestions now group related argument values together, so option flags and their parameters stay organized in the list.
+Terminal Suggest が安定版ユーザー向けに有効になり、シェルコマンドの入力中にインライン補完とコンテキストヒントが提供されるようになりました。提案では、関連する引数値がグループ化されるようになったため、オプションフラグとそのパラメーターがリスト内で整理された状態になります。
 
-## Authentication {: #authentication }
+## 認証 {: #authentication }
 
-### Cross-platform native broker support for Microsoft Authentication {: #crossplatform-native-broker-support-for-microsoft-authentication }
+### Microsoft 認証のクロスプラットフォームネイティブブローカーサポート {: #crossplatform-native-broker-support-for-microsoft-authentication }
 
 **Setting**: `setting(microsoft-authentication.implementation)`
 
-This milestone, we adopted the latest MSAL libraries, enabling you to sign in through a native experience on:
+このマイルストーンでは、最新の MSAL ライブラリを採用し、以下でネイティブエクスペリエンスを通じてサインインできるようになりました:
 
-* Intel Macs
-* Linux x64 (just certain distros that are Debian-based)
+* Intel Mac
+* Linux x64 (Debian ベースの特定のディストリビューションのみ)
 
-![Screenshot of a native broker dialog window asking to sign into VS Code.](https://code.visualstudio.com/assets/updates/1_107/macOS-auth-broker.png)
+![VS Code へのサインインを求めるネイティブブローカーダイアログウィンドウのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/macOS-auth-broker.png)
 
-This is in addition to the existing support for:
+これは、以下の既存のサポートに加えて提供されます:
 
 * Windows x64
-* macOS M-series (ARM)
+* macOS M シリーズ (ARM)
 
-macOS and Linux support requires your machine to be Intune enrolled and be opted in to using the native broker.
+macOS および Linux のサポートには、マシンが Intune に登録されており、ネイティブブローカーの使用にオプトインしている必要があります。
 
-This enables nice single sign-on flows and is the recommended way of acquiring a Microsoft authentication session. The MSAL team will enable this up for the remaining platforms (Windows ARM, Linux ARM and additional distros) over time, so stay tuned!
+これにより、優れたシングルサインオンフローが可能になり、Microsoft 認証セッションを取得するための推奨される方法となります。MSAL チームは、残りのプラットフォーム (Windows ARM、Linux ARM、および追加のディストリビューション) についても時間をかけてこれを有効にする予定ですので、ご期待ください！
 
-> NOTE: If you have trouble authenticating via the broker, you can change the `setting(microsoft-authentication.implementation)` to `msal-no-broker`, which will use your browser to authenticate instead.
+> NOTE: ブローカー経由での認証に問題がある場合は、`setting(microsoft-authentication.implementation)` を `msal-no-broker` に変更して、代わりにブラウザーを使用して認証することができます。
 
-### `classic` Microsoft authentication no longer available {: #classic-microsoft-authentication-no-longer-available }
+### `classic` Microsoft 認証が利用不可に {: #classic-microsoft-authentication-no-longer-available }
 
-As mentioned last month, we have removed the `classic` option for `setting(microsoft-authentication.implementation)` due to low usage and it not being recommended by the Entra ID team.
+先月述べたように、使用率が低く、Entra ID チームによって推奨されていないため、`setting(microsoft-authentication.implementation)` の `classic` オプションを削除しました。
 
-Reminder: The `setting(microsoft-authentication.implementation)` setting has been around to let users opt-out of native brokered authentication for Microsoft accounts if they experienced issues. The values for this setting are:
+リマインダー: `setting(microsoft-authentication.implementation)` 設定は、問題が発生した場合にユーザーが Microsoft アカウントのネイティブブローカー認証をオプトアウトできるようにするために存在していました。この設定の値は次のとおりです:
 
-* `msal` - Use MSAL with brokered authentication when available (default)
-* `msal-no-broker` - Use MSAL without brokered authentication
+* `msal` - 利用可能な場合はブローカー認証で MSAL を使用します (デフォルト)
+* `msal-no-broker` - ブローカー認証なしで MSAL を使用します 
 
-## Languages {: #languages }
+## 言語 {: #languages }
 
-### TypeScript 7.0 preview {: #typescript-70-preview }
+### TypeScript 7.0 プレビュー {: #typescript-70-preview }
 
-We continued to work with the TypeScript team to improve VS Code's support for the [upcoming TypeScript 7 release](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/). TypeScript 7 is a complete rewrite in native code and offers dramatically better performance.
+[次期 TypeScript 7 リリース](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/) に対する VS Code のサポートを改善するために、TypeScript チームと引き続き協力しました。TypeScript 7 はネイティブコードで完全に書き直されており、パフォーマンスが劇的に向上しています。
 
-The TypeScript 7 preview has almost complete type checking support, and the TypeScript team has been busy adding editor features too. Recent highlights include auto import completions, rename support, and references code lenses.
+TypeScript 7 プレビューでは、ほぼ完全な型チェックがサポートされており、TypeScript チームはエディター機能の追加にも取り組んでいます。最近のハイライトには、自動インポート補完、名前変更のサポート、参照コードレンズなどがあります。
 
-You can try out TypeScript 7.0 today by installing the [`TypeScript (Native Preview)` extension](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview). Then run the `TypeScript (Native Preview): Enable (Experimental)` command in a JavaScript or TypeScript file to switch all IntelliSense to use the native preview. Checkout the [most recent TypeScript 7 blog post](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/) for a full update on TypeScript 7 and the general direction of the TypeScript project.
+[`TypeScript (Native Preview)` 拡張機能](https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview) をインストールすることで、今日から TypeScript 7.0 を試すことができます。次に、JavaScript または TypeScript ファイルで `TypeScript (Native Preview): Enable (Experimental)` コマンドを実行して、すべての IntelliSense をネイティブプレビューを使用するように切り替えます。TypeScript 7 の完全なアップデートと TypeScript プロジェクトの一般的な方向性については、[最新の TypeScript 7 ブログ投稿](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/) を確認してください。
 
-We plan to continue working closely with the TypeScript team to improve TypeScript 7's VS Code support. Once TypeScript 7 is ready, our longer term plan is to switch to it as the default experience powering VS Code's JavaScript and TypeScript IntelliSense. If you need to use an older TS version or need editor features like TypeScript service plugins that can't be easily ported to TypeScript 7, we're planning to continue supporting existing TypeScript versions for the foreseeable future alongside TypeScript 7.0+.
+TypeScript 7 の VS Code サポートを改善するために、TypeScript チームと引き続き緊密に連携する予定です。TypeScript 7 の準備ができたら、VS Code の JavaScript および TypeScript IntelliSense を強化するデフォルトのエクスペリエンスとして切り替えるという長期的な計画があります。古い TS バージョンを使用する必要がある場合、または TypeScript 7 に簡単に移植できない TypeScript サービスプラグインなどのエディター機能が必要な場合は、TypeScript 7.0+ と並行して、当面の間、既存の TypeScript バージョンのサポートを継続する予定です。
 
-## Remote Development {: #remote-development }
+## リモート開発 {: #remote-development }
 
-The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
+[Remote Development 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) を使用すると、[Dev Container](https://code.visualstudio.com/docs/devcontainers/containers)、SSH 経由のリモートマシン、または [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels)、または [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) をフル機能の開発環境として使用できます。
 
-Highlights include:
+ハイライトは次のとおりです:
 
-* SSH reconnection grace time control
+* SSH 再接続猶予時間の制御
 
-You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_107.md).
+これらの機能の詳細については、[Remote Development リリースノート](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_107.md) を参照してください。
 
-## Enterprise {: #enterprise }
+## エンタープライズ {: #enterprise }
 
-Learn more about the [enterprise capabilities of VS Code](https://code.visualstudio.com/docs/setup/enterprise) in our documentation.
+VS Code の [エンタープライズ機能](https://code.visualstudio.com/docs/setup/enterprise) の詳細については、ドキュメントを参照してください。
 
-### Control auto approval for agent tools {: #control-auto-approval-for-agent-tools }
+### エージェントツールの自動承認の制御 {: #control-auto-approval-for-agent-tools }
 
 **Setting**: `setting(chat.tools.eligibleForAutoApproval)`
 
-Specific agent tools can be risky to use without explicit user approval, especially those that can perform destructive actions, access sensitive data, or run arbitrary code in the background (for example, `runTask`).
+特定のエージェントツールは、明示的なユーザー承認なしに使用するとリスクが生じる可能性があります。特に、破壊的なアクションを実行したり、機密データにアクセスしたり、バックグラウンドで任意のコードを実行したりできるツール (たとえば、`runTask`) はそうです。
 
-You can now define which tools are eligible for auto-approval with the new `setting(chat.tools.eligibleForAutoApproval)` setting. When a tool is denied from auto-approval, users won't have the option to always approve this tool in chat and must explicitly approve each use.
+新しい `setting(chat.tools.eligibleForAutoApproval)` 設定を使用して、自動承認の対象となるツールを定義できるようになりました。ツールが自動承認から拒否された場合、ユーザーはチャットでこのツールを常に承認するオプションを持たず、使用ごとに明示的に承認する必要があります。
 
-Organizations can enforce this behavior via an enterprise policy across their users to enhance security when using agents.
+組織は、エージェントを使用する際のセキュリティを強化するために、ユーザー全体にエンタープライズポリシーを介してこの動作を強制できます。
 
-### Disable the use of agents by policy {: #disable-the-use-of-agents-by-policy }
+### ポリシーによるエージェントの使用の無効化 {: #disable-the-use-of-agents-by-policy }
 
-When an enterprise policy disables the use of agents in chat, the Agents picker now better communicates why they're not available.
+エンタープライズポリシーによってチャットでのエージェントの使用が無効になっている場合、エージェントピッカーは、それらが利用できない理由をより適切に伝えるようになりました。
 
-![Screenshot of the Agent picker shows agent mode unavailable due to enterprise policy.](https://code.visualstudio.com/assets/updates/1_107/agent-mode-disabled-by-policy.png)
+![エンタープライズポリシーによりエージェントモードが利用できないことを示すエージェントピッカーのスクリーンショット。](https://code.visualstudio.com/assets/updates/1_107/agent-mode-disabled-by-policy.png)
 
-### Support GitHub Enterprise policies in Codespaces {: #support-github-enterprise-policies-in-codespaces }
+### Codespaces での GitHub Enterprise ポリシーのサポート {: #support-github-enterprise-policies-in-codespaces }
 
-You can specify policies for your enterprise or organization in GitHub that are applied in VS Code. For example, you can [configure the MCP registry URL](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry) to be used by developers in your organization.
+VS Code に適用されるエンタープライズまたは組織のポリシーを GitHub で指定できます。たとえば、組織の開発者が使用する [MCP レジストリ URL を構成](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry) できます。
 
-In this release, we added support for these policies when using VS Code with GitHub Codespaces. When a developer opens a Codespace, the same policies are applied automatically, as they already are when using VS Code locally.
+このリリースでは、GitHub Codespaces で VS Code を使用する場合のこれらのポリシーのサポートを追加しました。開発者が Codespace を開くと、VS Code をローカルで使用する場合と同様に、同じポリシーが自動的に適用されます。
 
-## Contributions to extensions {: #contributions-to-extensions }
+## 拡張機能への貢献 {: #contributions-to-extensions }
 
-### GitHub Pull Requests {: #github-pull-requests }
+### GitHub プルリクエスト {: #github-pull-requests }
 
-There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
+プルリクエストと問題の作業、作成、管理を可能にする [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) 拡張機能の進歩がさらに進んでいます。新機能は次のとおりです:
 
-* Pull request and issue implicit context when a pull request or issue webview is active.
-* Pull requests and issues can be added explicitly as context to chat sessions through "Add Context".
-* Copilot pull requests can be marked ready for review, approved, and auto-merge set with a single button.
+* プルリクエストまたは問題の Webビューがアクティブな場合のプルリクエストと問題の暗黙的なコンテキスト。
+* プルリクエストと問題は、"Add Context" を介してチャットセッションにコンテキストとして明示的に追加できます。
+* Copilot プルリクエストは、ボタン 1 つでレビューの準備完了、承認、自動マージの設定としてマークできます。
 
-Review the [changelog for the 0.124.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01240) release of the extension to learn about everything in the release.
+リリースのすべてについて知るには、拡張機能の [0.124.0 の変更ログ](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01240) を確認してください。
 
-## Proposed APIs {: #proposed-apis }
+## 提案された API {: #proposed-apis }
 
-### Contributed Chat Context {: #contributed-chat-context }
+### 寄稿されたチャットコンテキスト {: #contributed-chat-context }
 
-We have a new API proposal to let extensions contribute context providers for chat. This enables extensions to provide rich context from their own domain to be used in chat sessions. For example, the GitHub Pull Request extension provides the following context:
+拡張機能がチャットのコンテキストプロバイダーを提供できるようにする新しい API 提案があります。これにより、拡張機能は独自のドメインからリッチなコンテキストを提供して、チャットセッションで使用できるようになります。たとえば、GitHub Pull Request 拡張機能は次のコンテキストを提供します:
 
-* Workspace context, with information about the current repository, branch, and pull request.
-* Implicit pull request and issue context when a pull request or issue webview is active.
-* Explicit pull request and issue context when the user adds them via "Add Context".
+* 現在のリポジトリ、ブランチ、プルリクエストに関する情報を含むワークスペースコンテキスト。
+* プルリクエストまたは問題の Webビューがアクティブな場合の暗黙的なプルリクエストと問題のコンテキスト。
+* ユーザーが "Add Context" を介して追加した場合の明示的なプルリクエストと問題のコンテキスト。
 
-The API is still in the early stages, so expect changes to come. We'd love to get feedback on what parts of the proposal will solve extension authors' needs. You can find the proposal here: [vscode.proposed.chatContextProvider.d.ts](https://github.com/microsoft/vscode/blob/615abcc4ae680ef1950fe607c3b3532d3ee0a576/src/vscode-dts/vscode.proposed.chatContextProvider.d.ts).
+API はまだ初期段階にあるため、変更が予想されます。提案のどの部分が拡張機能作成者のニーズを解決するかについてのフィードバックをお待ちしています。提案はこちらにあります: [vscode.proposed.chatContextProvider.d.ts](https://github.com/microsoft/vscode/blob/615abcc4ae680ef1950fe607c3b3532d3ee0a576/src/vscode-dts/vscode.proposed.chatContextProvider.d.ts)。
 
-## Engineering {: #engineering }
+## エンジニアリング {: #engineering }
 
-### Builds rollout {: #builds-rollout }
+### ビルドのロールアウト {: #builds-rollout }
 
-We've started progressively rolling out Insiders build releases over a 4-hour time window. This means that, as an Insiders user, you might receive the update notification a bit later than usual. If you're in a hurry, you can always run **Check for Updates** to force the update to be applied immediately.
+Insiders ビルドリリースの 4 時間の時間枠での段階的なロールアウトを開始しました。つまり、Insiders ユーザーとして、通常よりも少し遅れて更新通知を受け取る可能性があります。急いでいる場合は、いつでも **Check for Updates** を実行して、更新を強制的に適用できます。
 
-We'll roll out the November 2025 (1.107) release to Stable users over a 24-hour time window. Just like Insiders, you can always run **Check for Updates** to force the update to be applied immediately.
+November 2025 (1.107) リリースを 24 時間の時間枠で Stable ユーザーにロールアウトします。Insiders と同様に、いつでも **Check for Updates** を実行して、更新を強制的に適用できます。
 
-### Improved website search functionality {: #improved-website-search-functionality }
+### Web サイトの検索機能の改善 {: #improved-website-search-functionality }
 
-We've improved [our website](https://code.visualstudio.com) with fast, client-side search that allows you to easily and quickly navigate across our documentation.
+ドキュメント全体を簡単かつ迅速にナビゲートできる高速なクライアント側検索により、[Web サイト](https://code.visualstudio.com) を改善しました。
 
-<video src="https://code.visualstudio.com/assets/updates/1_107/website-search.mp4" title="Video showing the website search functionality with search result suggestions showing in a dropdown list." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/website-search.mp4" title="ドロップダウンリストに検索結果の提案が表示される Web サイトの検索機能を示すビデオ。" autoplay loop controls muted></video>
 
-We've open-sourced the library behind this functionality: you can download [docfind](https://github.com/microsoft/docfind) and use it for your projects today! We'll follow up with a blog post on the innovations behind this tech.
+この機能の背後にあるライブラリをオープンソース化しました: [docfind](https://github.com/microsoft/docfind) をダウンロードして、今すぐプロジェクトに使用できます！この技術の背後にあるイノベーションに関するブログ投稿をフォローアップします。
 
-### Updated build scripts run directly as TypeScript {: #updated-build-scripts-run-directly-as-typescript }
+### TypeScript として直接実行されるように更新されたビルドスクリプト {: #updated-build-scripts-run-directly-as-typescript }
 
-This iteration, we cleaned up our build scripts to make them easier to work with and maintain. These build scripts were a mix of compiled TypeScript, TypeScript files run using `ts-node`, and JavaScript. Many of these scripts were not type checked and were using commonjs (`require`) instead of modern modules with `import` and `export`. Even worse, many of the TypeScript build scripts required checking in the compiled JS output to our source control. What a mess!
+このイテレーションでは、ビルドスクリプトをクリーンアップして、作業と保守を容易にしました。これらのビルドスクリプトは、コンパイルされた TypeScript、`ts-node` を使用して実行される TypeScript ファイル、および JavaScript が混在していました。これらのスクリプトの多くは型チェックされておらず、`import` と `export` を使用した最新のモジュールではなく commonjs (`require`) を使用していました。さらに悪いことに、TypeScript ビルドスクリプトの多くは、コンパイルされた JS 出力をソース管理にチェックインする必要がありました。なんてこった！
 
-Thankfully Node 22.18+ now allows [running scripts directly as TypeScript](https://nodejs.org/en/learn/typescript/run-natively). This lets us incrementally convert our build scripts to modern TypeScript. We used the follow tsconfig options to make sure our new TypeScript code could be run directly by Node:
+ありがたいことに、Node 22.18+ では [スクリプトを TypeScript として直接実行](https://nodejs.org/en/learn/typescript/run-natively) できるようになりました。これにより、ビルドスクリプトを最新の TypeScript に段階的に変換できます。新しい TypeScript コードを Node で直接実行できるように、次の tsconfig オプションを使用しました:
 
 ```json
 {
   "compilerOptions": {
      "target": "esnext",
      "module": "nodenext",
-     "noEmit": true, // Don't generate .js files
-     "erasableSyntaxOnly": true, // Only allow TypeScript syntax that node can strip out. Enums and namespaces for example are not allowed
-     "allowImportingTsExtensions": true, // Allow importing of .ts files
-     "verbatimModuleSyntax": true // Make sure imports will be valid when the script is run by node directly
+     "noEmit": true, // .js ファイルを生成しない
+     "erasableSyntaxOnly": true, // Node が削除できる TypeScript 構文のみを許可。たとえば、Enum や名前空間は許可されません
+     "allowImportingTsExtensions": true, // .ts ファイルのインポートを許可
+     "verbatimModuleSyntax": true // スクリプトが Node によって直接実行されるときに、インポートが有効であることを確認
   }
 }
 ```
 
-GitHub Copilot helped automate many of the required changes, such as converting old commonjs files to modules and adding type annotations.
+GitHub Copilot は、古い commonjs ファイルをモジュールに変換したり、型注釈を追加したりするなど、必要な変更の多くを自動化するのに役立ちました。
 
-One thing to keep in mind is that while Node can run TypeScript code, it doesn't actually type check it. You still need to use `tsc` for that. For vscode, we're actually using [`ts-go`](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/), which can fully type check all of our build scripts in well under a second.
+心に留めておくべきことの 1 つは、Node は TypeScript コードを実行できますが、実際には型チェックを行わないということです。そのためには、依然として `tsc` を使用する必要があります。vscode の場合、実際には [`ts-go`](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/) を使用しており、すべてのビルドスクリプトを 1 秒未満で完全に型チェックできます。
 
-It's pretty amazing to be able to run `node build/hygiene.ts` directly. Switching fully to TypeScript also lets us modernize and bring type safety to our build scripts, which will make it much easier to understand and make changes to them. Plus it enabled us to delete around 15,000 lines of compiled JS code that we previously had to keep checked in!
+`node build/hygiene.ts` を直接実行できるのは非常に素晴らしいことです。TypeScript に完全に切り替えることで、ビルドスクリプトを最新化し、タイプセーフをもたらすことができ、理解と変更がはるかに簡単になります。さらに、以前はチェックインしておく必要があった約 15,000 行のコンパイル済み JS コードを削除できました！
 
-### Copilot extensions unification {: #copilot-extensions-unification }
+### Copilot 拡張機能の統合 {: #copilot-extensions-unification }
 
 **Setting**: `setting(chat.extensionUnification.enabled)`
 
-We have fully rolled out inline suggestions to be served from the GitHub Copilot Chat extension. As part of this change, the GitHub Copilot extension will be disabled by default for all users.
+インライン提案が GitHub Copilot Chat 拡張機能から提供されるように完全にロールアウトしました。この変更の一環として、GitHub Copilot 拡張機能はすべてのユーザーに対してデフォルトで無効になります。
 
-If you run into any issues with inline suggestions, please report them. You can temporarily revert to the previous behavior by setting `setting(chat.extensionUnification.enabled)` to `false`, which reenables the GitHub Copilot extension.
+インライン提案で問題が発生した場合は、報告してください。`setting(chat.extensionUnification.enabled)` を `false` に設定することで、一時的に以前の動作に戻すことができます。これにより、GitHub Copilot 拡張機能が再度有効になります。
 
-Note that we are planning to fully deprecate the GitHub Copilot extension in January 2026, at which point the `setting(chat.extensionUnification.enabled)` setting will also be removed.
+2026 年 1 月に GitHub Copilot 拡張機能を完全に廃止する予定であり、その時点で `setting(chat.extensionUnification.enabled)` 設定も削除されることに注意してください。
 
-## Notable fixes {: #notable-fixes }
+## 注目すべき修正 {: #notable-fixes }
 
-* [vscode#233635](https://github.com/microsoft/vscode/issues/233635) - Add an action to close other windows
-* [vscode#262817](https://github.com/microsoft/vscode/issues/262817) - Running "Move Editor into Previous Group" from the left-most group should create a new group to the left
-* [vscode#264569](https://github.com/microsoft/vscode/issues/264569) - Setting and removing window.activeBorder color does not reset the window border color
-* [vscode#140186](https://github.com/microsoft/vscode/issues/140186) - Cannot open local terminal when remote container is opened as a workspace
-* [vscode#228359](https://github.com/microsoft/vscode/issues/228359) - Relaunching the terminal will often just close the terminal
-* [vscode#232420](https://github.com/microsoft/vscode/issues/232420) - Terminal Cursor is at the wrong place with Python3.13
-* [vscode#247568](https://github.com/microsoft/vscode/issues/247568) - Terminal Ctrl+Click on a file with colon in filename does not open the file, preceding zeroes are deleted
-* [vscode#275011](https://github.com/microsoft/vscode/issues/275011) - Getting strange terminal message when opening VS Code in WSL on a trusted workspace
-* [vscode#275417](https://github.com/microsoft/vscode/issues/275417) - Tasks with reveal:never, close:true no longer work on WSL
-* [vscode#277311](https://github.com/microsoft/vscode/issues/277311) - Add "X" button to remove command from "recently used" list in Command Palette
-* [vscode#282222](https://github.com/microsoft/vscode/issues/282222) - SCM - improve git blame/timeline/graph hover rendering. Thanks to Stanislav Fort (Aisle Research)
-* [vscode-python-environments#1000](https://github.com/microsoft/vscode-python-environments/issues/1000) - Environment activation is not working reliably with "Command Prompt"
+* [vscode#233635](https://github.com/microsoft/vscode/issues/233635) - 他のウィンドウを閉じるアクションを追加
+* [vscode#262817](https://github.com/microsoft/vscode/issues/262817) - 左端のグループから "Move Editor into Previous Group" を実行すると、左側に新しいグループが作成されるはずです
+* [vscode#264569](https://github.com/microsoft/vscode/issues/264569) - window.activeBorder の色を設定および削除しても、ウィンドウの境界線の色がリセットされない
+* [vscode#140186](https://github.com/microsoft/vscode/issues/140186) - リモートコンテナーがワークスペースとして開かれているときにローカルターミナルを開くことができない
+* [vscode#228359](https://github.com/microsoft/vscode/issues/228359) - ターミナルを再起動すると、ターミナルが閉じてしまうことがよくある
+* [vscode#232420](https://github.com/microsoft/vscode/issues/232420) - Python3.13 でターミナルカーソルが間違った場所にある
+* [vscode#247568](https://github.com/microsoft/vscode/issues/247568) - ファイル名にコロンが含まれるファイルでターミナル Ctrl+Click を実行してもファイルが開かず、先行するゼロが削除される
+* [vscode#275011](https://github.com/microsoft/vscode/issues/275011) - 信頼されたワークスペース上の WSL で VS Code を開くと、奇妙なターミナルメッセージが表示される
+* [vscode#275417](https://github.com/microsoft/vscode/issues/275417) - reveal:never, close:true のタスクが WSL で機能しなくなった
+* [vscode#277311](https://github.com/microsoft/vscode/issues/277311) - コマンドパレットの「最近使用した」リストからコマンドを削除する "X" ボタンを追加
+* [vscode#282222](https://github.com/microsoft/vscode/issues/282222) - SCM - git blame/timeline/graph ホバーレンダリングを改善。Stanislav Fort (Aisle Research) に感謝します
+* [vscode-python-environments#1000](https://github.com/microsoft/vscode-python-environments/issues/1000) - 環境のアクティブ化が "Command Prompt" で確実に機能しない
 
-## Thank you {: #thank-you }
+## ありがとう {: #thank-you }
 
-### Issue tracking {: #issue-tracking }
+### 問題追跡 {: #issue-tracking }
 
-Contributions to our issue tracking:
+問題追跡への貢献:
 
 * [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray)
 * [@RedCMD (RedCMD)](https://github.com/RedCMD)
@@ -761,101 +761,101 @@ Contributions to our issue tracking:
 * [@IllusionMH (Andrii Dieiev)](https://github.com/IllusionMH)
 * [@albertosantini (Alberto Santini)](https://github.com/albertosantini)
 
-Contributions to `vscode`:
+`vscode` への貢献:
 
 * [@Abrifq (Arda Aydın)](https://github.com/Abrifq)
-  * Fix terminal tab prompt input breaking when backticks are included [PR #272425](https://github.com/microsoft/vscode/pull/272425)
-  * Cleanup microsoft#272425 [PR #277406](https://github.com/microsoft/vscode/pull/277406)
-* [@bilogic](https://github.com/bilogic): also recognize `// #region ...` as valid markers [PR #278943](https://github.com/microsoft/vscode/pull/278943)
-* [@busorgin (Artem Busorgin)](https://github.com/busorgin): Set TextDecoder.ignoreBOM to true in VSBuffer [PR #272389](https://github.com/microsoft/vscode/pull/272389)
-* [@cannona (Aaron Cannon)](https://github.com/cannona): Allow "Move Editor into Previous Group" to create new group [PR #275968](https://github.com/microsoft/vscode/pull/275968)
-* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): Fix breakpoint range calculation [PR #280263](https://github.com/microsoft/vscode/pull/280263)
-* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): Correct non-standard capitalization of term 'status bar' in some settings (fix #277376) [PR #277383](https://github.com/microsoft/vscode/pull/277383)
-* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): Update `@types/vscode` package.json too [PR #277972](https://github.com/microsoft/vscode/pull/277972)
-* [@JeffreyCA](https://github.com/JeffreyCA): Terminal suggest - include persistent options in suggestions and improve suggestion grouping [PR #276409](https://github.com/microsoft/vscode/pull/276409)
-* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Expect runtime config from NuGet MCP install [PR #271770](https://github.com/microsoft/vscode/pull/271770)
-* [@Josbleuet (Eric Fortin)](https://github.com/Josbleuet): Fix illegal characters in Dynamic Auth Provider logger filename [PR #280217](https://github.com/microsoft/vscode/pull/280217)
-* [@nikdmello (Nik D'Mello)](https://github.com/nikdmello): Update katex regex for jQuery expressions in KaTeX matching [PR #269635](https://github.com/microsoft/vscode/pull/269635)
-* [@ramanverse (Raman)](https://github.com/ramanverse): Remove obsolete maybeMigrateCurrentSession method [PR #280042](https://github.com/microsoft/vscode/pull/280042)
-* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Mark Cursor mdc files as markdown [PR #276518](https://github.com/microsoft/vscode/pull/276518)
-* [@SalerSimo](https://github.com/SalerSimo): Fix settings boolean widget object overflow [PR #278884](https://github.com/microsoft/vscode/pull/278884)
+  * バッククォートが含まれている場合にターミナルタブのプロンプト入力が壊れる問題を修正 [PR #272425](https://github.com/microsoft/vscode/pull/272425)
+  * microsoft#272425 のクリーンアップ [PR #277406](https://github.com/microsoft/vscode/pull/277406)
+* [@bilogic](https://github.com/bilogic): `// #region ...` も有効なマーカーとして認識するように変更 [PR #278943](https://github.com/microsoft/vscode/pull/278943)
+* [@busorgin (Artem Busorgin)](https://github.com/busorgin): VSBuffer で TextDecoder.ignoreBOM を true に設定 [PR #272389](https://github.com/microsoft/vscode/pull/272389)
+* [@cannona (Aaron Cannon)](https://github.com/cannona): "Move Editor into Previous Group" で新しいグループを作成できるように変更 [PR #275968](https://github.com/microsoft/vscode/pull/275968)
+* [@DrSergei (Sergei Druzhkov)](https://github.com/DrSergei): ブレークポイントの範囲計算を修正 [PR #280263](https://github.com/microsoft/vscode/pull/280263)
+* [@gjsjohnmurray (John Murray)](https://github.com/gjsjohnmurray): 一部の設定における「ステータスバー」という用語の非標準的な大文字表記を修正 (#277376 を修正) [PR #277383](https://github.com/microsoft/vscode/pull/277383)
+* [@jakebailey (Jake Bailey)](https://github.com/jakebailey): `@types/vscode` の package.json も更新 [PR #277972](https://github.com/microsoft/vscode/pull/277972)
+* [@JeffreyCA](https://github.com/JeffreyCA): ターミナルの提案 - 提案に永続的なオプションを含め、提案のグループ化を改善 [PR #276409](https://github.com/microsoft/vscode/pull/276409)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): NuGet MCP インストールからのランタイム構成を期待するように変更 [PR #271770](https://github.com/microsoft/vscode/pull/271770)
+* [@Josbleuet (Eric Fortin)](https://github.com/Josbleuet): 動的認証プロバイダーのロガーファイル名に含まれる不正な文字を修正 [PR #280217](https://github.com/microsoft/vscode/pull/280217)
+* [@nikdmello (Nik D'Mello)](https://github.com/nikdmello): KaTeX マッチングにおける jQuery 式の katex 正規表現を更新 [PR #269635](https://github.com/microsoft/vscode/pull/269635)
+* [@ramanverse (Raman)](https://github.com/ramanverse): 廃止された maybeMigrateCurrentSession メソッドを削除 [PR #280042](https://github.com/microsoft/vscode/pull/280042)
+* [@remcohaszing (Remco Haszing)](https://github.com/remcohaszing): Cursor mdc ファイルを markdown としてマーク [PR #276518](https://github.com/microsoft/vscode/pull/276518)
+* [@SalerSimo](https://github.com/SalerSimo): 設定のブール値ウィジェットのオブジェクトオーバーフローを修正 [PR #278884](https://github.com/microsoft/vscode/pull/278884)
 * [@SimonSiefke (Simon Siefke)](https://github.com/SimonSiefke)
-  * fix: memory leak in breadcrumbs [PR #276597](https://github.com/microsoft/vscode/pull/276597)
-  * fix: memory leak in quick diff model [PR #276914](https://github.com/microsoft/vscode/pull/276914)
-  * fix: memory leak in breadcrumbs [PR #276915](https://github.com/microsoft/vscode/pull/276915)
-  * fix: memory leak in terminal process (partially) [PR #276962](https://github.com/microsoft/vscode/pull/276962)
-  * fix: memory leak in startup page [PR #277199](https://github.com/microsoft/vscode/pull/277199)
-  * fix: memory leak in terminal tabs list [PR #277225](https://github.com/microsoft/vscode/pull/277225)
-  * fix: memory leak with subdecorations not being disposed [PR #278328](https://github.com/microsoft/vscode/pull/278328)
-  * fix: possible memory leak with decoration registration [PR #278331](https://github.com/microsoft/vscode/pull/278331)
-  * fix: memory leak in task problem monitor [PR #279093](https://github.com/microsoft/vscode/pull/279093)
-  * fix: memory leak in history service [PR #279246](https://github.com/microsoft/vscode/pull/279246)
-  * fix: memory leak in composite bar [PR #280659](https://github.com/microsoft/vscode/pull/280659)
+  * 修正: breadcrumbs のメモリリーク [PR #276597](https://github.com/microsoft/vscode/pull/276597)
+  * 修正: quick diff モデルのメモリリーク [PR #276914](https://github.com/microsoft/vscode/pull/276914)
+  * 修正: breadcrumbs のメモリリーク [PR #276915](https://github.com/microsoft/vscode/pull/276915)
+  * 修正: ターミナルプロセスのメモリリーク (部分的) [PR #276962](https://github.com/microsoft/vscode/pull/276962)
+  * 修正: スタートアップページのメモリリーク [PR #277199](https://github.com/microsoft/vscode/pull/277199)
+  * 修正: ターミナルタブリストのメモリリーク [PR #277225](https://github.com/microsoft/vscode/pull/277225)
+  * 修正: サブデコレーションが破棄されないことによるメモリリークの可能性 [PR #278328](https://github.com/microsoft/vscode/pull/278328)
+  * 修正: デコレーション登録によるメモリリークの可能性 [PR #278331](https://github.com/microsoft/vscode/pull/278331)
+  * 修正: タスク問題モニターのメモリリーク [PR #279093](https://github.com/microsoft/vscode/pull/279093)
+  * 修正: 履歴サービスのメモリリーク [PR #279246](https://github.com/microsoft/vscode/pull/279246)
+  * 修正: 複合バーのメモリリーク [PR #280659](https://github.com/microsoft/vscode/pull/280659)
 * [@tamuratak (Takashi Tamura)](https://github.com/tamuratak)
-  * Fire onDidChangeHeight after code block editor render completes. Fix #265031 [PR #274691](https://github.com/microsoft/vscode/pull/274691)
-  * fix: use childNodes instead of children in DOM.reset for markdown rendering. Fix #266103 [PR #276890](https://github.com/microsoft/vscode/pull/276890)
-  * fix: update mathInlineRegExp to correctly handle $(a+b)^2$ [PR #280021](https://github.com/microsoft/vscode/pull/280021)
-* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): Improve performance of UriIdentityService (#273108) [PR #273111](https://github.com/microsoft/vscode/pull/273111)
-* [@yaxiaoliu](https://github.com/yaxiaoliu): fix(process-explorer): find name regexp error [PR #280273](https://github.com/microsoft/vscode/pull/280273)
+  * コードブロックエディターのレンダリング完了後に onDidChangeHeight を発行するように変更。#265031 を修正 [PR #274691](https://github.com/microsoft/vscode/pull/274691)
+  * 修正: markdown レンダリングの DOM.reset で children の代わりに childNodes を使用するように変更。#266103 を修正 [PR #276890](https://github.com/microsoft/vscode/pull/276890)
+  * 修正: $(a+b)^2$ を正しく処理するように mathInlineRegExp を更新 [PR #280021](https://github.com/microsoft/vscode/pull/280021)
+* [@yavanosta (Dmitry Guketlev)](https://github.com/yavanosta): UriIdentityService のパフォーマンスを向上 (#273108) [PR #273111](https://github.com/microsoft/vscode/pull/273111)
+* [@yaxiaoliu](https://github.com/yaxiaoliu): 修正(process-explorer): 名前正規表現のエラー [PR #280273](https://github.com/microsoft/vscode/pull/280273)
 
-Contributions to `vscode-copilot-chat`:
+`vscode-copilot-chat` への貢献:
 
 * [@AbdelrahmanAbouelenin (ababouelenin)](https://github.com/AbdelrahmanAbouelenin)
-  * Adding VSC hidden family [PR #1996](https://github.com/microsoft/vscode-copilot-chat/pull/1996)
-  * Merging hashes [PR #2181](https://github.com/microsoft/vscode-copilot-chat/pull/2181)
-  * Enable Replace String Tool For VSC Model C. [PR #2344](https://github.com/microsoft/vscode-copilot-chat/pull/2344)
-* [@cuining](https://github.com/cuining): Update ESLint configuration to use Node's built-in modules instead of a hard-coded restricted imports list [PR #2107](https://github.com/microsoft/vscode-copilot-chat/pull/2107)
+  * VSC hidden family を追加 [PR #1996](https://github.com/microsoft/vscode-copilot-chat/pull/1996)
+  * ハッシュの統合 [PR #2181](https://github.com/microsoft/vscode-copilot-chat/pull/2181)
+  * VSC モデル C の文字列置換ツールを有効化 [PR #2344](https://github.com/microsoft/vscode-copilot-chat/pull/2344)
+* [@cuining](https://github.com/cuining): ハードコードされた制限付きインポートリストの代わりに Node の組み込みモジュールを使用するように ESLint 構成を更新 [PR #2107](https://github.com/microsoft/vscode-copilot-chat/pull/2107)
 * [@IanMatthewHuff (Ian Huff)](https://github.com/IanMatthewHuff)
-  * fix any types in nullWorkspaceFileIndex [PR #1964](https://github.com/microsoft/vscode-copilot-chat/pull/1964)
-  * Fix up for the GitDiffService [PR #2116](https://github.com/microsoft/vscode-copilot-chat/pull/2116)
+  * nullWorkspaceFileIndex の any 型を修正 [PR #1964](https://github.com/microsoft/vscode-copilot-chat/pull/1964)
+  * GitDiffService の修正 [PR #2116](https://github.com/microsoft/vscode-copilot-chat/pull/2116)
 * [@jeffreyhunter77 (Jeff Hunter)](https://github.com/jeffreyhunter77)
-  * Inline completions in @vscode/chat-lib [PR #2131](https://github.com/microsoft/vscode-copilot-chat/pull/2131)
-  * Fix @vscode/chat-lib install script and package [PR #2134](https://github.com/microsoft/vscode-copilot-chat/pull/2134)
-  * Make capi client optional for completions in chat-lib [PR #2369](https://github.com/microsoft/vscode-copilot-chat/pull/2369)
-  * Update completions fallback model id [PR #2370](https://github.com/microsoft/vscode-copilot-chat/pull/2370)
-* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): Decouple server.json formatting from VS Code core [PR #1373](https://github.com/microsoft/vscode-copilot-chat/pull/1373)
+  * @vscode/chat-lib のインライン補完 [PR #2131](https://github.com/microsoft/vscode-copilot-chat/pull/2131)
+  * @vscode/chat-lib のインストールスクリプトとパッケージを修正 [PR #2134](https://github.com/microsoft/vscode-copilot-chat/pull/2134)
+  * chat-lib の補完で capi クライアントをオプションに変更 [PR #2369](https://github.com/microsoft/vscode-copilot-chat/pull/2369)
+  * 補完のフォールバックモデル ID を更新 [PR #2370](https://github.com/microsoft/vscode-copilot-chat/pull/2370)
+* [@joelverhagen (Joel Verhagen)](https://github.com/joelverhagen): server.json のフォーマットを VS Code コアから分離 [PR #1373](https://github.com/microsoft/vscode-copilot-chat/pull/1373)
 
-Contributions to `vscode-js-debug`:
+`vscode-js-debug` への貢献:
 
-* [@marat-gainullin](https://github.com/marat-gainullin): Dereferences of undefined at various places [PR #2297](https://github.com/microsoft/vscode-js-debug/pull/2297)
+* [@marat-gainullin](https://github.com/marat-gainullin): さまざまな場所での undefined のデリファレンスを修正 [PR #2297](https://github.com/microsoft/vscode-js-debug/pull/2297)
 
-Contributions to `vscode-pull-request-github`:
+`vscode-pull-request-github` への貢献:
 
 * [@vicky1999 (Vignesh)](https://github.com/vicky1999)
-  * fix: message wrapping in narrow editor panes [PR #8121](https://github.com/microsoft/vscode-pull-request-github/pull/8121)
-  * feat: Display commit status icon for each commit [PR #8142](https://github.com/microsoft/vscode-pull-request-github/pull/8142)
-  * feat: Add copy comment link button in PR overview [PR #8150](https://github.com/microsoft/vscode-pull-request-github/pull/8150)
+  * 修正: 狭いエディターペインでのメッセージの折り返し [PR #8121](https://github.com/microsoft/vscode-pull-request-github/pull/8121)
+  * 機能: 各コミットのコミットステータスアイコンを表示 [PR #8142](https://github.com/microsoft/vscode-pull-request-github/pull/8142)
+  * 機能: PR 概要にコメントリンクのコピーボタンを追加 [PR #8150](https://github.com/microsoft/vscode-pull-request-github/pull/8150)
 
-Contributions to `vscode-python`:
+`vscode-python` への貢献:
 
-* [@iBug](https://github.com/iBug): Fix [microsoft/vscode#232420](https://github.com/microsoft/vscode/issues/232420): Python REPL cursor drifting [PR #25521](https://github.com/microsoft/vscode-python/pull/25521)
+* [@iBug](https://github.com/iBug): [microsoft/vscode#232420](https://github.com/microsoft/vscode/issues/232420) を修正: Python REPL カーソルのドリフト [PR #25521](https://github.com/microsoft/vscode-python/pull/25521)
 
-Contributions to `vscode-python-debugger`:
+`vscode-python-debugger` への貢献:
 
-* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): Update to latest debugpy [PR #877](https://github.com/microsoft/vscode-python-debugger/pull/877)
+* [@rchiodo (Rich Chiodo)](https://github.com/rchiodo): 最新の debugpy に更新 [PR #877](https://github.com/microsoft/vscode-python-debugger/pull/877)
 
-Contributions to `vscode-python-environments`:
+`vscode-python-environments` への貢献:
 
-* [@zsol (Zsolt Dollenstein)](https://github.com/zsol): Support UvWorkspace envs too [PR #1022](https://github.com/microsoft/vscode-python-environments/pull/1022)
+* [@zsol (Zsolt Dollenstein)](https://github.com/zsol): UvWorkspace 環境もサポート [PR #1022](https://github.com/microsoft/vscode-python-environments/pull/1022)
 
-Contributions to `language-server-protocol`:
+`language-server-protocol` への貢献:
 
-* [@arshadrr (Arshad Riyaz)](https://github.com/arshadrr): add slang-server [PR #2200](https://github.com/microsoft/language-server-protocol/pull/2200)
+* [@arshadrr (Arshad Riyaz)](https://github.com/arshadrr): slang-server を追加 [PR #2200](https://github.com/microsoft/language-server-protocol/pull/2200)
 
-Contributions to `node-native-keymap`:
+`node-native-keymap` への貢献:
 
-* [@tmm1 (Aman Karmani)](https://github.com/tmm1): Fix casing of msctf.h header [PR #64](https://github.com/microsoft/node-native-keymap/pull/64)
-* [@yonas (Yonas Yanfa)](https://github.com/yonas): Update README.md - add libxkbfile as a dependency on FreeBSD [PR #61](https://github.com/microsoft/node-native-keymap/pull/61)
+* [@tmm1 (Aman Karmani)](https://github.com/tmm1): msctf.h ヘッダーの大文字小文字を修正 [PR #64](https://github.com/microsoft/node-native-keymap/pull/64)
+* [@yonas (Yonas Yanfa)](https://github.com/yonas): README.md を更新 - FreeBSD での依存関係として libxkbfile を追加 [PR #61](https://github.com/microsoft/node-native-keymap/pull/61)
 
-Contributions to `node-pty`:
+`node-pty` への貢献:
 
-* [@42lizard (Oliver Gassner)](https://github.com/42lizard): Add OpenBSD includes for termios and util [PR #817](https://github.com/microsoft/node-pty/pull/817)
-* [@huangcs427 (huangcs)](https://github.com/huangcs427): add "Enjoy Git" Real-world Uses [PR #818](https://github.com/microsoft/node-pty/pull/818)
+* [@42lizard (Oliver Gassner)](https://github.com/42lizard): termios と util の OpenBSD インクルードを追加 [PR #817](https://github.com/microsoft/node-pty/pull/817)
+* [@huangcs427 (huangcs)](https://github.com/huangcs427): "Enjoy Git" の実世界での使用例を追加 [PR #818](https://github.com/microsoft/node-pty/pull/818)
 
-Contributions to `python-environment-tools`:
+`python-environment-tools` への貢献:
 
-* [@reflectronic (John Tur)](https://github.com/reflectronic): Run commands without creating a console window on Windows [PR #266](https://github.com/microsoft/python-environment-tools/pull/266)
-* [@zsol (Zsolt Dollenstein)](https://github.com/zsol): Discover uv workspaces [PR #263](https://github.com/microsoft/python-environment-tools/pull/263)
+* [@reflectronic (John Tur)](https://github.com/reflectronic): Windows でコンソールウィンドウを作成せずにコマンドを実行するように変更 [PR #266](https://github.com/microsoft/python-environment-tools/pull/266)
+* [@zsol (Zsolt Dollenstein)](https://github.com/zsol): uv ワークスペースを検出するように変更 [PR #263](https://github.com/microsoft/python-environment-tools/pull/263)
 
 ---
 

--- a/docs/release-notes/v1_107.md
+++ b/docs/release-notes/v1_107.md
@@ -29,7 +29,7 @@ VS Code 1.107 introduces multi-agent orchestration - use GitHub Copilot and cust
 * **Background agents** run in isolated workspaces to not interfere with your active work, and enabling multiple background tasks at once.
 * **Delegate** work across local, background, or cloud agents to keep your workflow moving without interruptions.
 
-![VS Code November 2025 release image.](images/1_107/release-highlights-stable.webp)
+![VS Code November 2025 release image.](https://code.visualstudio.com/assets/updates/1_107/release-highlights-stable.webp)
 
 <br>
 
@@ -95,13 +95,13 @@ Agents are key to autonomously performing coding tasks on your behalf. The chat 
 
 This iteration, we integrated the agent sessions into the Chat view to give you a unified experience when working with agents. At a glance, you can see the session's status, progress, and file change statistics. You can archive or unarchive sessions to keep the sessions list manageable.
 
-<video src="images/1_107/agent-sessions.mp4" title="Video demonstrating the use agent sessions in Chat view." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/agent-sessions.mp4" title="Video demonstrating the use agent sessions in Chat view." autoplay loop controls muted></video>
 
 If you are working in a workspace, the session list only shows sessions related to the current workspace. If you are in an empty window, all sessions across workspaces are shown.
 
 When you select a session from the list, it opens the session in the Chat view in the Side Bar, allowing you to see the full conversation history. If you prefer, you can also open a session as an editor tab or in a new window. Right-click a session to see the context menu with these options.
 
-![Screenshot showing the context menu of a session in the sessions list.](images/1_107/sessions-context.png)
+![Screenshot showing the context menu of a session in the sessions list.](https://code.visualstudio.com/assets/updates/1_107/sessions-context.png)
 
 You can disable the sessions list in the Chat view by configuring `setting(chat.viewSessions.enabled)`.
 
@@ -111,11 +111,11 @@ As a consequence of this change, we're disabling the standalone **Agent Sessions
 
 When the Chat view is narrow, the list of sessions is shown inside the Chat view when you start a new chat session. By default, the list shows the three most recent sessions that are not archived.
 
-![Screenshot showing the recent sessions in the Chat view.](images/1_107/recent-sessions.png)
+![Screenshot showing the recent sessions in the Chat view.](https://code.visualstudio.com/assets/updates/1_107/recent-sessions.png)
 
 Select **Show All Sessions** to view the full list of sessions with options to search and filter.
 
-![Screenshot showing all sessions in the Chat view.](images/1_107/recent-sessions-all.png)
+![Screenshot showing all sessions in the Chat view.](https://code.visualstudio.com/assets/updates/1_107/recent-sessions-all.png)
 
 You can use the action to toggle the agent sessions sidebar for a wider experience of all sessions.
 
@@ -123,7 +123,7 @@ You can use the action to toggle the agent sessions sidebar for a wider experien
 
 Once the Chat view is wide enough (for example, when you maximize it), the list of agent sessions is automatically shown side-by-side with the Chat view. This view lets you quickly navigate between sessions without losing context. You can also manually toggle this side-by-side view using the corresponding control.
 
-![Screenshot showing all sessions side-by-side with the Chat view.](images/1_107/all-sessions.png)
+![Screenshot showing all sessions side-by-side with the Chat view.](https://code.visualstudio.com/assets/updates/1_107/all-sessions.png)
 
 To limit the sessions list, you can filter sessions by provider or state. VS Code persists this filter.
 
@@ -143,7 +143,7 @@ Previously, when you closed a local chat session, a running agent request was ca
 
 Now, the local agent continues running in the background, even when not open in a chat editor or the Chat view. You are able to see the status of the running agent in the sessions list and can switch back to the session at any time to see the detailed progress.
 
-<video src="images/1_107/local-agent-active-when-closed.mp4" title="Video showing local agent running in background." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/local-agent-active-when-closed.mp4" title="Video showing local agent running in background." autoplay loop controls muted></video>
 
 Learn more about [using local agent in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_switch-between-agents).
 
@@ -157,15 +157,15 @@ When you continue a local chat to background or cloud agent, the current chat co
 
 * Chat view:
 
-    ![Screenshot showing the 'Continue in' button in the Chat view.](images/1_107/continue-in-chatwidget.png)
+    ![Screenshot showing the 'Continue in' button in the Chat view.](https://code.visualstudio.com/assets/updates/1_107/continue-in-chatwidget.png)
 
 * Plan agent:
 
-    ![Screenshot showing the 'Start implementation' button when using the Plan agent.](images/1_107/continue-in-planmode.png)
+    ![Screenshot showing the 'Start implementation' button when using the Plan agent.](https://code.visualstudio.com/assets/updates/1_107/continue-in-planmode.png)
 
 * Untitled prompt file:
 
-    ![Screenshot showing the 'Continue in' button in an untitled prompt file.](images/1_107/continue-in-promptfile.png)
+    ![Screenshot showing the 'Continue in' button in an untitled prompt file.](https://code.visualstudio.com/assets/updates/1_107/continue-in-promptfile.png)
 
 ### Isolate background agents with Git worktrees {: #isolate-background-agents-with-git-worktrees }
 
@@ -173,13 +173,13 @@ Background agents (previously called CLI agents) are designed to run autonomousl
 
 This iteration, we enhanced the isolation of background agents by introducing support for [Git worktrees](https://code.visualstudio.com/docs/sourcecontrol/branches-worktrees#_working-with-git-worktrees). When you create a new background agent, you can choose to either run it on the current workspace or to run it in a dedicated Git worktree.
 
-![Screenshot showing the Git Worktree dropdown when creating a background agent.](images/1_107/background_worktree.png)
+![Screenshot showing the Git Worktree dropdown when creating a background agent.](https://code.visualstudio.com/assets/updates/1_107/background_worktree.png)
 
 When you run a background agent in a worktree, the agent automatically creates a new Git worktree for the session, isolating its changes in a separate folder. This lets you run multiple background agents simultaneously without conflicts.
 
 You can easily review and merge the changes made by the background agent in the worktree back into your main workspace when the agent completes its task. We've also added a new action to directly apply the changes from a worktree directly into your workspace.
 
-![Screenshot of a background agent, showing the file changes that occurred in the worktree.](images/1_107/filechanges.png)
+![Screenshot of a background agent, showing the file changes that occurred in the worktree.](https://code.visualstudio.com/assets/updates/1_107/filechanges.png)
 
 Learn more about using [background agents in VS Code](https://code.visualstudio.com/docs/copilot/agents/background-agents).
 
@@ -187,7 +187,7 @@ Learn more about using [background agents in VS Code](https://code.visualstudio.
 
 Background agents now support multiple context attachment types. You can attach selections, problems, symbols, search results, git commits, and more to any prompt. This makes it possible to build richer, more precise prompts, unlocking more complex and flexible workflows. For example, attach a reported problem and ask the agent to fix it without manually specifying file paths and line numbers.
 
-![Screenshot of a background agent session with a symbol and error attached as context.](images/1_107/background_attachments.png)
+![Screenshot of a background agent session with a symbol and error attached as context.](https://code.visualstudio.com/assets/updates/1_107/background_attachments.png)
 
 ### Share custom agents across your GitHub organization (Experimental) {: #share-custom-agents-across-your-github-organization-experimental }
 
@@ -209,7 +209,7 @@ You can now bring your own custom agents into Background Agents. Once enabled, c
 
 This experimental functionality can be enabled with the `setting(github.copilot.chat.cli.customAgents.enabled)` setting.
 
-![Screenshot showing a background agent session with a custom Planner agent in the Agents dropdown list.](images/1_107/background_agents.png)
+![Screenshot showing a background agent session with a custom Planner agent in the Agents dropdown list.](https://code.visualstudio.com/assets/updates/1_107/background_agents.png)
 
 Learn more about [defining custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
 
@@ -237,7 +237,7 @@ To use custom agents as subagents, follow these steps:
 
 1. Enter a prompt that meets the requirements for your custom agent. The language model uses the custom agent description and arguments to determine if it should be used for your request.
 
-    ![Screenshot of a chat conversation that uses a custom agent as subagent.](images/1_107/use-agents-as-subagents.png)
+    ![Screenshot of a chat conversation that uses a custom agent as subagent.](https://code.visualstudio.com/assets/updates/1_107/use-agents-as-subagents.png)
 
 To prevent a custom agent from being used as a subagent, set the metadata property `infer` to `false` in the `*.agent.md` file.
 
@@ -252,7 +252,7 @@ Once loaded, skills instructions and supporting files are part of the context of
 
 VS Code can now reuse your existing skills. Enable the `setting(chat.useClaudeSkills)` setting to allow agents to discover and use your skills.
 
-![Screenshot that shows reusing Claude skills in chat in VS Code.](images/1_107/use-claude-skills.png)
+![Screenshot that shows reusing Claude skills in chat in VS Code.](https://code.visualstudio.com/assets/updates/1_107/use-claude-skills.png)
 
 VS Code supports personal skills found at `~/.claude/skills/skill-name/SKILL.md` and project skills found in workspace folders at `${workspaceFolder}.claude/skills/skill-name/SKILL.md`.
 
@@ -282,11 +282,11 @@ In agent mode, make sure you have the read-file tool enabled and ask "What skill
 
 We continue to improve the inline chat experience to align it with the other chat experiences in VS Code and to optimize it for quick, single-file code changes.
 
-<video src="images/1_107/inline_chat_edit.mp4" title="Video showing the updated UX for inline chat in action." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/inline_chat_edit.mp4" title="Video showing the updated UX for inline chat in action." autoplay loop controls muted></video>
 
 Previously, you could also use inline chat for general questions and discussions. Now, inline chat is optimized for code changes within the current file. For tasks that inline chat cannot handle, you are automatically upgraded to the Chat view where your prompt is being replayed, using the same model and the same context
 
-<video src="images/1_107/inline_chat_exit.mp4" title="Video showing inline chat exit to Chat view flow." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/inline_chat_exit.mp4" title="Video showing inline chat exit to Chat view flow." autoplay loop controls muted></video>
 The `setting(inlineChat.enableV2:true)` setting (preview) now only controls how the extension handles your prompt. This is still under development but can be tried with confidence.
 
 ### Language Models editor {: #language-models-editor }
@@ -295,7 +295,7 @@ Chat in VS Code supports multiple language models, either provided by GitHub Cop
 
 The **Language Models** editor provides a centralized place to view and manage all available language models for chat in VS Code. You can open it from the model picker in chat or via the Command Palette with **Chat: Manage Language Models**.
 
-<video src="images/1_107/language-models-editor.mp4" title="Video showing the Language Models editor" autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/language-models-editor.mp4" title="Video showing the Language Models editor" autoplay loop controls muted></video>
 
 The editor lists all models available to you, showing key information such as the model capabilities, context size, billing details, and visibility status. By default, models are grouped by provider, but you can also group them by visibility.
 
@@ -326,7 +326,7 @@ This iteration, we enhanced the security and user experience of auto-approving U
 
     This step ensures that you trust the domain being contacted and can prevent sensitive data to be sent to untrusted sites.
 
-    ![Screenshot showing a confirmation to approve the initial fetch request.](images/1_107/approve-fetch.png)
+    ![Screenshot showing a confirmation to approve the initial fetch request.](https://code.visualstudio.com/assets/updates/1_107/approve-fetch.png)
 
     You have options for one-time approval or automatically approving future requests to the specific URL or domain.
 
@@ -364,13 +364,13 @@ Learn more about [using terminal commands in chat](https://code.visualstudio.com
 
 Chat terminal messages now display command start time, duration, and exit code on hover of the command decoration.
 
-![Screenshot of the terminal showing npm install candy is run by the agent and the command decoration hover displays command execution time and status.](images/1_107/terminal-command-exit.png)
+![Screenshot of the terminal showing npm install candy is run by the agent and the command decoration hover displays command execution time and status.](https://code.visualstudio.com/assets/updates/1_107/terminal-command-exit.png)
 
 ### Allow all terminal commands in this session {: #allow-all-terminal-commands-in-this-session }
 
 To optimize your chat experience, while maintaining security and control, the terminal tool has a new auto approve option to allow all future commands for the session. When you start a new session, terminal commands will follow the existing approval configuration.
 
-![Screenshot that shows the Allow All Commands in this Session option when approving a terminal command in chat.](images/1_107/terminal-allow-all.png)
+![Screenshot that shows the Allow All Commands in this Session option when approving a terminal command in chat.](https://code.visualstudio.com/assets/updates/1_107/terminal-allow-all.png)
 
 ### Keyboard shortcuts for chat terminal actions {: #keyboard-shortcuts-for-chat-terminal-actions }
 
@@ -380,7 +380,7 @@ You can now focus the most recent chat terminal `kb(workbench.action.terminal.ch
 
 Each custom agent now has a separate action in the command list for them and you can bind keyboard shortcuts to them individually. For example, if you define a "Code Reviewer" custom agent, there will be a **Chat: Open Chat (Code Reviewer Agent)** command in the Command Palette to bind a keyboard shortcut to.
 
-![Screenshot of custom agent commands in the Command Palette.](images/1_107/custom-agent-commands.png)
+![Screenshot of custom agent commands in the Command Palette.](https://code.visualstudio.com/assets/updates/1_107/custom-agent-commands.png)
 
 ### Azure model provider: Entra ID as the default authentication {: #azure-model-provider-entra-id-as-the-default-authentication }
 
@@ -408,13 +408,13 @@ We've made several improvements to the Chat view's appearance to enhance readabi
 
     When you open a chat, a new title control appears to the top showing you the title of the chat as well as giving you a quick way to get back to an empty chat. Configure this behavior via the `setting(chat.viewTitle.enabled)` setting.
 
-    <video src="images/1_107/chat-title.mp4" title="Video showing chat titles and returning back to the session list." autoplay loop controls muted></video>
+    <video src="https://code.visualstudio.com/assets/updates/1_107/chat-title.mp4" title="Video showing chat titles and returning back to the session list." autoplay loop controls muted></video>
 
 * **Welcome banner**:
 
     If you prefer a more minimal experience when opening a new chat, the new setting `setting(chat.viewWelcome.enabled)` lets you hide the icon and welcome text.
 
-    ![Screenshot of empty chat view with the icon and welcome text hidden.](images/1_107/chat-welcome.png)
+    ![Screenshot of empty chat view with the icon and welcome text hidden.](https://code.visualstudio.com/assets/updates/1_107/chat-welcome.png)
 
 * **Restore previous chat session**:
 
@@ -426,7 +426,7 @@ When chat attempts to edit sensitive files, such as the `settings.json` or `pack
 
 Previously, you would see the raw edit that the model proposed, which could be difficult to understand. Now, we show you a diff of the proposed changes, making it easier to review and approve the edits.
 
-![Screenshot showing a diff of proposed changes to `package.json` in chat.](images/1_107/sensitive-file-diff.png)
+![Screenshot showing a diff of proposed changes to `package.json` in chat.](https://code.visualstudio.com/assets/updates/1_107/sensitive-file-diff.png)
 
 Learn more about editing [sensitive files in chat](https://code.visualstudio.com/docs/copilot/chat/review-code-edits#_edit-sensitive-files).
 
@@ -440,7 +440,7 @@ This iteration, we're further optimizing the chat experience by introducing coll
 
 Collapsible items (most tools and reasoning text) will be summarized and an AI-generated title will be given to each collapsible section.
 
-![Screenshot showing multiple tool calls collapsed in a collapsible section.](images/1_107/collapsed-tools.png)
+![Screenshot showing multiple tool calls collapsed in a collapsible section.](https://code.visualstudio.com/assets/updates/1_107/collapsed-tools.png)
 
 ## MCP {: #mcp }
 
@@ -495,7 +495,7 @@ When an agent prompts for confirmation, you can now approve via keyboard using `
 
 We added an indicator to the **Open Recent** picker for when a workspace is already open in a VS Code window.
 
-![Screenshot of recently opened workspaces.](images/1_107/pickers.png)
+![Screenshot of recently opened workspaces.](https://code.visualstudio.com/assets/updates/1_107/pickers.png)
 
 The currently active window is indicated slightly differently from other opened windows to make that distinction clearer. Entries that are not opened in any window have no icon.
 
@@ -534,7 +534,7 @@ Rename suggestions predict when a symbol rename should happen instead of a regul
 
 In the following video, property `a` is renamed to `width`. The rename suggestion then suggests to rename `b` to `height`, as well as renaming the two parameters `a` and `b` accordingly. Next rename suggestion works best when it predicts related renames to other symbols.
 
-<video src="images/1_107/next-rename-suggestion.mp4" title="Video showing next rename suggestion in the editor." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/next-rename-suggestion.mp4" title="Video showing next rename suggestion in the editor." autoplay loop controls muted></video>
 
 > **Note**: this feature is currently rolled out to our user base using an experiment and is only available for TypeScript for now. Support for other programming languages is planned.
 
@@ -546,7 +546,7 @@ We have released a new model for next edit suggestions that is smarter and more 
 
 When you receive a next edit suggestion that is outside the current viewport, it can be difficult to know what the suggestion is without scrolling away from your current position. We improved this experience by rendering a preview of the next edit suggestion where your cursor is currently located. This helps reduce the impact on your flow when reviewing suggestions.
 
-<video src="images/1_107/nes-outside-viewport.mp4" title="Video of next edit suggestion preview." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/nes-outside-viewport.mp4" title="Video of next edit suggestion preview." autoplay loop controls muted></video>
 
 > **Note**: Our current language model focuses on next edit suggestions close to the cursor, so you might not often see suggestions outside the viewport. However, we are actively working on models which can give you suggestions much further away!
 
@@ -560,7 +560,7 @@ Learn more about [inline suggestions in VS Code](https://code.visualstudio.com/d
 
 This milestone, we continued to expand the list of repository artifacts shown in the Source Control Repositories view by adding a Stashes node. Under this node, you can see the complete list of stashes, view, apply, and pop each stash. The context menu also contains an action to drop each stash.
 
-![Screenshot of the Source Control Repositories view showing the Stashes node and its context menu.](images/1_107/stashes-repo-explorer.png)
+![Screenshot of the Source Control Repositories view showing the Stashes node and its context menu.](https://code.visualstudio.com/assets/updates/1_107/stashes-repo-explorer.png)
 
 You can enable the experimental repository explorer by setting the `setting(scm.repositories.selectionMode:single)` and `setting(scm.repositories.explorer:true)` settings. Please give it a try and let us know what other repository artifacts you would like to see in the repositories explorer.
 
@@ -589,7 +589,7 @@ This milestone, we adopted the latest MSAL libraries, enabling you to sign in th
 * Intel Macs
 * Linux x64 (just certain distros that are Debian-based)
 
-![Screenshot of a native broker dialog window asking to sign into VS Code.](images/1_107/macOS-auth-broker.png)
+![Screenshot of a native broker dialog window asking to sign into VS Code.](https://code.visualstudio.com/assets/updates/1_107/macOS-auth-broker.png)
 
 This is in addition to the existing support for:
 
@@ -651,7 +651,7 @@ Organizations can enforce this behavior via an enterprise policy across their us
 
 When an enterprise policy disables the use of agents in chat, the Agents picker now better communicates why they're not available.
 
-![Screenshot of the Agent picker shows agent mode unavailable due to enterprise policy.](images/1_107/agent-mode-disabled-by-policy.png)
+![Screenshot of the Agent picker shows agent mode unavailable due to enterprise policy.](https://code.visualstudio.com/assets/updates/1_107/agent-mode-disabled-by-policy.png)
 
 ### Support GitHub Enterprise policies in Codespaces {: #support-github-enterprise-policies-in-codespaces }
 
@@ -695,7 +695,7 @@ We'll roll out the November 2025 (1.107) release to Stable users over a 24-hour 
 
 We've improved [our website](https://code.visualstudio.com) with fast, client-side search that allows you to easily and quickly navigate across our documentation.
 
-<video src="images/1_107/website-search.mp4" title="Video showing the website search functionality with search result suggestions showing in a dropdown list." autoplay loop controls muted></video>
+<video src="https://code.visualstudio.com/assets/updates/1_107/website-search.mp4" title="Video showing the website search functionality with search result suggestions showing in a dropdown list." autoplay loop controls muted></video>
 
 We've open-sourced the library behind this functionality: you can download [docfind](https://github.com/microsoft/docfind) and use it for your projects today! We'll follow up with a blog post on the innovations behind this tech.
 

--- a/docs/release-notes/v1_107.md
+++ b/docs/release-notes/v1_107.md
@@ -7,7 +7,7 @@ MetaSocialImage: 1_107/release-highlights-stable.webp
 Date: 2025-12-10
 DownloadVersion: 1.107.1
 ---
-# November 2025 (version 1.107)
+# November 2025 (version 1.107) {: #november-2025-version-1107 }
 
 _Release date: December 10, 2025_
 
@@ -72,7 +72,7 @@ Happy Coding!
   <div class="notes-main">
 Navigation End -->
 
-## Agents
+## Agents {: #agents }
 
 * Manage your agents from chat ([Show more](#integrating-agent-sessions-and-chat)).
 * Share agents across your organization ([Show more](#share-custom-agents-across-your-github-organization-experimental)).
@@ -85,7 +85,7 @@ Navigation End -->
 * Run custom subagents ([Show more](#run-agents-as-subagents-experimental)).
 * Reuse Claude skills ([Show more](#reuse-your-claude-skills-experimental)).
 
-### Integrating agent sessions and chat
+### Integrating agent sessions and chat {: #integrating-agent-sessions-and-chat }
 
 **Setting**: `setting(chat.viewSessions.enabled)`
 
@@ -107,7 +107,7 @@ You can disable the sessions list in the Chat view by configuring `setting(chat.
 
 As a consequence of this change, we're disabling the standalone **Agent Sessions** view by default. If you prefer to keep using the standalone view, you can re-enable it via `setting(chat.agentSessionsViewLocation)`. In a future release, we plan to remove the standalone view entirely.
 
-#### Compact view
+#### Compact view {: #compact-view }
 
 When the Chat view is narrow, the list of sessions is shown inside the Chat view when you start a new chat session. By default, the list shows the three most recent sessions that are not archived.
 
@@ -119,7 +119,7 @@ Select **Show All Sessions** to view the full list of sessions with options to s
 
 You can use the action to toggle the agent sessions sidebar for a wider experience of all sessions.
 
-#### Side-by-side view
+#### Side-by-side view {: #sidebyside-view }
 
 Once the Chat view is wide enough (for example, when you maximize it), the list of agent sessions is automatically shown side-by-side with the Chat view. This view lets you quickly navigate between sessions without losing context. You can also manually toggle this side-by-side view using the corresponding control.
 
@@ -127,7 +127,7 @@ Once the Chat view is wide enough (for example, when you maximize it), the list 
 
 To limit the sessions list, you can filter sessions by provider or state. VS Code persists this filter.
 
-#### Orientation setting
+#### Orientation setting {: #orientation-setting }
 
 **Setting**: `setting(chat.viewSessions.orientation)`
 
@@ -137,7 +137,7 @@ By default, the sessions list appears side-by-side with the Chat view when it's 
 * `stacked`: always show the sessions above empty chats
 * `sideBySide`: show the session list side-by-side if the width allows it, otherwise hide the sessions list
 
-### Local agent sessions remain active when closed
+### Local agent sessions remain active when closed {: #local-agent-sessions-remain-active-when-closed }
 
 Previously, when you closed a local chat session, a running agent request was cancelled. This limited the usefulness of local agents for long-running tasks or for running multiple tasks simultaneously.
 
@@ -147,7 +147,7 @@ Now, the local agent continues running in the background, even when not open in 
 
 Learn more about [using local agent in chat](https://code.visualstudio.com/docs/copilot/chat/copilot-chat#_switch-between-agents).
 
-### Continue tasks in background or cloud agents
+### Continue tasks in background or cloud agents {: #continue-tasks-in-background-or-cloud-agents }
 
 Local agents are great for interactive sessions inside VS Code where you can go back and forth with the agent. This can be useful for brainstorming, performing exploratory tasks, or to work out an implementation plan. Once you have a clear plan, you can then hand the task off to a background or cloud agent to execute it autonomously.
 
@@ -167,7 +167,7 @@ When you continue a local chat to background or cloud agent, the current chat co
 
     ![Screenshot showing the 'Continue in' button in an untitled prompt file.](images/1_107/continue-in-promptfile.png)
 
-### Isolate background agents with Git worktrees
+### Isolate background agents with Git worktrees {: #isolate-background-agents-with-git-worktrees }
 
 Background agents (previously called CLI agents) are designed to run autonomously in the background, allowing you to offload tasks while you focus on other work. Running multiple background agents simultaneously can lead to conflicts if they modify the same files in your workspace.
 
@@ -183,13 +183,13 @@ You can easily review and merge the changes made by the background agent in the 
 
 Learn more about using [background agents in VS Code](https://code.visualstudio.com/docs/copilot/agents/background-agents).
 
-### Adding context to background agents
+### Adding context to background agents {: #adding-context-to-background-agents }
 
 Background agents now support multiple context attachment types. You can attach selections, problems, symbols, search results, git commits, and more to any prompt. This makes it possible to build richer, more precise prompts, unlocking more complex and flexible workflows. For example, attach a reported problem and ask the agent to fix it without manually specifying file paths and line numbers.
 
 ![Screenshot of a background agent session with a symbol and error attached as context.](images/1_107/background_attachments.png)
 
-### Share custom agents across your GitHub organization (Experimental)
+### Share custom agents across your GitHub organization (Experimental) {: #share-custom-agents-across-your-github-organization-experimental }
 
 **Setting**: `setting(github.copilot.chat.customAgents.showOrganizationAndEnterpriseAgents)`
 
@@ -201,7 +201,7 @@ To enable this feature, set `setting(github.copilot.chat.customAgents.showOrgani
 
 To learn more about creating custom agents for your organization, see [Create custom agents](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-custom-agents) in the GitHub documentation.
 
-### Use custom agents with background agents (Experimental)
+### Use custom agents with background agents (Experimental) {: #use-custom-agents-with-background-agents-experimental }
 
 **Setting**: `setting(github.copilot.chat.cli.customAgents.enabled)`
 
@@ -213,13 +213,13 @@ This experimental functionality can be enabled with the `setting(github.copilot.
 
 Learn more about [defining custom agents](https://code.visualstudio.com/docs/copilot/customization/custom-agents) in our documentation.
 
-### Agent tooling reorganization
+### Agent tooling reorganization {: #agent-tooling-reorganization }
 
 We've reorganized the agent tooling structure to enable better compatibility with GitHub custom agents. This lets you more easily reuse custom agents across VS Code and GitHub environments without requiring separate configurations.
 
 As part of this change, we've renamed certain existing tool references and the toolsets they belong to. Existing tool references in your agent files will continue to work, but you'll see a Code Action for renaming them to the latest recommended format. This ensures that your agent configurations follow the current best practices and maintain compatibility across platforms.
 
-### Run agents as subagents (Experimental)
+### Run agents as subagents (Experimental) {: #run-agents-as-subagents-experimental }
 
 **Setting**: `setting(chat.customAgentInSubagent.enabled)`
 
@@ -243,7 +243,7 @@ To prevent a custom agent from being used as a subagent, set the metadata proper
 
 Learn more about [using subagents in chat](https://code.visualstudio.com/docs/copilot/chat/chat-sessions#_contextisolated-subagents).
 
-### Reuse your Claude skills (Experimental)
+### Reuse your Claude skills (Experimental) {: #reuse-your-claude-skills-experimental }
 
 **Setting**: `setting(chat.useClaudeSkills)`
 
@@ -260,7 +260,7 @@ Check that the `SKILL.md` file has a `description` attribute in the header that 
 
 In agent mode, make sure you have the read-file tool enabled and ask "What skills do you have" to find out if skills are found. Next, make a request that can be answered with a skill. If the agent doesn't use the skill, improve the skill description or nudge the model to use skills.
 
-## Chat
+## Chat {: #chat }
 
 * Inline chat is optimized for code edits ([Show more](#inline-chat-ux)).
 * Manage your chat models ([Show more](#language-models-editor)).
@@ -276,7 +276,7 @@ In agent mode, make sure you have the read-file tool enabled and ask "What skill
 * View diffs for edits to sensitive files ([Show more](#diffs-for-edits-to-sensitive-files)).
 * Hide chat tool calls for reasoning models ([Show more](#collapsible-reasoning-and-tools-output-experimental)).
 
-### Inline chat UX
+### Inline chat UX {: #inline-chat-ux }
 
 **Setting**: `setting(inlineChat.enableV2:true)`
 
@@ -289,7 +289,7 @@ Previously, you could also use inline chat for general questions and discussions
 <video src="images/1_107/inline_chat_exit.mp4" title="Video showing inline chat exit to Chat view flow." autoplay loop controls muted></video>
 The `setting(inlineChat.enableV2:true)` setting (preview) now only controls how the extension handles your prompt. This is still under development but can be tried with confidence.
 
-### Language Models editor
+### Language Models editor {: #language-models-editor }
 
 Chat in VS Code supports multiple language models, either provided by GitHub Copilot, third-party extensions, or via bring your own key (BYOK) providers. Managing all these models can be challenging, especially when you have access to many models across different providers. Learn more about [using language models in VS Code](https://code.visualstudio.com/docs/copilot/customization/language-models).
 
@@ -308,17 +308,17 @@ You can search and filter models using:
 * Capability filters: `@capability:tools`, `@capability:vision`, `@capability:agent`
 * Visibility filter: `@visible:true/false`
 
-#### Manage model visibility
+#### Manage model visibility {: #manage-model-visibility }
 
 As more models are available to you, the model picker can become overwhelming and difficult to navigate. In the Language Models editor, you can toggle the visibility of each model to control which models appear in the model picker. Hover over a model and select the eye icon to toggle its visibility.
 
-#### Add models from installed providers
+#### Add models from installed providers {: #add-models-from-installed-providers }
 
 From the Language Models editor, you can add more models with **Add Models...**. This shows a dropdown list of all installed model providers. Select a provider to configure it and add its models to chat in VS Code.
 
 This makes it easy to activate additional model providers you've installed without needing to navigate away from the Language Models editor. Access provider management by selecting the gear icon on provider rows.
 
-### URL and domain auto approval
+### URL and domain auto approval {: #url-and-domain-auto-approval }
 
 This iteration, we enhanced the security and user experience of auto-approving URLs for the fetch tool. When the model decides to fetch content from a URL that you did not explicitly ask for, you'll see the new two-step approval experience:
 
@@ -340,7 +340,7 @@ This iteration, we enhanced the security and user experience of auto-approving U
 
 Learn more about [URL and domain approval](https://code.visualstudio.com/docs/copilot/chat/chat-tools#url-approval) in VS Code chat.
 
-### More robust fetch tool
+### More robust fetch tool {: #more-robust-fetch-tool }
 
 The `#fetch` agent tool now handles dynamic web content more effectively. It can retrieve dynamic content, in addition to static HTML. Websites that rely on JavaScript to load their content, such as Single-Page Applications (SPAs), modern documentation sites, or issue tracking systems like Jira, no longer return incomplete or empty results.
 
@@ -348,11 +348,11 @@ The fetch tool waits for JavaScript to execute and content to load before retrie
 
 When you use `#fetch` followed by a URL, the model accesses the actual content you'd see in the browser, not just the initial HTML skeleton. This means more accurate and complete information when asking questions about web pages or requesting the model to analyze online content.
 
-### Text Search tool can search ignored files
+### Text Search tool can search ignored files {: #text-search-tool-can-search-ignored-files }
 
 The `#textSearch` tool now supports searching in ignored files/folders specified by `files.exclude` or `search.exclude` settings or `.gitignore` files, such as the `node_modules` folder. It also returns hints to the agent about the ignored files/folders when there are no results, allowing agents to turn around and enable searching in those ignored files/folders.
 
-### Rich terminal output in chat
+### Rich terminal output in chat {: #rich-terminal-output-in-chat }
 
 Using **Toggle Output** on a **Run in Terminal** response now renders output in a full, read-only `xterm.js` terminal inside chat. A nice benefit of this approach is that VS Code preserves captured output even after the backing terminal has exited, so you can reopen previous runs at any time and see the terminal output as it was when the command ran.
 
@@ -360,29 +360,29 @@ The chat terminal now adopts the integrated terminal's color theme for improved 
 
 Learn more about [using terminal commands in chat](https://code.visualstudio.com/docs/copilot/chat/chat-tools#_terminal-commands).
 
-### Command status details in chat terminals
+### Command status details in chat terminals {: #command-status-details-in-chat-terminals }
 
 Chat terminal messages now display command start time, duration, and exit code on hover of the command decoration.
 
 ![Screenshot of the terminal showing npm install candy is run by the agent and the command decoration hover displays command execution time and status.](images/1_107/terminal-command-exit.png)
 
-### Allow all terminal commands in this session
+### Allow all terminal commands in this session {: #allow-all-terminal-commands-in-this-session }
 
 To optimize your chat experience, while maintaining security and control, the terminal tool has a new auto approve option to allow all future commands for the session. When you start a new session, terminal commands will follow the existing approval configuration.
 
 ![Screenshot that shows the Allow All Commands in this Session option when approving a terminal command in chat.](images/1_107/terminal-allow-all.png)
 
-### Keyboard shortcuts for chat terminal actions
+### Keyboard shortcuts for chat terminal actions {: #keyboard-shortcuts-for-chat-terminal-actions }
 
 You can now focus the most recent chat terminal `kb(workbench.action.terminal.chat.focusMostRecentChatTerminal)` or toggle its expansion state `kb(workbench.action.terminal.chat.focusMostRecentChatTerminalOutput)` via dedicated keyboard shortcuts.
 
-### Keyboard shortcuts for custom agents
+### Keyboard shortcuts for custom agents {: #keyboard-shortcuts-for-custom-agents }
 
 Each custom agent now has a separate action in the command list for them and you can bind keyboard shortcuts to them individually. For example, if you define a "Code Reviewer" custom agent, there will be a **Chat: Open Chat (Code Reviewer Agent)** command in the Command Palette to bind a keyboard shortcut to.
 
 ![Screenshot of custom agent commands in the Command Palette.](images/1_107/custom-agent-commands.png)
 
-### Azure model provider: Entra ID as the default authentication
+### Azure model provider: Entra ID as the default authentication {: #azure-model-provider-entra-id-as-the-default-authentication }
 
 **Setting**: `setting(github.copilot.chat.azureAuthType)`
 
@@ -390,7 +390,7 @@ By default, the Azure model provider now uses Entra ID authentication when conne
 
 If you prefer to authenticate using an API key, set `setting(github.copilot.chat.azureAuthType)` to `apiKey` instead of `entraId` (default).
 
-### Anthropic models: Extended thinking support
+### Anthropic models: Extended thinking support {: #anthropic-models-extended-thinking-support }
 
 **Setting**: `setting(github.copilot.chat.anthropic.thinking.budgetTokens)`
 
@@ -400,7 +400,7 @@ The default thinking budget is set to 4,000 tokens. You can customize this budge
 
 > **Note**: Interleaved thinking, which enables Claude to reason between tool calls, is only available when using Anthropic models via Bring-Your-Own-Key (BYOK). It uses the same thinking budget setting configured above.
 
-### Chat view appearance improvements
+### Chat view appearance improvements {: #chat-view-appearance-improvements }
 
 We've made several improvements to the Chat view's appearance to enhance readability and usability:
 
@@ -420,7 +420,7 @@ We've made several improvements to the Chat view's appearance to enhance readabi
 
     When you open chat after restarting or opening a different workspace, the previous session is now restored by default. You can change this behavior via the `setting(chat.viewRestorePreviousSession)` setting and choose to always start with an empty chat.
 
-### Diffs for edits to sensitive files
+### Diffs for edits to sensitive files {: #diffs-for-edits-to-sensitive-files }
 
 When chat attempts to edit sensitive files, such as the `settings.json` or `package.json`, you get a notification and are asked to approve the changes before they are applied. You can configure which files are considered sensitive via the `setting(chat.tools.edits.autoApprove)` setting.
 
@@ -430,7 +430,7 @@ Previously, you would see the raw edit that the model proposed, which could be d
 
 Learn more about editing [sensitive files in chat](https://code.visualstudio.com/docs/copilot/chat/review-code-edits#_edit-sensitive-files).
 
-### Collapsible reasoning and tools output (Experimental)
+### Collapsible reasoning and tools output (Experimental) {: #collapsible-reasoning-and-tools-output-experimental }
 
 **Setting**: `setting(chat.agent.thinkingStyle)`, `setting(chat.agent.thinking.collapsedTools)`
 
@@ -442,12 +442,12 @@ Collapsible items (most tools and reasoning text) will be summarized and an AI-g
 
 ![Screenshot showing multiple tool calls collapsed in a collapsible section.](images/1_107/collapsed-tools.png)
 
-## MCP
+## MCP {: #mcp }
 
 * We added support for the latest MCP specification ([Show more](#support-for-the-latest-mcp-specification)).
 * Use the GitHub remote MCP server without extra setup ([Show more](#github-mcp-server-provided-by-github-copilot-chat-preview)).
 
-### Support for the latest MCP specification
+### Support for the latest MCP specification {: #support-for-the-latest-mcp-specification }
 
 VS Code supports the latest revision of the MCP specification, `2025-11-25`. This includes, among other things:
 
@@ -459,7 +459,7 @@ These improvements come in addition to the `2025-11-25` draft features VS Code a
 
 Learn more about [using MCP servers in VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers).
 
-### GitHub MCP Server provided by GitHub Copilot Chat (Preview)
+### GitHub MCP Server provided by GitHub Copilot Chat (Preview) {: #github-mcp-server-provided-by-github-copilot-chat-preview }
 
 **Setting**: `setting(github.copilot.chat.githubMcpServer.enabled)`
 
@@ -479,19 +479,19 @@ The GitHub MCP Server supports customization through several settings:
 
 > **Note**: This feature is currently in Preview and requires explicit opt-in through the setting mentioned above. We are planning to enable it by default in a future release in a way that makes it available when wanted, but not intrusive when not needed.
 
-## Accessibility
+## Accessibility {: #accessibility }
 
-### Keyboard approval for chat confirmations
+### Keyboard approval for chat confirmations {: #keyboard-approval-for-chat-confirmations }
 
 When an agent prompts for confirmation, you can now approve via keyboard using `kb(workbench.action.chat.acceptTool)`.
 
-## Editor Experience
+## Editor Experience {: #editor-experience }
 
 * More easily identify open projects ([Show more](#more-support-to-indicate-opened-windows-in-pickers)).
 * Swipe to navigate on macOS ([Show more](#macos-mouse-swipe-to-navigate)).
 * Choose when to view hover popups ([Show more](#on-demand-editor-hover-popups)).
 
-### More support to indicate opened windows in pickers
+### More support to indicate opened windows in pickers {: #more-support-to-indicate-opened-windows-in-pickers }
 
 We added an indicator to the **Open Recent** picker for when a workspace is already open in a VS Code window.
 
@@ -501,7 +501,7 @@ The currently active window is indicated slightly differently from other opened 
 
 The indicator of which window is active has also been applied to the window picker.
 
-### macOS: Mouse swipe to navigate
+### macOS: Mouse swipe to navigate {: #macos-mouse-swipe-to-navigate }
 
 **Setting**: `setting(workbench.editor.swipeToNavigate)`
 
@@ -512,7 +512,7 @@ On macOS you can now navigate between editors using 3-finger swipe gesture with 
 > * Swipe between pages: Scroll left or right with three fingers.
 > * Swipe between full-screen apps: Swipe left or right with four fingers.
 
-### On demand editor hover popups
+### On demand editor hover popups {: #on-demand-editor-hover-popups }
 
 **Setting**: `setting(editor.hover.enabled)`
 
@@ -522,13 +522,13 @@ When set to `onKeyboardModifier`, hover information only appears when you hold t
 
 For example, if your `setting(editor.multiCursorModifier)` is set to `ctrlCmd`, hover appears when you hold `kbstyle(Alt)` while hovering. If set to `alt`, hover appears when you hold `kbstyle(Ctrl)` (or `kbstyle(Cmd)` on macOS).
 
-## Code Editing
+## Code Editing {: #code-editing }
 
 * TypeScript offers rename suggestions ([Show more](#rename-suggestions-for-typescript)).
 * Use a new model for next edit suggestions ([Show more](#new-model-for-next-edit-suggestions)).
 * Preview next edit suggestions outside your viewport ([Show more](#preview-next-edit-suggestions-outside-the-viewport)).
 
-### Rename suggestions for TypeScript
+### Rename suggestions for TypeScript {: #rename-suggestions-for-typescript }
 
 Rename suggestions predict when a symbol rename should happen instead of a regular text suggestion. When predicted, an additional indicator is shown together with the normal textual edit. You can then apply the symbol rename by using `kbstyle(Shift+Tab)`.
 
@@ -538,11 +538,11 @@ In the following video, property `a` is renamed to `width`. The rename suggestio
 
 > **Note**: this feature is currently rolled out to our user base using an experiment and is only available for TypeScript for now. Support for other programming languages is planned.
 
-### New model for next edit suggestions
+### New model for next edit suggestions {: #new-model-for-next-edit-suggestions }
 
 We have released a new model for next edit suggestions that is smarter and more in-tune with your latest edits. It delivers significantly better acceptance and dismissal performance. Learn more about the [model and its development](https://github.blog/ai-and-ml/github-copilot/evolving-github-copilots-next-edit-suggestions-through-custom-model-training/#h-continuous-improvements-nbsp) in our GitHub blog post.
 
-### Preview next edit suggestions outside the viewport
+### Preview next edit suggestions outside the viewport {: #preview-next-edit-suggestions-outside-the-viewport }
 
 When you receive a next edit suggestion that is outside the current viewport, it can be difficult to know what the suggestion is without scrolling away from your current position. We improved this experience by rendering a preview of the next edit suggestion where your cursor is currently located. This helps reduce the impact on your flow when reviewing suggestions.
 
@@ -552,9 +552,9 @@ When you receive a next edit suggestion that is outside the current viewport, it
 
 Learn more about [inline suggestions in VS Code](https://code.visualstudio.com/docs/copilot/ai-powered-suggestions).
 
-## Source Control
+## Source Control {: #source-control }
 
-### Stashes in the Source Control Repositories view (Experimental)
+### Stashes in the Source Control Repositories view (Experimental) {: #stashes-in-the-source-control-repositories-view-experimental }
 
 **Settings**: `setting(scm.repositories.explorer:true)`, `setting(scm.repositories.selectionMode:single)`
 
@@ -566,21 +566,21 @@ You can enable the experimental repository explorer by setting the `setting(scm.
 
 Learn more about [using source control in VS Code](https://code.visualstudio.com/docs/sourcecontrol/overview).
 
-## Debugging
+## Debugging {: #debugging }
 
-### Attach variables to chat
+### Attach variables to chat {: #attach-variables-to-chat }
 
 You can now attach variables, scopes, and expressions to your chat context in VS Code. You can do this by right clicking on data in the **Variables** and **Watch** views, or by using the **Add Context** button in chat.
 
-## Terminal
+## Terminal {: #terminal }
 
-### Terminal suggest rolled out to stable
+### Terminal suggest rolled out to stable {: #terminal-suggest-rolled-out-to-stable }
 
 Terminal Suggest is now enabled for stable users, offering inline completions and contextual hints while you type shell commands. Suggestions now group related argument values together, so option flags and their parameters stay organized in the list.
 
-## Authentication
+## Authentication {: #authentication }
 
-### Cross-platform native broker support for Microsoft Authentication
+### Cross-platform native broker support for Microsoft Authentication {: #crossplatform-native-broker-support-for-microsoft-authentication }
 
 **Setting**: `setting(microsoft-authentication.implementation)`
 
@@ -602,7 +602,7 @@ This enables nice single sign-on flows and is the recommended way of acquiring a
 
 > NOTE: If you have trouble authenticating via the broker, you can change the `setting(microsoft-authentication.implementation)` to `msal-no-broker`, which will use your browser to authenticate instead.
 
-### `classic` Microsoft authentication no longer available
+### `classic` Microsoft authentication no longer available {: #classic-microsoft-authentication-no-longer-available }
 
 As mentioned last month, we have removed the `classic` option for `setting(microsoft-authentication.implementation)` due to low usage and it not being recommended by the Entra ID team.
 
@@ -611,9 +611,9 @@ Reminder: The `setting(microsoft-authentication.implementation)` setting has bee
 * `msal` - Use MSAL with brokered authentication when available (default)
 * `msal-no-broker` - Use MSAL without brokered authentication
 
-## Languages
+## Languages {: #languages }
 
-### TypeScript 7.0 preview
+### TypeScript 7.0 preview {: #typescript-70-preview }
 
 We continued to work with the TypeScript team to improve VS Code's support for the [upcoming TypeScript 7 release](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/). TypeScript 7 is a complete rewrite in native code and offers dramatically better performance.
 
@@ -623,7 +623,7 @@ You can try out TypeScript 7.0 today by installing the [`TypeScript (Native Prev
 
 We plan to continue working closely with the TypeScript team to improve TypeScript 7's VS Code support. Once TypeScript 7 is ready, our longer term plan is to switch to it as the default experience powering VS Code's JavaScript and TypeScript IntelliSense. If you need to use an older TS version or need editor features like TypeScript service plugins that can't be easily ported to TypeScript 7, we're planning to continue supporting existing TypeScript versions for the foreseeable future alongside TypeScript 7.0+.
 
-## Remote Development
+## Remote Development {: #remote-development }
 
 The [Remote Development extensions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack), allow you to use a [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers), remote machine via SSH or [Remote Tunnels](https://code.visualstudio.com/docs/remote/tunnels), or the [Windows Subsystem for Linux](https://learn.microsoft.com/windows/wsl) (WSL) as a full-featured development environment.
 
@@ -633,11 +633,11 @@ Highlights include:
 
 You can learn more about these features in the [Remote Development release notes](https://github.com/microsoft/vscode-docs/blob/main/remote-release-notes/v1_107.md).
 
-## Enterprise
+## Enterprise {: #enterprise }
 
 Learn more about the [enterprise capabilities of VS Code](https://code.visualstudio.com/docs/setup/enterprise) in our documentation.
 
-### Control auto approval for agent tools
+### Control auto approval for agent tools {: #control-auto-approval-for-agent-tools }
 
 **Setting**: `setting(chat.tools.eligibleForAutoApproval)`
 
@@ -647,21 +647,21 @@ You can now define which tools are eligible for auto-approval with the new `sett
 
 Organizations can enforce this behavior via an enterprise policy across their users to enhance security when using agents.
 
-### Disable the use of agents by policy
+### Disable the use of agents by policy {: #disable-the-use-of-agents-by-policy }
 
 When an enterprise policy disables the use of agents in chat, the Agents picker now better communicates why they're not available.
 
 ![Screenshot of the Agent picker shows agent mode unavailable due to enterprise policy.](images/1_107/agent-mode-disabled-by-policy.png)
 
-### Support GitHub Enterprise policies in Codespaces
+### Support GitHub Enterprise policies in Codespaces {: #support-github-enterprise-policies-in-codespaces }
 
 You can specify policies for your enterprise or organization in GitHub that are applied in VS Code. For example, you can [configure the MCP registry URL](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-mcp-usage/configure-mcp-registry) to be used by developers in your organization.
 
 In this release, we added support for these policies when using VS Code with GitHub Codespaces. When a developer opens a Codespace, the same policies are applied automatically, as they already are when using VS Code locally.
 
-## Contributions to extensions
+## Contributions to extensions {: #contributions-to-extensions }
 
-### GitHub Pull Requests
+### GitHub Pull Requests {: #github-pull-requests }
 
 There has been more progress on the [GitHub Pull Requests](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, which enables you to work on, create, and manage pull requests and issues. New features include:
 
@@ -671,9 +671,9 @@ There has been more progress on the [GitHub Pull Requests](https://marketplace.v
 
 Review the [changelog for the 0.124.0](https://github.com/microsoft/vscode-pull-request-github/blob/main/CHANGELOG.md#01240) release of the extension to learn about everything in the release.
 
-## Proposed APIs
+## Proposed APIs {: #proposed-apis }
 
-### Contributed Chat Context
+### Contributed Chat Context {: #contributed-chat-context }
 
 We have a new API proposal to let extensions contribute context providers for chat. This enables extensions to provide rich context from their own domain to be used in chat sessions. For example, the GitHub Pull Request extension provides the following context:
 
@@ -683,15 +683,15 @@ We have a new API proposal to let extensions contribute context providers for ch
 
 The API is still in the early stages, so expect changes to come. We'd love to get feedback on what parts of the proposal will solve extension authors' needs. You can find the proposal here: [vscode.proposed.chatContextProvider.d.ts](https://github.com/microsoft/vscode/blob/615abcc4ae680ef1950fe607c3b3532d3ee0a576/src/vscode-dts/vscode.proposed.chatContextProvider.d.ts).
 
-## Engineering
+## Engineering {: #engineering }
 
-### Builds rollout
+### Builds rollout {: #builds-rollout }
 
 We've started progressively rolling out Insiders build releases over a 4-hour time window. This means that, as an Insiders user, you might receive the update notification a bit later than usual. If you're in a hurry, you can always run **Check for Updates** to force the update to be applied immediately.
 
 We'll roll out the November 2025 (1.107) release to Stable users over a 24-hour time window. Just like Insiders, you can always run **Check for Updates** to force the update to be applied immediately.
 
-### Improved website search functionality
+### Improved website search functionality {: #improved-website-search-functionality }
 
 We've improved [our website](https://code.visualstudio.com) with fast, client-side search that allows you to easily and quickly navigate across our documentation.
 
@@ -699,7 +699,7 @@ We've improved [our website](https://code.visualstudio.com) with fast, client-si
 
 We've open-sourced the library behind this functionality: you can download [docfind](https://github.com/microsoft/docfind) and use it for your projects today! We'll follow up with a blog post on the innovations behind this tech.
 
-### Updated build scripts run directly as TypeScript
+### Updated build scripts run directly as TypeScript {: #updated-build-scripts-run-directly-as-typescript }
 
 This iteration, we cleaned up our build scripts to make them easier to work with and maintain. These build scripts were a mix of compiled TypeScript, TypeScript files run using `ts-node`, and JavaScript. Many of these scripts were not type checked and were using commonjs (`require`) instead of modern modules with `import` and `export`. Even worse, many of the TypeScript build scripts required checking in the compiled JS output to our source control. What a mess!
 
@@ -724,7 +724,7 @@ One thing to keep in mind is that while Node can run TypeScript code, it doesn't
 
 It's pretty amazing to be able to run `node build/hygiene.ts` directly. Switching fully to TypeScript also lets us modernize and bring type safety to our build scripts, which will make it much easier to understand and make changes to them. Plus it enabled us to delete around 15,000 lines of compiled JS code that we previously had to keep checked in!
 
-### Copilot extensions unification
+### Copilot extensions unification {: #copilot-extensions-unification }
 
 **Setting**: `setting(chat.extensionUnification.enabled)`
 
@@ -734,7 +734,7 @@ If you run into any issues with inline suggestions, please report them. You can 
 
 Note that we are planning to fully deprecate the GitHub Copilot extension in January 2026, at which point the `setting(chat.extensionUnification.enabled)` setting will also be removed.
 
-## Notable fixes
+## Notable fixes {: #notable-fixes }
 
 * [vscode#233635](https://github.com/microsoft/vscode/issues/233635) - Add an action to close other windows
 * [vscode#262817](https://github.com/microsoft/vscode/issues/262817) - Running "Move Editor into Previous Group" from the left-most group should create a new group to the left
@@ -749,9 +749,9 @@ Note that we are planning to fully deprecate the GitHub Copilot extension in Jan
 * [vscode#282222](https://github.com/microsoft/vscode/issues/282222) - SCM - improve git blame/timeline/graph hover rendering. Thanks to Stanislav Fort (Aisle Research)
 * [vscode-python-environments#1000](https://github.com/microsoft/vscode-python-environments/issues/1000) - Environment activation is not working reliably with "Command Prompt"
 
-## Thank you
+## Thank you {: #thank-you }
 
-### Issue tracking
+### Issue tracking {: #issue-tracking }
 
 Contributions to our issue tracking:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/main/docs/
 nav:
   - Home: index.md
   - Release notes:
+    - release-notes/v1_107.md
     - release-notes/v1_106.md
     - release-notes/v1_105.md
     - release-notes/v1_104.md


### PR DESCRIPTION
## Work logs

Revision: https://github.com/microsoft/vscode-docs/commit/534bcf5fe711f0478a19b2fee6d7aee19e214220

For future reference ...

1. Checkout original file (CLI command)
   ```
   curl --output-dir docs/release-notes -fLOJ https://github.com/microsoft/vscode-docs/raw/534bcf5fe711f0478a19b2fee6d7aee19e214220/release-notes/v1_107.md
   ```
2. Replace relative links (VS Code Replace)
   ```
   (\./)?images/
   ```
   ```
   https://code.visualstudio.com/assets/updates/
   ```
3. Generate english anchor (Copilot Agent mode - Gemini 3.0 Flash)
   ```
   Add custom anchors ({#custom-anchor}) to Markdown headers
   ```
4. Translate into Japanese (Copilot Agent mode - Gemini 3.0 Flash)
   ```
   Translate the full Markdown content into Japanese. Insert a half-width space between full-width and half-width characters.
   ```